### PR TITLE
chore: Supabase Session Pooler 연결 설정

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,9 +13,9 @@ CORS_ORIGINS=http://localhost:5173
 # Supabase 대시보드 > Project Settings > Database > Connection string 에서 복사.
 # 드라이버 접두사(+asyncpg)는 코드가 자동으로 붙이므로 postgresql:// 그대로 두면 된다.
 #
-# 현재 백엔드 DB 세션은 Transaction pooler 기준으로 설정되어 있다.
-# 연결 문자열은 Supabase의 연결 호스트와 모드를 확인해 입력한다.
+# 현재 백엔드 DB 세션은 장기 실행 FastAPI 서버용 Session pooler 기준이다.
+# Supabase Connect > Direct Connection string > Session pooler > URI 를 복사한다.
 #
 # 스키마 변경은 backend/sql/ 의 SQL 을 Supabase SQL Editor 에서 실행한다.
-# psql 로 직접 붙을 때만 포트 5432 를 쓴다 (backend/sql/README.md 참고).
+# 관리 작업에는 앱 연결 문자열 대신 direct 연결을 사용한다 (backend/sql/README.md 참고).
 DATABASE_URL=

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,7 +1,7 @@
 """비동기 DB 엔진과 세션.
 
-Supabase transaction pooler(포트 6543, PgBouncer) 를 전제로 설정돼 있습니다.
-아래 connect_args 를 빼면 평소엔 잘 돌다가 부하가 걸릴 때 산발적으로 터집니다.
+Supabase session pooler를 사용하는 장기 실행 FastAPI 서버를 전제로 합니다.
+SQLAlchemy의 기본 연결 풀을 사용하고 끊어진 연결은 재사용 전에 확인합니다.
 
 엔진은 import 시점이 아니라 처음 쓸 때 만듭니다.
 그래야 DATABASE_URL 이 없는 환경(CI 등)에서도 앱을 import 할 수 있고,
@@ -10,7 +10,6 @@ DB 를 쓰지 않는 테스트가 DB 설정에 끌려가지 않습니다.
 
 from collections.abc import AsyncGenerator
 from functools import lru_cache
-from uuid import uuid4
 
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
@@ -18,7 +17,6 @@ from sqlalchemy.ext.asyncio import (
     async_sessionmaker,
     create_async_engine,
 )
-from sqlalchemy.pool import NullPool
 
 from app.core.config import settings
 
@@ -31,19 +29,7 @@ def get_engine() -> AsyncEngine:
     return create_async_engine(
         settings.async_database_url,
         echo=settings.debug,
-        # PgBouncer 가 이미 커넥션을 풀링하므로 SQLAlchemy 쪽에서 또 풀링하지 않는다.
-        # 이중 풀링은 유휴 커넥션을 붙잡아 Supabase 커넥션 한도를 빠르게 소진시킨다.
-        poolclass=NullPool,
-        connect_args={
-            # transaction 모드 PgBouncer 는 prepared statement 를 지원하지 않는다.
-            # asyncpg 는 기본으로 statement 를 캐시하므로 반드시 꺼야 한다.
-            "statement_cache_size": 0,
-            # SQLAlchemy asyncpg 방언의 자체 캐시도 함께 끈다.
-            "prepared_statement_cache_size": 0,
-            # 커넥션마다 이름이 겹치지 않게 한다.
-            # 풀러가 커넥션을 재사용하면서 같은 이름의 statement 가 충돌하는 걸 막는다.
-            "prepared_statement_name_func": lambda: f"__asyncpg_{uuid4()}__",
-        },
+        pool_pre_ping=True,
     )
 
 

--- a/backend/sql/README.md
+++ b/backend/sql/README.md
@@ -13,7 +13,7 @@
 
 ## 연결 구분
 
-- 현재 앱 세션은 Supabase transaction pooler를 기준으로 설정되어 있습니다.
+- 현재 앱 세션은 장기 실행 FastAPI 서버용 Supabase session pooler를 기준으로 설정되어 있습니다.
 - 스키마 변경과 관리 작업에는 direct 연결을 우선 사용합니다.
 - 포트만으로 연결 종류를 단정하지 말고 Supabase의 연결 호스트와 모드를 함께 확인합니다.
 - SQL Editor로 실행해도 저장소와 환경별 적용 이력은 자동으로 남지 않으므로 SQL 파일과 적용 기록이 필요합니다.


### PR DESCRIPTION
## 변경 요약

- Supabase PostgreSQL 연결을 장기 실행 FastAPI 서버에 맞는 Session pooler 기준으로 변경했습니다.
- Transaction pooler 전용 `NullPool` 및 prepared statement 우회 설정을 제거하고 SQLAlchemy 기본 연결 풀과 `pool_pre_ping`을 사용합니다.
- `.env.example`과 DB 연결 문서를 현재 구성에 맞게 수정했습니다.

### 연결 방식 검토

- **Session pooler**: 클라이언트 연결 동안 DB 세션을 유지합니다. 상시 실행되는 FastAPI 서버와 일반적인 SQLAlchemy 연결 풀, prepared statement 사용에 적합합니다.
- **Transaction pooler**: 트랜잭션이 끝날 때마다 DB 연결을 반환합니다. Lambda처럼 짧게 실행되는 서버리스 작업이 동시에 많이 접속할 때 유리하지만 세션 상태와 prepared statement 사용에 제약이 있습니다.

현재는 FastAPI가 DB 접근을 중앙에서 관리하고 RunPod 및 멀티에이전트가 FastAPI를 통해 작업하는 구조이므로 Session pooler를 선택했습니다.

추후 Lambda 형태의 단기 에이전트가 Supabase에 직접 접속하거나 짧은 DB 연결이 대량으로 발생하는 구조가 추가되면 해당 작업에 Transaction pooler 적용을 검토할 예정입니다.

## 검증

- Supabase 실제 DB 연결 테스트: `2 passed`
- `uv run ruff check app tests`: 통과
- `git diff --check`: 통과

## 영향 및 주의 사항

- 실제 연결 문자열이 들어 있는 `backend/.env`는 Git에 포함되지 않습니다.
- 각 로컬 및 배포 환경에서 `DATABASE_URL`에 Session pooler URI를 별도로 설정해야 합니다.
- DB 스키마 변경은 없습니다.