### PR TITLE
데모 수정본을 demo-jeseop 파일로 분리

### DIFF
--- a/demo/demo-jeseop.html
+++ b/demo/demo-jeseop.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#ffffff">
-  <title>FieldMed — 영업 History 자동화 플랫폼</title>
+  <title>SalesLuv — 영업 History 자동화 플랫폼</title>
   <style>
     :root {
       --ink: #10211e;
@@ -227,10 +227,43 @@
       z-index: 30;
       border-right: 1px solid rgba(255,255,255,.08);
     }
-    .sidebar .brand-lockup { padding: 0 8px 25px; }
+    .sidebar .brand-lockup { padding: 0 8px 17px; }
     .sidebar .brand-mark { width: 31px; height: 31px; font-size: 15px; }
     .side-label { margin: 14px 10px 8px; color: #708c85; font: 700 9px "Manrope"; letter-spacing: .15em; text-transform: uppercase; }
-    .nav { display: grid; gap: 5px; }
+    .nav {
+      display: flex;
+      flex: 1;
+      min-height: 0;
+      flex-direction: column;
+      gap: 14px;
+      overflow-y: auto;
+      padding: 2px 3px 12px 0;
+      scrollbar-width: thin;
+    }
+    .nav-section { display: grid; gap: 3px; }
+    .nav-section-label {
+      margin: 0;
+      padding: 0 10px 3px;
+      color: #8e8e93;
+      font: 700 9px "Manrope", sans-serif;
+      letter-spacing: .12em;
+      text-transform: uppercase;
+    }
+    .nav-section-toggle {
+      width: 100%;
+      border: 0;
+      background: transparent;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      cursor: pointer;
+      text-align: left;
+    }
+    .nav-section-toggle::after { content: "⌄"; font-size: 12px; transition: transform .18s ease; }
+    .nav-section.is-collapsed .nav-section-toggle::after { transform: rotate(-90deg); }
+    .nav-section.is-collapsed > :not(.nav-section-toggle) { display: none; }
+    .nav-section-icon { width: 18px; height: 18px; flex: 0 0 auto; }
+    .nav-section-title { flex: 1; }
     .nav-btn {
       position: relative;
       width: 100%;
@@ -238,15 +271,15 @@
       color: #a9bdb7;
       background: transparent;
       border-radius: 11px;
-      padding: 11px 12px;
+      padding: 8px 11px;
       display: grid;
-      grid-template-columns: 25px 1fr auto;
+      grid-template-columns: 1fr auto;
       align-items: center;
-      gap: 9px;
+      gap: 8px;
       text-align: left;
       cursor: pointer;
       font-weight: 600;
-      font-size: 13px;
+      font-size: 12px;
       transition: color .2s, background .2s;
     }
     .nav-btn:hover { color: white; background: rgba(255,255,255,.055); }
@@ -267,6 +300,13 @@
     .nav-sub-btn:hover { color: var(--ink); background: var(--line); }
     .nav-sub-btn.active { color: var(--blue); font-weight: 700; }
     .nav-sub-btn.active::before { opacity: 1; }
+    .sidebar-utility {
+      display: grid;
+      gap: 3px;
+      margin-top: 9px;
+      padding-top: 9px;
+      border-top: 1px solid rgba(60,60,67,.1);
+    }
     .sidebar-spacer { flex: 1; }
     .role-switch {
       display: flex;
@@ -362,56 +402,72 @@
     .link-btn { padding: 0; border: 0; background: none; color: #4f6d65; font-size: 11px; font-weight: 700; cursor: pointer; }
 
     /* Dashboard */
-    .briefing-hero {
-      position: relative;
-      overflow: hidden;
-      min-height: 330px;
-      display: block;
-      color: white;
-      background: var(--forest);
-      border-radius: 24px;
-      box-shadow: var(--shadow);
-      margin-bottom: 18px;
+    .dashboard-top-grid { display: grid; grid-template-columns: minmax(0, 7fr) minmax(250px, 3fr); gap: 14px; margin-bottom: 18px; }
+    .dashboard-notice {
+      min-height: 88px;
+      padding: 18px 22px;
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      color: #fff;
+      border: 0;
+      border-radius: 18px;
+      background: linear-gradient(110deg, #0a84ff 0%, #006bd8 68%, #0054ad 100%);
+      box-shadow: 0 12px 30px rgba(0,95,205,.18);
     }
-    .briefing-hero::before {
-      content: "";
-      position: absolute;
-      width: 360px;
-      height: 360px;
-      right: -80px;
-      top: -180px;
-      border: 1px solid rgba(217,255,103,.45);
-      border-radius: 50%;
-      box-shadow: 0 0 0 44px rgba(217,255,103,.025), 0 0 0 88px rgba(217,255,103,.018);
-    }
-    .brief-main { padding: clamp(25px, 3.5vw, 45px); position: relative; z-index: 1; }
-    .brief-main .eyebrow { color: #91aaa3; }
-    .visit-time { display: inline-flex; align-items: center; gap: 8px; color: var(--lime); font: 700 12px "Manrope"; }
-    .brief-main h2 { margin: 18px 0 6px; font-size: clamp(28px, 3.2vw, 46px); line-height: 1.05; letter-spacing: -.055em; }
-    .visit-meta { color: #a8bcb6; font-size: 12px; }
-    .ai-summary { max-width: 670px; margin: 24px 0; color: #d4dfdb; line-height: 1.75; font-size: 14px; }
-    .ai-summary mark { color: var(--lime); background: rgba(217,255,103,.08); border-bottom: 1px solid var(--lime); padding: 0 2px; }
-    .hero-actions { display: flex; gap: 9px; flex-wrap: wrap; }
-    .briefing-next-btn {
-      position: absolute; top: 50%; right: clamp(14px, 2.2vw, 26px); transform: translateY(-50%);
-      width: 46px; height: 46px; border-radius: 50%; z-index: 2;
-      display: grid; place-items: center;
-      background: rgba(255,255,255,.08); border: 1px solid rgba(255,255,255,.22);
-      color: rgba(255,255,255,.85); cursor: pointer;
-      transition: background .15s, transform .15s, border-color .15s;
-    }
-    .briefing-next-btn:hover { background: rgba(255,255,255,.16); border-color: rgba(255,255,255,.4); }
-    .briefing-next-btn:active { transform: translateY(-50%) scale(.94); }
-    .briefing-next-btn:focus-visible { outline: 2px solid var(--lime); outline-offset: 2px; }
-    .briefing-next-btn svg { width: 18px; height: 18px; }
-    .briefing-dots { position: absolute; right: clamp(14px, 2.2vw, 26px); bottom: 16px; z-index: 2; display: flex; gap: 5px; }
-    .briefing-dots span { width: 5px; height: 5px; border-radius: 50%; background: rgba(255,255,255,.28); transition: background .15s, width .15s; }
-    .briefing-dots span.active { background: var(--lime); width: 14px; border-radius: 3px; }
-    @media (max-width: 640px) {
-      .briefing-next-btn { top: auto; bottom: 16px; right: 16px; transform: none; }
-      .briefing-next-btn:active { transform: scale(.94); }
-      .briefing-dots { right: auto; left: 16px; bottom: 26px; }
-    }
+    .dashboard-notice-icon { width: 42px; height: 42px; flex: 0 0 auto; display: grid; place-items: center; border-radius: 13px; background: rgba(255,255,255,.16); font-weight: 900; }
+    .dashboard-notice-copy { min-width: 0; flex: 1; }
+    .dashboard-notice-copy .eyebrow { color: rgba(255,255,255,.72); }
+    .dashboard-notice h2 { margin: 3px 0 4px; font-size: 16px; }
+    .dashboard-notice p { margin: 0; color: rgba(255,255,255,.82); font-size: 10px; line-height: 1.55; }
+    .dashboard-notice-meta { flex: 0 0 auto; color: rgba(255,255,255,.75); font-size: 9px; font-weight: 700; }
+    .dashboard-monthly-goal { min-height: 88px; padding: 17px 19px; color: #fff; border: 0; border-radius: 18px; background: #163934; box-shadow: 0 12px 30px rgba(16,43,38,.14); }
+    .monthly-goal-head, .monthly-goal-value { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+    .monthly-goal-head .eyebrow { color: rgba(255,255,255,.58); }
+    .monthly-goal-head span { color: var(--lime); font-size: 8px; font-weight: 750; }
+    .monthly-goal-value { margin-top: 8px; }
+    .monthly-goal-value strong { font: 800 24px "Manrope"; letter-spacing: -.04em; }
+    .monthly-goal-value span { color: rgba(255,255,255,.7); font-size: 8px; }
+    .monthly-goal-track { height: 5px; margin-top: 10px; overflow: hidden; border-radius: 999px; background: rgba(255,255,255,.14); }
+    .monthly-goal-track i { display: block; width: 0; height: 100%; border-radius: inherit; background: var(--lime); transition: width .35s ease; }
+    .week-plan-card { padding: 20px; margin-bottom: 18px; }
+    .week-plan-head, .today-schedule-head { display: flex; align-items: center; justify-content: space-between; gap: 14px; margin-bottom: 14px; }
+    .week-plan-head h2, .today-schedule-head h2 { margin: 3px 0 0; font-size: 16px; }
+    .week-plan-grid { display: grid; grid-template-columns: repeat(7, minmax(100px, 1fr)); gap: 7px; overflow-x: auto; padding-bottom: 2px; }
+    .week-day { min-height: 126px; padding: 12px; border: 1px solid var(--line); border-radius: 13px; background: #f7f8fa; display: flex; flex-direction: column; }
+    .week-day time { display: flex; justify-content: space-between; color: var(--muted); font-size: 9px; font-weight: 700; }
+    .week-day time span { margin: 0; }
+    .week-day strong { display: block; margin-top: 14px; font-size: 10px; line-height: 1.45; }
+    .week-day-account { display: block; margin-top: 5px; color: var(--muted); font-size: 8px; line-height: 1.4; }
+    .week-day-meta { margin-top: auto; padding-top: 11px; color: #5f6b67; font-size: 8px; font-style: normal; font-weight: 750; }
+    .week-day.today { color: #fff; border-color: var(--blue); background: var(--blue); box-shadow: 0 8px 18px rgba(0,122,255,.18); }
+    .week-day.today time, .week-day.today .week-day-account, .week-day.today .week-day-meta { color: rgba(255,255,255,.78); }
+    .today-schedule { margin-bottom: 18px; }
+    .today-schedule-controls { display: flex; align-items: center; gap: 7px; }
+    .schedule-nav { width: 34px; height: 34px; display: grid; place-items: center; border: 1px solid rgba(60,60,67,.14); border-radius: 50%; color: var(--ink); background: #fff; cursor: pointer; font-size: 18px; }
+    .schedule-nav:hover { color: var(--blue); border-color: rgba(0,122,255,.3); }
+    .today-schedule-progress { min-width: 88px; color: var(--muted); font-size: 9px; text-align: right; }
+    .today-schedule-card { position: relative; min-height: 330px; padding: 28px; overflow: hidden; border-color: rgba(0,122,255,.34); background: linear-gradient(135deg, #eaf4ff 0%, #f8fbff 48%, #fff 100%); box-shadow: 0 18px 42px rgba(0,91,190,.13); }
+    .today-schedule-card::before { content: ""; position: absolute; inset: 0 auto 0 0; width: 7px; background: linear-gradient(180deg, #0a84ff, #005fca); }
+    .today-schedule-card.completed { border-color: rgba(36,138,61,.34); background: linear-gradient(135deg, #edf9f0 0%, #fbfefb 55%, #fff 100%); }
+    .today-schedule-card.completed::before { background: linear-gradient(180deg, #34c759, #248a3d); }
+    .schedule-edit { position: absolute; top: 22px; right: 22px; }
+    .schedule-card-head { padding-right: 100px; }
+    .schedule-status { display: inline-flex; align-items: center; gap: 7px; color: var(--blue); font-size: 10px; font-weight: 800; }
+    .schedule-status::before { content: ""; width: 7px; height: 7px; border-radius: 50%; background: currentColor; box-shadow: 0 0 0 5px rgba(0,122,255,.1); }
+    .today-schedule-card.completed .schedule-status { color: #248a3d; }
+    .schedule-card-head h2 { margin: 14px 0 6px; font-size: clamp(24px, 2.7vw, 36px); letter-spacing: -.045em; }
+    .schedule-card-head p { margin: 0; color: var(--muted); font-size: 11px; }
+    .schedule-insights { display: grid; grid-template-columns: 1.15fr .85fr; gap: 12px; margin-top: 22px; }
+    .schedule-insight { min-height: 122px; padding: 16px; border: 1px solid rgba(0,122,255,.08); border-radius: 14px; background: rgba(255,255,255,.74); }
+    .schedule-insight-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 10px; }
+    .schedule-insight h3 { margin: 0; font-size: 12px; }
+    .schedule-insight p { margin: 0; color: var(--ink-2); font-size: 10px; line-height: 1.65; }
+    .schedule-insight mark { color: var(--blue); background: #e6f0ff; padding: 1px 3px; }
+    .schedule-card-foot { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-top: 18px; }
+    .schedule-dots { display: flex; gap: 5px; }
+    .schedule-dots span { width: 6px; height: 6px; border-radius: 50%; background: #c8cbd1; }
+    .schedule-dots span.active { width: 18px; border-radius: 4px; background: var(--blue); }
     .btn-hero-outline { border: 1px solid rgba(255,255,255,.2); background: rgba(255,255,255,.06); color: white; }
 
     .metric-strip { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 18px; }
@@ -420,7 +476,6 @@
     .metric strong { display: block; margin-top: 8px; font: 800 25px "Manrope"; letter-spacing: -.04em; }
     .metric small { font-size: 9px; color: var(--muted); }
     .delta { padding: 4px 6px; border-radius: 8px; background: #e6f4ea; color: #347258; font: 700 9px "Manrope"; }
-    .dashboard-grid { display: grid; grid-template-columns: minmax(0, 1.16fr) minmax(340px, .84fr); gap: 18px; }
     .agenda-list { display: grid; gap: 0; }
     .agenda-item { display: grid; grid-template-columns: 58px 13px 1fr auto; gap: 13px; align-items: start; padding: 17px 0; border-top: 1px solid #e3e8e1; }
     .agenda-item:first-child { border-top: 0; }
@@ -435,17 +490,6 @@
     .tag-pill { padding: 4px 7px; border-radius: 7px; background: var(--surface-2); color: #52645f; font-size: 9px; font-weight: 600; }
     .tag-pill.risk { color: #a45427; background: #fff0e5; }
     .tag-pill.good { color: #37765c; background: #e6f4ea; }
-    .news-mini { display: grid; gap: 0; }
-    .news-mini-group + .news-mini-group { margin-top: 6px; }
-    .mini-group-label { display: flex; align-items: center; gap: 8px; margin: 0 0 2px; font-size: 8px; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; color: var(--muted); }
-    .mini-group-label::after { content: ""; flex: 1; height: 1px; background: #e3e8e1; }
-    .news-mini-item { display: grid; grid-template-columns: 50px 1fr; gap: 13px; padding: 15px 0; border-top: 1px solid #e3e8e1; }
-    .news-mini-item:first-child { border-top: 0; }
-    .news-date { font: 700 9px "Manrope"; color: var(--muted); }
-    .news-mini-item h4 { margin: 0 0 6px; font-size: 11px; line-height: 1.5; }
-    .news-mini-item p { margin: 0; color: var(--muted); font-size: 9px; line-height: 1.55; }
-    .source { display: inline-flex; align-items: center; gap: 5px; margin-top: 7px; color: #4d7066; font-size: 8px; font-weight: 700; }
-
     /* Shared toolbars */
     .toolbar { display: flex; align-items: center; gap: 9px; margin-bottom: 17px; flex-wrap: wrap; }
     .search-box { position: relative; flex: 1; min-width: 220px; max-width: 430px; }
@@ -454,28 +498,42 @@
     .chip { border: 1px solid var(--line); border-radius: 999px; background: rgba(255,255,255,.65); padding: 8px 11px; font-size: 10px; font-weight: 700; cursor: pointer; }
     .chip.active { color: white; background: var(--forest); border-color: var(--forest); }
 
-    /* News */
-    .source-banner { padding: 22px; margin-bottom: 17px; background: #e8efdf; border: 1px solid #cfdac6; border-radius: 17px; }
-    .source-banner strong { display: block; font-size: 13px; }
-    .source-banner p { margin: 5px 0 0; color: #65756e; font-size: 10px; }
-    .news-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 15px; }
-    .news-section { margin-bottom: 26px; }
-    .news-section[hidden] { display: none; }
-    .section-divider { display: flex; align-items: flex-end; gap: 12px; padding-bottom: 10px; margin-bottom: 14px; border-bottom: 1px solid var(--line); }
-    .section-divider h2 { margin: 0; font-size: 15px; letter-spacing: -.03em; }
-    .section-divider p { margin: 3px 0 0; color: var(--muted); font-size: 9px; }
-    .section-divider .tag-pill { margin-left: auto; }
-    .news-empty { padding: 26px; color: var(--muted); text-align: center; font-size: 10px; }
-    .news-card { padding: 20px; display: flex; min-height: 230px; flex-direction: column; transition: transform .2s, border-color .2s; }
-    .news-card:hover { transform: translateY(-3px); border-color: #a9b9b0; }
-    .news-card-top { display: flex; justify-content: space-between; gap: 10px; }
-    .category { padding: 5px 7px; border-radius: 7px; background: #e8eee8; font-size: 9px; font-weight: 700; }
-    .news-card time { color: var(--muted); font: 600 9px "Manrope"; }
-    .news-card h3 { margin: 18px 0 9px; font-size: 15px; line-height: 1.48; letter-spacing: -.025em; }
-    .news-card p { margin: 0; color: var(--muted); font-size: 10px; line-height: 1.65; }
-    .news-card-footer { margin-top: auto; padding-top: 15px; display: flex; justify-content: space-between; align-items: center; }
-
     /* Customers */
+    .section-tabs {
+      width: min(100%, 720px);
+      margin-bottom: 16px;
+      padding: 6px;
+      display: grid;
+      grid-auto-flow: column;
+      grid-auto-columns: minmax(140px, 1fr);
+      gap: 6px;
+      border: 1px solid rgba(60,60,67,.1);
+      border-radius: 18px;
+      background: #edf1f7;
+    }
+    .section-tab {
+      min-height: 64px;
+      padding: 11px 15px;
+      border: 0;
+      border-radius: 13px;
+      color: #6e6e73;
+      background: transparent;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      cursor: pointer;
+      text-align: left;
+      transition: color .18s ease, background .18s ease, box-shadow .18s ease, transform .18s ease;
+    }
+    .section-tab:hover { color: var(--ink); background: rgba(255,255,255,.65); }
+    .section-tab:active { transform: scale(.985); }
+    .section-tab span { font-size: 12px; font-weight: 750; }
+    .section-tab.active { color: #fff; background: var(--blue); box-shadow: 0 7px 18px rgba(0,122,255,.2); }
+    .account-tab { justify-content: space-between; }
+    .account-tab strong { font: 800 21px "Manrope", sans-serif; font-variant-numeric: tabular-nums; }
+    .customer-toolbar { margin-bottom: 17px; }
+    .customer-toolbar .search-box { max-width: 620px; }
     .customer-layout { display: grid; grid-template-columns: minmax(350px, .7fr) minmax(520px, 1.3fr); gap: 17px; align-items: start; }
     .customer-list { overflow: hidden; }
     .customer-row { width: 100%; border: 0; border-top: 1px solid #e2e8e0; background: transparent; padding: 15px 18px; display: grid; grid-template-columns: 42px 1fr auto; align-items: center; gap: 12px; text-align: left; cursor: pointer; }
@@ -520,6 +578,62 @@
     .hospital-contact .initial { width: 30px; height: 30px; border-radius: 9px; }
     .hospital-contact strong { display: block; font-size: 9px; }
     .hospital-contact span { color: var(--muted); font-size: 8px; }
+
+    /* Deal pipeline */
+    .deal-summary { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 18px; }
+    .deal-summary .metric { min-height: 112px; }
+    .deal-pipeline {
+      display: grid;
+      grid-template-columns: repeat(7, minmax(220px, 1fr));
+      gap: 12px;
+      overflow-x: auto;
+      padding: 2px 2px 14px;
+      scroll-snap-type: x proximity;
+    }
+    .deal-column {
+      min-width: 220px;
+      padding: 12px;
+      border-radius: 17px;
+      background: #edf2f8;
+      scroll-snap-align: start;
+    }
+    .deal-column-head { display: flex; align-items: center; gap: 8px; padding: 2px 2px 11px; }
+    .deal-column-head strong { font-size: 12px; }
+    .deal-column-head span { margin-left: auto; color: var(--muted); font: 700 9px "Manrope", sans-serif; }
+    .deal-column-value { color: var(--blue); font-size: 9px; font-weight: 700; }
+    .deal-stack { display: grid; gap: 9px; min-height: 92px; }
+    .deal-card {
+      padding: 14px;
+      border: 1px solid rgba(60,60,67,.12);
+      border-radius: 13px;
+      background: #fff;
+      box-shadow: 0 5px 16px rgba(0,65,140,.05);
+      transition: transform .18s ease, border-color .18s ease, opacity .18s ease;
+    }
+    .deal-card:hover { transform: translateY(-2px); border-color: rgba(0,122,255,.3); }
+    .deal-card[hidden] { display: none; }
+    .deal-company { margin: 0 0 5px; color: var(--muted); font-size: 8px; font-weight: 700; }
+    .deal-card h3 { margin: 0; font-size: 12px; line-height: 1.45; }
+    .deal-card-meta { display: flex; align-items: center; gap: 6px; margin-top: 12px; }
+    .deal-value { font: 800 12px "Manrope", sans-serif; font-variant-numeric: tabular-nums; }
+    .deal-probability { margin-left: auto; color: var(--muted); font: 700 9px "Manrope", sans-serif; }
+    .deal-next { margin: 9px 0 0; color: var(--muted); font-size: 8.5px; line-height: 1.45; }
+    .deal-owner { display: flex; align-items: center; gap: 6px; margin-top: 11px; color: var(--muted); font-size: 8.5px; }
+    .deal-owner i { width: 20px; height: 20px; border-radius: 7px; display: grid; place-items: center; color: var(--blue); background: #e5f0ff; font-style: normal; font-weight: 800; }
+    .deal-card-actions { display: flex; justify-content: space-between; gap: 6px; margin-top: 12px; padding-top: 10px; border-top: 1px solid var(--line); }
+    .deal-move {
+      border: 0;
+      padding: 4px 0;
+      color: var(--muted);
+      background: transparent;
+      cursor: pointer;
+      font-size: 9px;
+      font-weight: 700;
+    }
+    .deal-move:hover { color: var(--blue); }
+    .deal-move:disabled { opacity: .25; cursor: default; }
+    .deal-empty { display: none; margin: 8px 0 0; color: var(--muted); font-size: 9px; text-align: center; }
+    .deal-column.is-empty .deal-empty { display: block; }
 
     /* Calendar */
     .calendar-layout { display: grid; grid-template-columns: minmax(0, 1.35fr) minmax(320px, .65fr); gap: 17px; align-items: start; }
@@ -614,17 +728,6 @@
     .member-stats strong { display: block; color: var(--ink); font: 800 10px "Manrope"; }
 
     /* Team goals and coaching */
-    .member-command-grid { display: grid; grid-template-columns: 1.1fr .85fr 1.05fr; gap: 12px; margin-bottom: 17px; }
-    .member-command { min-height: 150px; padding: 18px; }
-    .member-command h2 { margin: 4px 0 8px; font-size: 14px; }
-    .member-command p { margin: 0; color: var(--muted); font-size: 9px; line-height: 1.6; }
-    .member-notice { color: #e8f3ef; background: var(--forest); border-color: transparent; }
-    .member-notice h2 { color: white; }
-    .member-notice p { color: #a9bdb7; }
-    .notice-meta { display: flex; align-items: center; justify-content: space-between; margin-top: 17px; color: var(--lime); font-size: 8px; }
-    .sales-goal-value { display: flex; align-items: baseline; gap: 6px; margin: 10px 0 11px; }
-    .sales-goal-value strong { font: 800 26px "Manrope"; }
-    .sales-goal-value span { color: var(--muted); font-size: 8px; }
     .progress-bar { height: 7px; border-radius: 99px; background: #e2e7df; overflow: hidden; }
     .progress-bar > span { display: block; height: 100%; border-radius: inherit; background: var(--lime-deep); transition: width .35s ease; }
     .goal-brief-list { display: grid; gap: 7px; margin-top: 11px; }
@@ -671,9 +774,6 @@
     .daily-item .del { border: 0; background: none; color: var(--muted); cursor: pointer; font-size: 13px; }
     .daily-empty { padding: 18px; color: var(--muted); text-align: center; font-size: 9px; }
     .next-directive { margin-top: 10px !important; padding-left: 10px; border-left: 3px solid var(--orange); color: var(--ink-2) !important; font-weight: 700; }
-    .manager-tabs { display: flex; gap: 5px; width: fit-content; margin-bottom: 17px; padding: 5px; border: 1px solid var(--line); border-radius: 13px; background: #e9ede7; }
-    .manager-tab { border: 0; border-radius: 9px; padding: 10px 16px; color: var(--muted); background: transparent; font-size: 9px; font-weight: 800; cursor: pointer; }
-    .manager-tab.active { color: white; background: var(--forest); box-shadow: 0 7px 18px rgba(16,43,38,.14); }
     .manager-panel { display: none; }
     .manager-panel.active { display: block; animation: pageIn .28s both; }
     .settings-grid { display: grid; grid-template-columns: minmax(0, 1.15fr) minmax(320px, .85fr); gap: 17px; align-items: start; }
@@ -812,10 +912,9 @@
 
     @media (max-width: 1150px) {
       :root { --sidebar: 210px; }
-      .news-grid { grid-template-columns: repeat(2, 1fr); }
-      .metric-strip, .manager-kpis { grid-template-columns: repeat(2, 1fr); }
+      .metric-strip, .manager-kpis, .deal-summary { grid-template-columns: repeat(2, 1fr); }
       .customer-layout, .calendar-layout, .manager-grid { grid-template-columns: 1fr; }
-      .member-command-grid, .settings-grid { grid-template-columns: 1fr; }
+      .settings-grid { grid-template-columns: 1fr; }
       .team-strip { grid-template-columns: repeat(2, 1fr); }
     }
 
@@ -834,9 +933,13 @@
         border-top: 1px solid rgba(255,255,255,.1);
         border-right: 0;
       }
-      .sidebar > .brand-lockup, .side-label, .sidebar-spacer, .role-switch { display: none; }
-      .nav { grid-template-columns: repeat(6, 1fr); gap: 2px; }
-      .nav-btn { display: flex; flex-direction: column; gap: 2px; padding: 7px 2px; text-align: center; font-size: 8px; }
+      .sidebar > .brand-lockup, .side-label, .sidebar-spacer, .sidebar-utility, .role-switch { display: none; }
+      .nav { display: flex; flex-direction: row; gap: 2px; overflow-x: auto; overflow-y: hidden; padding: 0 0 3px; }
+      .nav-section, .nav-group { display: contents; }
+      .nav-section-label, .nav-sub { display: none !important; }
+      .nav-section.is-collapsed > .nav-btn { display: flex; }
+      .nav-section.is-collapsed > .nav-group { display: contents; }
+      .nav-btn { flex: 0 0 74px; display: flex; justify-content: center; padding: 7px 4px; text-align: center; font-size: 8px; }
       .nav-index { font-size: 7px; }
       .nav-dot { display: none; }
       .main { margin-left: 0; }
@@ -847,11 +950,10 @@
       .page-header { align-items: flex-start; flex-direction: column; }
       .page-actions { margin-left: 0; width: 100%; flex-wrap: nowrap; overflow-x: auto; -webkit-overflow-scrolling: touch; padding-bottom: 2px; }
       .page-actions .btn { flex: 0 0 auto; white-space: nowrap; }
-      .briefing-hero { min-height: auto; border-radius: 18px; }
-      .brief-main { padding: 24px; }
-      .metric-strip, .manager-kpis { grid-template-columns: 1fr 1fr; }
-      .dashboard-grid, .customer-layout { grid-template-columns: 1fr; }
-      .news-grid { grid-template-columns: 1fr; }
+      .dashboard-top-grid { grid-template-columns: 1fr; }
+      .metric-strip, .manager-kpis, .deal-summary { grid-template-columns: 1fr 1fr; }
+      .customer-layout { grid-template-columns: 1fr; }
+      .schedule-insights { grid-template-columns: 1fr; }
       .detail-grid { grid-template-columns: 1fr; }
       .customer-cover { padding-bottom: 76px; }
       .customer-actions { left: 22px; right: auto; }
@@ -879,11 +981,17 @@
     }
 
     @media (max-width: 500px) {
+      .section-tabs { grid-auto-columns: minmax(138px, 1fr); overflow-x: auto; }
+      .dashboard-notice { align-items: flex-start; flex-wrap: wrap; }
+      .dashboard-notice-meta { width: 100%; padding-left: 58px; }
+      .today-schedule-card { padding: 22px; }
+      .schedule-edit { top: 18px; right: 18px; }
+      .schedule-card-head { padding-right: 82px; }
+      .schedule-card-foot { align-items: stretch; flex-direction: column; }
+      .schedule-card-foot .btn { width: 100%; }
       .nav-btn .nav-text { max-width: 48px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-      .metric-strip, .manager-kpis, .team-strip { grid-template-columns: 1fr; }
+      .metric-strip, .manager-kpis, .team-strip, .deal-summary { grid-template-columns: 1fr; }
       .issue-summary { grid-template-columns: 1fr 1fr; }
-      .manager-tabs { width: 100%; }
-      .manager-tab { flex: 1; padding-inline: 8px; }
       .target-setting-row { grid-template-columns: 1fr; }
       .member-issue-row { grid-template-columns: 1fr auto; }
       .member-issue-row > :not(:first-child):not(:last-child) { display: none; }
@@ -935,6 +1043,7 @@
       outline-color: rgba(0, 122, 255, .35);
     }
     .page-header h1, .login-copy h1 { letter-spacing: -.035em; }
+
     .eyebrow { letter-spacing: .11em; }
     .positive { color: #248a3d; }
     .warning, .attention-note { color: #a65300; }
@@ -967,6 +1076,44 @@
     .nav-btn { color: #6e6e73; }
     .nav-btn:hover { color: var(--ink); background: #f2f2f7; }
     .nav-btn.active { color: #fff; background: var(--blue); box-shadow: 0 8px 20px rgba(0,122,255,.22); }
+    .nav-section {
+      gap: 4px;
+      padding: 8px;
+      border-radius: 16px;
+      background: #f1f1f3;
+      transition: padding .18s ease, background .18s ease;
+    }
+    .nav-section-label {
+      gap: 9px;
+      padding: 8px 9px 7px;
+      color: var(--ink);
+      font: 750 13px "Pretendard", sans-serif;
+      letter-spacing: 0;
+      text-transform: none;
+    }
+    .nav-section-toggle::after {
+      content: "";
+      width: 8px;
+      height: 8px;
+      margin: 3px 3px 0 0;
+      border-top: 1.5px solid currentColor;
+      border-left: 1.5px solid currentColor;
+      transform: rotate(45deg);
+      opacity: .55;
+    }
+    .nav-section.is-collapsed {
+      padding: 0 8px;
+      background: transparent;
+    }
+    .nav-section.is-collapsed .nav-section-label { color: #6e6e73; }
+    .nav-section.is-collapsed .nav-section-toggle::after { transform: rotate(-135deg); }
+    .nav-section .nav-btn { padding: 9px 11px; }
+    .nav-section .nav-btn:hover { color: var(--ink); background: rgba(255,255,255,.55); }
+    .nav-section .nav-btn.active {
+      color: var(--ink);
+      background: #fff;
+      box-shadow: 0 1px 3px rgba(0,0,0,.045);
+    }
     .role-switch { color: var(--ink); background: #f2f4f8; border-color: rgba(60,60,67,.12); }
     .avatar { color: var(--blue); background: #e5f0ff; }
     .logout-btn:hover { color: var(--blue); background: #eaf3ff; }
@@ -989,21 +1136,16 @@
       box-shadow: 0 1px 2px rgba(0,0,0,.025), 0 12px 34px rgba(0,70,150,.055);
     }
     .metric, .manager-kpi, .issue-summary .card { border-radius: 17px; }
-    .source-banner { background: #eaf3ff; border-color: #c9e0ff; }
-    .source-banner p { color: #52657a; }
-    .category, .doc-row.header, .member-issue-row.header, .weekday, .logic-step, .goal-brief-item, .rec-reason, .match-box { background: #f2f5fa; }
-    .news-card:hover { border-color: #b9d7ff; box-shadow: 0 15px 36px rgba(0,122,255,.08); }
-    .agenda-item, .news-mini-item, .customer-row, .doc-row { border-color: rgba(60,60,67,.12); }
-    .link-btn, .source, .issue small { color: var(--blue); }
+    .doc-row.header, .member-issue-row.header, .weekday, .logic-step, .goal-brief-item, .rec-reason, .match-box { background: #f2f5fa; }
+    .agenda-item, .customer-row, .doc-row { border-color: rgba(60,60,67,.12); }
+    .link-btn, .issue small { color: var(--blue); }
     .delta { color: #248a3d; background: #eaf7ee; }
 
-    .briefing-hero, .customer-cover, .manager-banner, .member-notice, .notice-preview {
+    .customer-cover, .manager-banner, .notice-preview {
       background: linear-gradient(145deg, #0a84ff 0%, #006bd8 62%, #0054ad 100%);
     }
-    .briefing-hero::before, .customer-cover::after { border-color: rgba(255,255,255,.25); box-shadow: 0 0 0 44px rgba(255,255,255,.022), 0 0 0 88px rgba(255,255,255,.014); }
-    .brief-main .eyebrow, .visit-meta, .ai-summary, .customer-identity p, .manager-banner span, .member-notice p, .notice-preview p { color: rgba(255,255,255,.76); }
-    .visit-time, .notice-meta { color: #fff; }
-    .ai-summary mark { color: #fff; background: rgba(255,255,255,.12); border-bottom-color: rgba(255,255,255,.78); }
+    .customer-cover::after { border-color: rgba(255,255,255,.25); box-shadow: 0 0 0 44px rgba(255,255,255,.022), 0 0 0 88px rgba(255,255,255,.014); }
+    .customer-identity p, .manager-banner span, .notice-preview p { color: rgba(255,255,255,.76); }
     .manager-banner .lock { color: #fff; background: rgba(255,255,255,.16); }
 
     .btn { border-radius: 12px; transition: transform 180ms cubic-bezier(.2,.8,.2,1), box-shadow 180ms ease, background 180ms ease, border-color 180ms ease; }
@@ -1016,8 +1158,7 @@
     .btn-hero-outline { color: #fff; background: rgba(255,255,255,.12); border-color: rgba(255,255,255,.3); }
 
     .chip { color: #515154; background: rgba(255,255,255,.88); border-color: rgba(60,60,67,.16); }
-    .chip.active, .manager-tab.active { color: #fff; background: var(--blue); border-color: var(--blue); box-shadow: 0 6px 16px rgba(0,122,255,.18); }
-    .manager-tabs { background: #edf1f7; border-color: rgba(60,60,67,.1); }
+    .chip.active { color: #fff; background: var(--blue); border-color: var(--blue); box-shadow: 0 6px 16px rgba(0,122,255,.18); }
     .customer-row:hover { background: #f4f7fb; }
     .customer-row.active { background: #eaf3ff; box-shadow: inset 3px 0 var(--blue); }
     .initial, .customer-row:nth-child(3n+2) .initial, .customer-row:nth-child(3n+3) .initial { color: var(--blue); background: #e4efff; }
@@ -1119,11 +1260,11 @@
 <body>
   <section class="login-shell" id="loginView">
     <div class="login-story">
-      <div class="brand-lockup"><span class="brand-mark">F</span><span class="brand-name">FieldMed</span></div>
+      <div class="brand-lockup"><span class="brand-mark">S</span><span class="brand-name">SalesLuv</span></div>
       <div class="login-copy">
         <span class="tag"><i class="pulse-dot"></i> Sales History Workspace</span>
         <h1>흩어진 영업기록을<br><span>한 곳에 모아</span> 보여 줍니다.</h1>
-        <p>병원·고객·일정·미팅 기록을 한 흐름으로 연결해 방문 준비와 보고서 작성을 돕습니다.</p>
+        <p>회사·고객·일정·미팅 기록을 한 흐름으로 연결해 방문 준비와 보고서 작성을 돕습니다.</p>
       </div>
       <div class="login-proof">
         <div><strong>01</strong><small>방문 전 브리핑</small></div>
@@ -1134,10 +1275,10 @@
     <div class="login-panel">
       <p class="eyebrow">Welcome back</p>
       <h2>현장으로 돌아가기</h2>
-      <p>FieldMed 데모 계정으로 주요 영업 흐름을 확인하세요.</p>
+      <p>SalesLuv 데모 계정으로 주요 영업 흐름을 확인하세요.</p>
       <form id="loginForm">
-        <div class="field"><label for="email">이메일</label><input class="input" id="email" type="email" value="manager@fieldmed.demo" required></div>
-        <div class="field"><label for="password">비밀번호</label><input class="input" id="password" type="password" value="fieldmed" required></div>
+        <div class="field"><label for="email">이메일</label><input class="input" id="email" type="email" value="manager@salesluv.demo" required></div>
+        <div class="field"><label for="password">비밀번호</label><input class="input" id="password" type="password" value="salesluv" required></div>
         <button class="btn btn-primary login-main-btn" type="submit">팀장 데모로 로그인 <span>→</span></button>
       </form>
       <div class="or">역할별 화면 바로 보기</div>
@@ -1151,37 +1292,52 @@
 
   <div class="app" id="app" hidden>
     <aside class="sidebar">
-      <button class="brand-lockup" type="button" data-route="dashboard" aria-label="영업 대시보드로 이동"><span class="brand-mark">F</span><span class="brand-name">FieldMed</span></button>
-      <p class="side-label">Workspace</p>
+      <button class="brand-lockup" type="button" data-route="dashboard" aria-label="영업 대시보드로 이동"><span class="brand-mark">S</span><span class="brand-name">SalesLuv</span></button>
       <nav class="nav" aria-label="주요 메뉴">
-        <button class="nav-btn active" data-route="dashboard"><span class="nav-index">01</span><span class="nav-text">영업 대시보드</span><i class="nav-dot"></i></button>
-        <button class="nav-btn" data-route="calendar"><span class="nav-index">02</span><span class="nav-text">업무 캘린더</span><i class="nav-dot"></i></button>
-        <button class="nav-btn" data-route="customers"><span class="nav-index">03</span><span class="nav-text">고객 관리</span><i class="nav-dot"></i></button>
-        <button class="nav-btn" data-route="orders"><span class="nav-index">04</span><span class="nav-text">발주 관리</span><i class="nav-dot"></i></button>
-        <button class="nav-btn" data-route="complaints"><span class="nav-index">05</span><span class="nav-text">고객불만 관리</span><i class="nav-dot"></i></button>
-        <div class="nav-group">
-          <button class="nav-btn" data-route="daily"><span class="nav-index">06</span><span class="nav-text">업무보고 관리</span><i class="nav-dot"></i></button>
-          <div class="nav-sub">
-            <button class="nav-sub-btn" type="button" data-route="daily" data-report-tab="daily">일일업무 분석</button>
-            <button class="nav-sub-btn" type="button" data-route="daily" data-report-tab="weekly">주간업무 분석</button>
-            <button class="nav-sub-btn" type="button" data-route="daily" data-report-tab="monthly">월간업무 분석</button>
-          </div>
+        <div class="nav-section" role="group" aria-labelledby="nav-overview-label">
+          <button class="nav-section-label nav-section-toggle" id="nav-overview-label" type="button" aria-expanded="true"><svg class="nav-section-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg><span class="nav-section-title">대시보드</span></button>
+          <button class="nav-btn active" data-route="dashboard"><span class="nav-text">영업 대시보드</span><i class="nav-dot"></i></button>
         </div>
-        <button class="nav-btn" data-route="reports"><span class="nav-index">07</span><span class="nav-text">리포트 라이브러리</span><i class="nav-dot"></i></button>
-        <button class="nav-btn" data-route="documents"><span class="nav-index">08</span><span class="nav-text">문서 라이브러리</span><i class="nav-dot"></i></button>
-        <button class="nav-btn" data-route="publication"><span class="nav-index">09</span><span class="nav-text">Publication</span><i class="nav-dot"></i></button>
-        <button class="nav-btn" data-route="news"><span class="nav-index">10</span><span class="nav-text">News</span><i class="nav-dot"></i></button>
-        <button class="nav-btn manager-only" data-route="manager"><span class="nav-index">11</span><span class="nav-text">팀장</span><i class="nav-dot"></i></button>
+        <div class="nav-section" role="group" aria-labelledby="nav-account-label">
+          <button class="nav-section-label nav-section-toggle" id="nav-account-label" type="button" aria-expanded="true"><svg class="nav-section-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="9" cy="8" r="3"/><path d="M3.5 20v-1.5A4.5 4.5 0 0 1 8 14h2a4.5 4.5 0 0 1 4.5 4.5V20"/><path d="M16 5.5a3 3 0 0 1 0 5.8M17 14a4.5 4.5 0 0 1 3.5 4.4V20"/></svg><span class="nav-section-title">고객·회사</span></button>
+          <button class="nav-btn" data-route="customers"><span class="nav-text">고객·회사 관리</span><i class="nav-dot"></i></button>
+          <button class="nav-btn" data-route="complaints"><span class="nav-text">고객 요청·이슈</span><i class="nav-dot"></i></button>
+        </div>
+        <div class="nav-section" role="group" aria-labelledby="nav-sales-label">
+          <button class="nav-section-label nav-section-toggle" id="nav-sales-label" type="button" aria-expanded="true"><svg class="nav-section-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M15 8.5h-4.5a2 2 0 0 0 0 4H13a2 2 0 0 1 0 4H8.5M12 6.5v11"/></svg><span class="nav-section-title">세일즈</span></button>
+          <button class="nav-btn" data-route="deals"><span class="nav-text">딜 파이프라인</span><i class="nav-dot"></i></button>
+          <button class="nav-btn" data-route="reports"><span class="nav-text">견적·계약·리포트</span><i class="nav-dot"></i></button>
+          <button class="nav-btn" data-route="orders"><span class="nav-text">발주 관리</span><i class="nav-dot"></i></button>
+        </div>
+        <div class="nav-section" role="group" aria-labelledby="nav-work-label">
+          <button class="nav-section-label nav-section-toggle" id="nav-work-label" type="button" aria-expanded="true"><svg class="nav-section-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="3" width="16" height="18" rx="2"/><path d="M8 8h8M8 12h5M8 16h3"/></svg><span class="nav-section-title">업무</span></button>
+          <button class="nav-btn" data-route="calendar"><span class="nav-text">업무 캘린더</span><i class="nav-dot"></i></button>
+          <div class="nav-group">
+            <button class="nav-btn" data-route="daily"><span class="nav-text">업무보고</span><i class="nav-dot"></i></button>
+            <div class="nav-sub">
+              <button class="nav-sub-btn" type="button" data-route="daily" data-report-tab="daily">일일업무 분석</button>
+              <button class="nav-sub-btn" type="button" data-route="daily" data-report-tab="weekly">주간업무 분석</button>
+              <button class="nav-sub-btn" type="button" data-route="daily" data-report-tab="monthly">월간업무 분석</button>
+            </div>
+          </div>
+          <button class="nav-btn" data-route="documents"><span class="nav-text">문서 라이브러리</span><i class="nav-dot"></i></button>
+        </div>
+        <div class="nav-section manager-only" role="group" aria-labelledby="nav-manager-label">
+          <button class="nav-section-label nav-section-toggle" id="nav-manager-label" type="button" aria-expanded="true"><svg class="nav-section-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 20V10M10 20V4M16 20v-7M22 20H2"/></svg><span class="nav-section-title">팀장</span></button>
+          <button class="nav-btn" data-route="manager" data-manager-view="reports"><span class="nav-text">팀 대시보드</span><i class="nav-dot"></i></button>
+          <button class="nav-btn" data-route="manager" data-manager-view="team"><span class="nav-text">팀 관리</span><i class="nav-dot"></i></button>
+        </div>
+      </nav>
+      <div class="sidebar-utility">
         <div class="nav-group">
-          <button class="nav-btn" data-route="info"><span class="nav-index">11</span><span class="nav-text">상세정보</span><i class="nav-dot"></i></button>
+          <button class="nav-btn" data-route="info"><span class="nav-text">설정 및 지원</span><i class="nav-dot"></i></button>
           <div class="nav-sub">
             <button class="nav-sub-btn" type="button" data-route="info" data-info-tab="mypage">마이 페이지</button>
             <button class="nav-sub-btn" type="button" data-route="info" data-info-tab="billing">결제 및 청구</button>
             <button class="nav-sub-btn" type="button" data-route="info" data-info-tab="support">고객 지원</button>
           </div>
         </div>
-      </nav>
-      <div class="sidebar-spacer"></div>
+      </div>
       <div class="role-switch">
         <button class="logout-btn" id="logoutButton" type="button">로그아웃</button>
       </div>
@@ -1189,8 +1345,8 @@
 
     <main class="main">
       <header class="topbar">
-        <button class="icon-btn mobile-menu" type="button" aria-label="홈으로 이동" data-route="dashboard">F</button>
-        <div class="breadcrumb">FieldMed / <strong id="currentPageName">대시보드</strong></div>
+        <button class="icon-btn mobile-menu" type="button" aria-label="홈으로 이동" data-route="dashboard">S</button>
+        <div class="breadcrumb">SalesLuv / <strong id="currentPageName">대시보드</strong></div>
         <div class="topbar-spacer"></div>
         <span class="demo-badge">SYNTHETIC DEMO</span>
         <span class="top-date">2026.08.05 수요일</span>
@@ -1203,136 +1359,170 @@
       <div class="content">
         <section class="page active" data-page="dashboard">
           <div class="page-header">
-            <div><p class="eyebrow">Wednesday, 05 August</p><h1>오늘의 영업 필드</h1><p>방문 일정과 지난 기록, 준비사항을 먼저 확인하세요.</p></div>
+            <div><p class="eyebrow">Wednesday, 05 August</p><h1>오늘의 영업 일정</h1><p>이번 주 계획을 확인하고 오늘 미팅을 준비한 뒤 업무보고까지 완료하세요.</p></div>
           </div>
 
-          <div class="member-command-grid member-only" id="memberCommandCenter" hidden>
-            <article class="card member-command member-notice">
-              <p class="eyebrow">Today's team notice</p>
-              <h2 id="memberNoticeTitle">오후 방문 전 계약 조건 확인</h2>
-              <p id="memberNoticeBody">오늘 진행하는 모든 병원 미팅에서 예산 집행 시기와 실제 승인 담당자를 우선 확인해 주세요.</p>
-              <div class="notice-meta"><span id="memberNoticeMeta">김서현 팀장 · 08:40</span></div>
+          <div class="dashboard-top-grid">
+            <article class="dashboard-notice">
+              <span class="dashboard-notice-icon" aria-hidden="true">!</span>
+              <div class="dashboard-notice-copy"><p class="eyebrow">Team notice</p><h2 id="memberNoticeTitle">오후 방문 전 계약 조건 확인</h2><p id="memberNoticeBody">오늘 진행하는 모든 고객사 미팅에서 예산 집행 시기와 실제 승인 담당자를 우선 확인해 주세요.</p></div>
+              <span class="dashboard-notice-meta" id="memberNoticeMeta">김서현 팀장 · 08:40</span>
             </article>
-            <article class="card member-command">
-              <p class="eyebrow">August sales target</p>
-              <h2>나의 월 매출 목표</h2>
-              <div class="sales-goal-value"><strong id="memberSalesPercent">65.5%</strong><span id="memberSalesValue">₩52.4M / ₩80M</span></div>
-              <div class="progress-bar" aria-label="월 매출 목표 달성률"><span id="memberSalesProgress" style="width:65.5%"></span></div>
-              <p style="margin-top:10px" id="memberSalesRemaining">목표까지 ₩27.6M 남았습니다 · 확정 매출 기준</p>
-            </article>
-            <article class="card member-command">
-              <div class="card-head" style="margin-bottom:0"><div><p class="eyebrow">Purchase orders</p><h2>발주 관리</h2></div><span class="tag-pill" id="memberPoLateTag">0건 지연</span></div>
-              <div class="goal-brief-list" id="memberPoSummary" style="margin-top:11px"></div>
-              <p class="next-directive" id="memberPoDirective">발주 등록·상태 변경은 발주관리에서 처리하세요.</p>
-              <button class="link-btn" data-route="orders" style="margin-top:10px">발주관리 열기 →</button>
+            <article class="dashboard-monthly-goal">
+              <div class="monthly-goal-head"><p class="eyebrow">Monthly sales</p><span id="memberSalesScope">영업 1팀</span></div>
+              <div class="monthly-goal-value"><strong id="memberSalesPercent">63.3%</strong><span id="memberSalesValue">₩189.9M / ₩300M</span></div>
+              <div class="monthly-goal-track" aria-label="월 매출 목표 달성률"><i id="memberSalesProgress" style="width:63.3%"></i></div>
             </article>
           </div>
 
-          <article class="briefing-hero">
-            <div class="brief-main">
-              <p class="eyebrow">Next hospital briefing</p>
-              <span class="visit-time" id="briefHeroTime"><i class="pulse-dot"></i> 10:30 · 1시간 20분 후</span>
-              <h2 id="briefHeroTitle">한빛대학교병원</h2>
-              <p class="visit-meta" id="briefHeroMeta">순환기내과 · 박서준 교수 외 2명 · CardioView X7 도입 협의</p>
-              <p class="ai-summary" id="briefHeroSummary">지난 미팅에서 제품 테스트는 긍정적이었지만 <mark>구매팀 담당자</mark>와 <mark>예산 편성 시기</mark>가 확인되지 않았습니다. 오늘은 구매 절차를 확인하고 유지보수 비용 비교표를 제시하세요.</p>
-              <div class="hero-actions">
-                <button class="btn btn-lime" data-open="briefingDialog">브리핑 전체 보기</button>
-                <button class="btn btn-hero-outline" data-route="daily">일일업무보고 작성</button>
-                <button class="btn btn-hero-outline" data-route="customers">고객 History</button>
-                <button class="btn btn-hero-outline" data-open="scheduleDialog">일정 수정</button>
-              </div>
+          <article class="card week-plan-card">
+            <div class="week-plan-head"><div><p class="eyebrow">Weekly plan</p><h2>이번 주 계획</h2></div><button class="link-btn" data-route="calendar">전체 캘린더 보기 →</button></div>
+            <div class="week-plan-grid" aria-label="8월 첫째 주 영업 계획">
+              <div class="week-day"><time><span>월</span><b>03</b></time><strong>견적 후속 정리</strong><span class="week-day-account">한빛테크 외 1곳</span><em class="week-day-meta">업무 2건</em></div>
+              <div class="week-day"><time><span>화</span><b>04</b></time><strong>사용 교육</strong><span class="week-day-account">서림커머스</span><em class="week-day-meta">완료 1건</em></div>
+              <div class="week-day today"><time><span>수 · 오늘</span><b>05</b></time><strong>고객 미팅</strong><span class="week-day-account">한빛테크 외 2곳</span><em class="week-day-meta">방문 3건 · 10:30 시작</em></div>
+              <div class="week-day"><time><span>목</span><b>06</b></time><strong>후속 일정 등록</strong><span class="week-day-account">새봄솔루션</span><em class="week-day-meta">미등록 1건</em></div>
+              <div class="week-day"><time><span>금</span><b>07</b></time><strong>주간업무 제출</strong><span class="week-day-account">영업 1팀</span><em class="week-day-meta">17:00 마감</em></div>
+              <div class="week-day"><time><span>토</span><b>08</b></time><strong>등록 일정 없음</strong><span class="week-day-account">개인 휴무</span><em class="week-day-meta">일정 0건</em></div>
+              <div class="week-day"><time><span>일</span><b>09</b></time><strong>다음 주 준비</strong><span class="week-day-account">추천 일정 검토</span><em class="week-day-meta">추천 2건</em></div>
             </div>
-            <button class="briefing-next-btn" id="briefHeroNext" type="button" aria-label="다음 병원 브리핑 보기">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg>
-            </button>
-            <div class="briefing-dots" id="briefHeroDots" aria-hidden="true"></div>
           </article>
 
+          <section class="today-schedule" aria-labelledby="todayScheduleTitle">
+            <div class="today-schedule-head"><div><p class="eyebrow">Today's meetings</p><h2 id="todayScheduleTitle">오늘 일정</h2></div><div class="today-schedule-controls"><span class="today-schedule-progress" id="todayScheduleProgress"></span><button class="schedule-nav" id="todaySchedulePrev" type="button" aria-label="이전 일정">‹</button><button class="schedule-nav" id="todayScheduleNext" type="button" aria-label="다음 일정">›</button></div></div>
+            <article class="card today-schedule-card" id="todayScheduleCard"></article>
+          </section>
+
           <div class="metric-strip">
-            <div class="metric"><div class="metric-top"><span>오늘 방문병원</span><span class="delta">+1</span></div><strong>3</strong><small>병원 3곳 · 고객 5명</small></div>
+            <div class="metric"><div class="metric-top"><span>오늘 방문 회사</span><span class="delta">+1</span></div><strong>3</strong><small>회사 3곳 · 고객 5명</small></div>
             <div class="metric"><div class="metric-top"><span>미완료 후속업무</span><span class="delta" style="background:#fff0e4;color:#a75b2d">2 지연</span></div><strong>7</strong><small>이번 주 마감 4건</small></div>
             <div class="metric"><div class="metric-top"><span>C/S 대응요청</span><span class="delta" style="background:#fbe6e6;color:#a33b3b">긴급 1건</span></div><strong>4</strong><small>미응답 2건 · 처리중 2건</small></div>
-            <div class="metric"><div class="metric-top"><span>계약갱신 예정</span><span class="delta" style="background:#fff0e4;color:#a75b2d">30일 이내</span></div><strong>2</strong><small>새봄정형외과 외 1곳</small></div>
+            <div class="metric"><div class="metric-top"><span>계약갱신 예정</span><span class="delta" style="background:#fff0e4;color:#a75b2d">30일 이내</span></div><strong>2</strong><small>새봄솔루션 외 1곳</small></div>
           </div>
 
-          <div class="dashboard-grid">
-            <article class="card">
-              <div class="card-head"><div><p class="eyebrow">Field agenda</p><h2>오늘 일정과 후속 업무</h2></div><button class="link-btn" data-route="calendar">캘린더 전체 보기 →</button></div>
-              <div class="card-body agenda-list" id="dashboardAgenda">
+          <article class="card dashboard-deals">
+              <div class="card-head"><div><p class="eyebrow">Active deals</p><h2>지금 움직여야 할 딜</h2></div><button class="link-btn" data-route="deals">파이프라인 전체 보기 →</button></div>
+              <div class="card-body agenda-list">
                 <div class="agenda-item">
-                  <div class="agenda-time"><strong>10:30</strong><small>80분 후</small></div><i class="timeline-dot"></i>
-                  <div class="agenda-copy"><strong>한빛대학교병원 · 제품 도입 협의</strong><span>박서준 교수 · CardioView X7 · 본관 3층</span><div class="tag-row"><i class="tag-pill risk">구매팀 미접촉</i><i class="tag-pill">비교표 준비</i></div></div>
-                  <button class="btn btn-small btn-secondary" data-open="briefingDialog">브리핑</button>
+                  <div class="agenda-time"><strong>협상</strong><small>78.0M</small></div><i class="timeline-dot"></i>
+                  <div class="agenda-copy"><strong>그린모빌리티 · 운영 데이터 플랫폼</strong><span>가격 조정안 회신이 오늘 마감입니다.</span><div class="tag-row"><i class="tag-pill risk">결정 지연 6일</i><i class="tag-pill">확률 72%</i></div></div>
+                  <button class="btn btn-small btn-secondary" data-route="deals">보기</button>
                 </div>
                 <div class="agenda-item">
-                  <div class="agenda-time"><strong>14:00</strong><small>서림구</small></div><i class="timeline-dot"></i>
-                  <div class="agenda-copy"><strong>서림메디컬센터 · 사용 교육</strong><span>윤가영 간호팀장 · SonoFlex Pro · 교육실</span><div class="tag-row"><i class="tag-pill good">자료 준비 완료</i></div></div>
-                  <button class="btn btn-small btn-secondary" data-open="meetingDialog">기록</button>
+                  <div class="agenda-time"><strong>제안</strong><small>63.0M</small></div><i class="timeline-dot"></i>
+                  <div class="agenda-copy"><strong>파인웍스 · 영업 자동화 구축</strong><span>구매 담당자가 비교 견적을 요청했습니다.</span><div class="tag-row"><i class="tag-pill">8월 12일 예정</i></div></div>
+                  <button class="btn btn-small btn-secondary" data-route="deals">보기</button>
                 </div>
-                <div class="agenda-item alert">
-                  <div class="agenda-time"><strong>지연</strong><small>2일</small></div><i class="timeline-dot"></i>
-                  <div class="agenda-copy"><strong>새봄정형외과 · 후속 방문 미등록</strong><span>견적 검토 회신 예정일이 지났지만 일정이 없습니다.</span><div class="tag-row"><i class="tag-pill risk">일정 누락</i></div></div>
-                  <button class="btn btn-small btn-primary" data-open="scheduleDialog">등록</button>
+                <div class="agenda-item">
+                  <div class="agenda-time"><strong>검증</strong><small>45.0M</small></div><i class="timeline-dot"></i>
+                  <div class="agenda-copy"><strong>모노랩스 · 협업 시스템 전환</strong><span>보안 요구사항 확인이 아직 완료되지 않았습니다.</span><div class="tag-row"><i class="tag-pill risk">후속 3일</i></div></div>
+                  <button class="btn btn-small btn-secondary" data-route="deals">보기</button>
                 </div>
               </div>
-            </article>
-
-            <article class="card">
-              <div class="card-head"><div><p class="eyebrow">Relevant signal</p><h2>오늘 알아야 할 뉴스</h2></div><button class="link-btn" data-route="news">전체 뉴스 →</button></div>
-              <div class="card-body">
-                <div class="news-mini-group">
-                  <p class="mini-group-label">뉴스</p>
-                  <div class="news-mini">
-                    <div class="news-mini-item"><div class="news-date">AUG 05</div><div><h4>한빛대학교병원, 심혈관 통합진료센터 확대 계획 발표</h4><p>CardioView X7 제안과 관련성이 높은 병원 공식 보도자료입니다.</p><span class="source">● 병원 공식 사이트 · 09:12 수집</span></div></div>
-                    <div class="news-mini-item"><div class="news-date">AUG 04</div><div><h4>의료기기 유지보수 계약 기준 개정 논의</h4><p>오늘 협의 예정인 유지보수 조건에 참고할 수 있습니다.</p><span class="source">● 의료기기산업협회 · 원문 확인</span></div></div>
-                  </div>
-                </div>
-                <div class="news-mini-group">
-                  <p class="mini-group-label">동정</p>
-                  <div class="news-mini">
-                    <div class="news-mini-item"><div class="news-date">AUG 03</div><div><h4>서림메디컬센터 윤가영 간호팀장, 신규 교육위원 선임</h4><p>오후 사용 교육 일정의 참석 범위를 확인하세요.</p><span class="source">● 병원 공지 · 14:10 수집</span></div></div>
-                  </div>
-                </div>
-              </div>
-            </article>
-          </div>
+          </article>
         </section>
 
-        <section class="page" data-page="news">
-          <div class="page-header"><div><p class="eyebrow">Latest news & updates</p><h1>최신 뉴스와 동정</h1><p>지정된 출처에서 업계·병원 뉴스와 인사 동정을 확인합니다.</p></div><div class="page-actions"><button class="btn btn-outline" id="refreshNews">↻ 최신뉴스 갱신</button></div></div>
-          <div class="source-banner"><strong>팀에서 지정할 출처의 최신 정보를 확인하는 화면입니다.</strong><p>각 항목에는 출처, 게시일, 수집시각을 함께 표시합니다. 최종 갱신 10:24</p></div>
-          <div class="toolbar">
-            <div class="search-box"><input class="input" id="newsSearch" placeholder="병원, 고객, 키워드 검색"></div>
-            <button class="chip active" data-news-filter="all">전체</button><button class="chip" data-news-filter="industry">업계</button><button class="chip" data-news-filter="hospital">병원</button><button class="chip" data-news-filter="people">인사·동정</button>
+        <section class="page" data-page="deals">
+          <div class="page-header">
+            <div><p class="eyebrow">Sales pipeline</p><h1>딜 파이프라인</h1><p>영업기회를 단계별로 확인하고 다음 행동과 마감 위험을 관리합니다.</p></div>
+            <div class="page-actions"><button class="btn btn-primary" type="button" id="newDealButton">＋ 새 딜 등록</button></div>
           </div>
-          <section class="news-section" id="newsSectionNews">
-            <div class="section-divider"><div><h2>뉴스</h2><p>업계 동향과 병원 발표 자료</p></div><span class="tag-pill" id="newsCountNews">0건</span></div>
-            <div class="news-grid">
-            <article class="card news-card" data-category="hospital" data-search="한빛대학교병원 심혈관 통합진료센터"><div class="news-card-top"><span class="category">병원</span><time>2026.08.05</time></div><h3>한빛대학교병원, 심혈관 통합진료센터 확대 계획 발표</h3><p>심혈관 검사 장비와 진료 인프라 확대가 포함된 계획입니다.</p><div class="news-card-footer"><span class="source">● 공식 뉴스룸 · 09:12 수집</span></div></article>
-            <article class="card news-card" data-category="industry" data-search="의료기기 유지보수 계약 기준"><div class="news-card-top"><span class="category">업계</span><time>2026.08.04</time></div><h3>의료기기 유지보수 계약 기준 개정 논의</h3><p>정기점검 범위와 비용 산정 기준이 주요 안건입니다.</p><div class="news-card-footer"><span class="source">● 산업협회 · 17:40 수집</span></div></article>
-            <article class="card news-card" data-category="hospital" data-search="서림메디컬센터 간호교육 프로그램"><div class="news-card-top"><span class="category">병원</span><time>2026.08.03</time></div><h3>서림메디컬센터, 임상 인력 대상 간호교육 프로그램 개편</h3><p>신규 장비 사용 교육과 연계 가능한 프로그램입니다.</p><div class="news-card-footer"><span class="source">● 병원 뉴스룸 · 08:20 수집</span></div></article>
-            <article class="card news-card" data-category="industry" data-search="중소 의료기기 디지털 영업 전환"><div class="news-card-top"><span class="category">업계</span><time>2026.08.02</time></div><h3>중소 의료기기 기업의 디지털 영업 전환 지원사업 공고</h3><p>영업 데이터 관리와 현장 업무 자동화 항목이 포함됐습니다.</p><div class="news-card-footer"><span class="source">● 공공기관 · 11:35 수집</span></div></article>
-            </div>
-            <p class="news-empty" id="newsEmptyNews" hidden>조건에 맞는 뉴스가 없습니다.</p>
-          </section>
 
-          <section class="news-section" id="newsSectionPeople">
-            <div class="section-divider"><div><h2>인사·동정</h2><p>공개된 인사 이동과 담당자 활동</p></div><span class="tag-pill" id="newsCountPeople">0건</span></div>
-            <div class="news-grid">
-            <article class="card news-card" data-category="people" data-search="윤가영 서림메디컬센터 간호팀장 교육"><div class="news-card-top"><span class="category">인사·동정</span><time>2026.08.03</time></div><h3>서림메디컬센터 윤가영 간호팀장, 신규 교육위원 선임</h3><p>병원 공지에 게시된 공개 인사 동정입니다.</p><div class="news-card-footer"><span class="source">● 병원 공지 · 14:10 수집</span></div></article>
-            <article class="card news-card" data-category="people" data-search="병원 구매 담당자 세미나"><div class="news-card-top"><span class="category">인사·동정</span><time>2026.08.01</time></div><h3>병원 구매 실무자 대상 의료기기 조달 세미나 개최</h3><p>예산 집행과 공급사 평가 기준이 다뤄질 예정입니다.</p><div class="news-card-footer"><span class="source">● 행사 주최기관 · 16:05 수집</span></div></article>
-            </div>
-            <p class="news-empty" id="newsEmptyPeople" hidden>조건에 맞는 동정이 없습니다.</p>
-          </section>
+          <div class="deal-summary">
+            <div class="metric"><div class="metric-top"><span>진행 중 파이프라인</span></div><strong id="dealMetricOpen">₩0M</strong><small>성사·실패 제외</small></div>
+            <div class="metric"><div class="metric-top"><span>가중 예상 매출</span></div><strong id="dealMetricWeighted">₩0M</strong><small>단계별 성공 확률 반영</small></div>
+            <div class="metric"><div class="metric-top"><span>8월 마감 예정</span></div><strong id="dealMetricMonth">₩0M</strong><small>이번 달 클로징 대상</small></div>
+            <div class="metric"><div class="metric-top"><span>위험 딜</span></div><strong id="dealMetricRisk">0건</strong><small>지연·후속 조치 필요</small></div>
+          </div>
+
+          <div class="toolbar">
+            <div class="search-box"><input class="input" id="dealSearch" placeholder="회사, 딜, 담당자 검색"></div>
+            <button class="chip active" type="button" data-deal-filter="all">전체</button>
+            <button class="chip" type="button" data-deal-filter="open">진행 중</button>
+            <button class="chip" type="button" data-deal-filter="won">성사</button>
+            <button class="chip" type="button" data-deal-filter="lost">실패</button>
+            <button class="chip" type="button" data-deal-filter="mine">내 딜</button>
+            <button class="chip" type="button" data-deal-filter="risk">위험 딜</button>
+            <button class="chip" type="button" data-deal-filter="month">8월 마감</button>
+            <select class="input" id="dealSort" aria-label="딜 정렬" style="max-width:145px"><option value="close">마감일 빠른순</option><option value="value">금액 높은순</option></select>
+          </div>
+
+          <div class="deal-pipeline" id="dealPipeline">
+            <section class="deal-column" data-deal-column="lead">
+              <div class="deal-column-head"><strong>첫 미팅 준비</strong><span data-deal-count>0건</span></div><div class="deal-column-value" data-deal-value>₩0M</div>
+              <div class="deal-stack" data-deal-stack>
+                <article class="deal-card" data-deal-card data-stage="lead" data-value="32000000" data-probability="10" data-risk="false" data-owner="이수민" data-close="2026-09-18" data-search="에버라인 물류 배차 최적화 이수민">
+                  <p class="deal-company">에버라인 물류</p><h3>배차 운영 최적화</h3><div class="deal-card-meta"><span class="deal-value">₩32.0M</span><span class="deal-probability">10%</span></div><p class="deal-next">다음: 운영 담당자 요구사항 확인</p><div class="deal-owner"><i>이</i>이수민 · 9월 18일</div><div class="deal-card-actions"><button class="deal-move" type="button" data-deal-move="-1" disabled>← 이전</button><button class="deal-move" type="button" data-deal-move="1">다음 →</button></div>
+                </article>
+                <article class="deal-card" data-deal-card data-stage="lead" data-value="28000000" data-probability="10" data-risk="true" data-owner="김지훈" data-close="2026-08-28" data-search="다온리테일 매장 영업관리 김지훈">
+                  <p class="deal-company">다온리테일</p><h3>매장 영업관리 전환</h3><div class="deal-card-meta"><span class="deal-value">₩28.0M</span><span class="deal-probability">10%</span></div><p class="deal-next">다음: 첫 미팅 일정 확정</p><div class="deal-owner"><i>김</i>김지훈 · 8월 28일</div><div class="deal-card-actions"><button class="deal-move" type="button" data-deal-move="-1" disabled>← 이전</button><button class="deal-move" type="button" data-deal-move="1">다음 →</button></div>
+                </article>
+              </div><p class="deal-empty">표시할 딜이 없습니다.</p>
+            </section>
+
+            <section class="deal-column" data-deal-column="discovery">
+              <div class="deal-column-head"><strong>고객 니즈 파악</strong><span data-deal-count>0건</span></div><div class="deal-column-value" data-deal-value>₩0M</div>
+              <div class="deal-stack" data-deal-stack>
+                <article class="deal-card" data-deal-card data-stage="discovery" data-value="45000000" data-probability="30" data-risk="true" data-owner="김지훈" data-close="2026-08-22" data-search="모노랩스 협업 시스템 전환 김지훈">
+                  <p class="deal-company">모노랩스</p><h3>협업 시스템 전환</h3><div class="deal-card-meta"><span class="deal-value">₩45.0M</span><span class="deal-probability">30%</span></div><p class="deal-next">다음: 보안 요구사항 회신</p><div class="deal-owner"><i>김</i>김지훈 · 8월 22일</div><div class="deal-card-actions"><button class="deal-move" type="button" data-deal-move="-1">← 이전</button><button class="deal-move" type="button" data-deal-move="1">다음 →</button></div>
+                </article>
+              </div><p class="deal-empty">표시할 딜이 없습니다.</p>
+            </section>
+
+            <section class="deal-column" data-deal-column="proposal">
+              <div class="deal-column-head"><strong>솔루션 제안</strong><span data-deal-count>0건</span></div><div class="deal-column-value" data-deal-value>₩0M</div>
+              <div class="deal-stack" data-deal-stack>
+                <article class="deal-card" data-deal-card data-stage="proposal" data-value="63000000" data-probability="50" data-risk="false" data-owner="김지훈" data-close="2026-08-12" data-search="파인웍스 영업 자동화 구축 김지훈">
+                  <p class="deal-company">파인웍스</p><h3>영업 자동화 구축</h3><div class="deal-card-meta"><span class="deal-value">₩63.0M</span><span class="deal-probability">50%</span></div><p class="deal-next">다음: 비교 견적 및 도입 범위 전달</p><div class="deal-owner"><i>김</i>김지훈 · 8월 12일</div><div class="deal-card-actions"><button class="deal-move" type="button" data-deal-move="-1">← 이전</button><button class="deal-move" type="button" data-deal-move="1">다음 →</button></div>
+                </article>
+              </div><p class="deal-empty">표시할 딜이 없습니다.</p>
+            </section>
+
+            <section class="deal-column" data-deal-column="negotiation">
+              <div class="deal-column-head"><strong>최종 협상</strong><span data-deal-count>0건</span></div><div class="deal-column-value" data-deal-value>₩0M</div>
+              <div class="deal-stack" data-deal-stack>
+                <article class="deal-card" data-deal-card data-stage="negotiation" data-value="78000000" data-probability="72" data-risk="true" data-owner="김지훈" data-close="2026-08-08" data-search="그린모빌리티 운영 데이터 플랫폼 김지훈">
+                  <p class="deal-company">그린모빌리티</p><h3>운영 데이터 플랫폼</h3><div class="deal-card-meta"><span class="deal-value">₩78.0M</span><span class="deal-probability">72%</span></div><p class="deal-next">다음: 가격 조정안 최종 회신</p><div class="deal-owner"><i>김</i>김지훈 · 8월 8일</div><div class="deal-card-actions"><button class="deal-move" type="button" data-deal-move="-1">← 이전</button><button class="deal-move" type="button" data-deal-move="1">다음 →</button></div>
+                </article>
+              </div><p class="deal-empty">표시할 딜이 없습니다.</p>
+            </section>
+
+            <section class="deal-column" data-deal-column="approval">
+              <div class="deal-column-head"><strong>계약 승인</strong><span data-deal-count>0건</span></div><div class="deal-column-value" data-deal-value>₩0M</div>
+              <div class="deal-stack" data-deal-stack>
+                <article class="deal-card" data-deal-card data-stage="approval" data-value="52000000" data-probability="85" data-risk="false" data-owner="박도윤" data-close="2026-08-26" data-search="블루웨이브 고객 데이터 통합 박도윤">
+                  <p class="deal-company">블루웨이브</p><h3>고객 데이터 통합</h3><div class="deal-card-meta"><span class="deal-value">₩52.0M</span><span class="deal-probability">85%</span></div><p class="deal-next">다음: 계약서 법무 검토</p><div class="deal-owner"><i>박</i>박도윤 · 8월 26일</div><div class="deal-card-actions"><button class="deal-move" type="button" data-deal-move="-1">← 이전</button><button class="deal-move" type="button" data-deal-move="1">다음 →</button></div>
+                </article>
+              </div><p class="deal-empty">표시할 딜이 없습니다.</p>
+            </section>
+
+            <section class="deal-column" data-deal-column="won">
+              <div class="deal-column-head"><strong>성사</strong><span data-deal-count>0건</span></div><div class="deal-column-value" data-deal-value>₩0M</div>
+              <div class="deal-stack" data-deal-stack>
+                <article class="deal-card" data-deal-card data-stage="won" data-value="36000000" data-probability="100" data-risk="false" data-owner="최가은" data-close="2026-08-04" data-search="오렌지팩토리 리테일 분석 도입 최가은">
+                  <p class="deal-company">오렌지팩토리</p><h3>리테일 분석 도입</h3><div class="deal-card-meta"><span class="deal-value">₩36.0M</span><span class="deal-probability">100%</span></div><p class="deal-next">다음: 온보딩 일정 확정</p><div class="deal-owner"><i>최</i>최가은 · 8월 4일</div><div class="deal-card-actions"><button class="deal-move" type="button" data-deal-move="-1">← 이전</button><button class="deal-move" type="button" data-deal-move="1" disabled>다음 →</button></div>
+                </article>
+              </div><p class="deal-empty">표시할 딜이 없습니다.</p>
+            </section>
+
+            <section class="deal-column" data-deal-column="lost">
+              <div class="deal-column-head"><strong>실패</strong><span data-deal-count>0건</span></div><div class="deal-column-value" data-deal-value>₩0M</div>
+              <div class="deal-stack" data-deal-stack>
+                <article class="deal-card" data-deal-card data-stage="lost" data-value="24000000" data-probability="0" data-risk="false" data-owner="이수민" data-close="2026-08-01" data-search="네오커머스 고객 상담 자동화 이수민">
+                  <p class="deal-company">네오커머스</p><h3>고객 상담 자동화</h3><div class="deal-card-meta"><span class="deal-value">₩24.0M</span><span class="deal-probability">실패</span></div><p class="deal-next">사유: 도입 예산 보류</p><div class="deal-owner"><i>이</i>이수민 · 8월 1일</div>
+                </article>
+              </div><p class="deal-empty">표시할 딜이 없습니다.</p>
+            </section>
+          </div>
         </section>
 
         <section class="page" data-page="daily">
           <div class="page-header"><div><p class="eyebrow" id="reportTabEyebrow">Daily report</p><h1 id="reportTabTitle">일일업무 분석</h1><p id="reportTabDesc">당일 확정된 미팅보고서와 일정을 모아 일일보고서 초안을 구성합니다. 제출 전까지 수정할 수 있습니다.</p></div><div class="page-actions" id="dailyPanelActions"><button class="btn btn-outline" id="dailyReload">↻ 초안 다시 불러오기</button><button class="btn btn-primary" id="dailySubmit">보고서 제출</button></div></div>
 
-          <div class="toolbar report-tabs" role="tablist" aria-label="업무보고 기간 선택">
-            <button class="chip active" data-report-tab="daily" role="tab" aria-selected="true">일간</button>
-            <button class="chip" data-report-tab="weekly" role="tab" aria-selected="false">주간업무 분석</button>
-            <button class="chip" data-report-tab="monthly" role="tab" aria-selected="false">월간업무 분석</button>
+          <div class="section-tabs report-tabs" role="tablist" aria-label="업무보고 기간 선택">
+            <button class="section-tab active" data-report-tab="daily" role="tab" aria-selected="true">일간업무 분석</button>
+            <button class="section-tab" data-report-tab="weekly" role="tab" aria-selected="false">주간업무 분석</button>
+            <button class="section-tab" data-report-tab="monthly" role="tab" aria-selected="false">월간업무 분석</button>
           </div>
 
           <div class="report-panel" id="dailyReportPanel">
@@ -1378,7 +1568,7 @@
           <div class="report-panel" id="weeklyReportPanel" hidden>
             <div class="daily-strip">
               <div class="metric"><p class="eyebrow">대상 주차</p><strong>8월 1주차</strong><span>8.3 ~ 8.7</span></div>
-              <div class="metric"><p class="eyebrow">이번 주 방문</p><strong>9건</strong><span>병원 6곳</span></div>
+              <div class="metric"><p class="eyebrow">이번 주 방문</p><strong>9건</strong><span>회사 6곳</span></div>
               <div class="metric"><p class="eyebrow">확정 매출</p><strong>₩18.2M</strong><span>주간 신규 계약 1건 포함</span></div>
               <div class="metric"><p class="eyebrow">일일보고 제출</p><strong id="weeklySubmitCount">3 / 5일</strong><span>미제출 2일</span></div>
             </div>
@@ -1411,7 +1601,7 @@
             <div class="daily-strip">
               <div class="metric"><p class="eyebrow">대상 월</p><strong>2026년 8월</strong><span>1~4주차 누계</span></div>
               <div class="metric"><p class="eyebrow">확정 매출</p><strong>₩52.4M</strong><span>월 목표 ₩80M · 65.5%</span></div>
-              <div class="metric"><p class="eyebrow">방문 병원</p><strong>11곳</strong><span>신규 2곳 포함</span></div>
+              <div class="metric"><p class="eyebrow">방문 회사</p><strong>11곳</strong><span>신규 2곳 포함</span></div>
               <div class="metric"><p class="eyebrow">신규 계약</p><strong>2건</strong><span>발주 진행 중 3건</span></div>
             </div>
             <div class="daily-layout">
@@ -1440,20 +1630,25 @@
 
         <section class="page" data-page="reports">
           <div class="page-header"><div><p class="eyebrow">Document operations</p><h1>리포트 라이브러리</h1><p>확정된 영업 기록을 정해진 양식의 보고서·견적서·계약서로 관리합니다.</p></div></div>
-          <div class="toolbar"><div class="search-box"><input class="input" id="docSearch" placeholder="문서명, 병원, 고객 검색"></div><button class="chip active" data-doc-filter="all">전체</button><button class="chip" data-doc-filter="report">보고서</button><button class="chip" data-doc-filter="quote">견적서</button><button class="chip" data-doc-filter="contract">계약서</button></div>
+          <div class="toolbar"><div class="search-box"><input class="input" id="docSearch" placeholder="문서명, 회사, 고객 검색"></div><button class="chip active" data-doc-filter="all">전체</button><button class="chip" data-doc-filter="report">보고서</button><button class="chip" data-doc-filter="quote">견적서</button><button class="chip" data-doc-filter="contract">계약서</button></div>
           <article class="card document-list" id="documentList">
-            <div class="doc-row header"><span>유형</span><span>문서</span><span>병원·고객</span><span>작성일</span><span>상태</span><span></span></div>
-            <div class="doc-row" data-doc-type="report" data-search="한빛대학교병원 박서준 주간보고"><span class="doc-type">WK</span><span class="doc-title"><strong>8월 1주차 주간업무 분석</strong><span>확정 일일보고서 5건 통합</span></span><span>영업 1팀</span><span>2026.08.05</span><span class="status draft">검토 대기</span><button class="btn btn-small btn-secondary preview-doc">열기</button></div>
-            <div class="doc-row" data-doc-type="quote" data-search="한빛대학교병원 CardioView 견적서"><span class="doc-type">QT</span><span class="doc-title"><strong>CardioView X7 제품 견적서</strong><span>FM-QT-2026-0812</span></span><span>한빛대학교병원</span><span>2026.08.04</span><span class="status">확정</span><button class="btn btn-small btn-secondary preview-doc">원본·PDF</button></div>
-            <div class="doc-row" data-doc-type="contract" data-search="새봄정형외과 SonoFlex 계약서"><span class="doc-type">CT</span><span class="doc-title"><strong>SonoFlex Pro 공급계약서</strong><span>FM-CT-2026-0038</span></span><span>새봄정형외과</span><span>2026.08.03</span><span class="status signing">전자서명 중</span><button class="btn btn-small btn-secondary preview-doc">상태</button></div>
-            <div class="doc-row" data-doc-type="report" data-search="서림메디컬센터 윤가영 미팅보고서"><span class="doc-type">MT</span><span class="doc-title"><strong>서림메디컬센터 미팅보고서</strong><span>14:00 사용 교육 협의</span></span><span>윤가영 간호팀장</span><span>2026.08.03</span><span class="status">확정</span><button class="btn btn-small btn-secondary preview-doc">열기</button></div>
+            <div class="doc-row header"><span>유형</span><span>문서</span><span>회사·고객</span><span>작성일</span><span>상태</span><span></span></div>
+            <div class="doc-row" data-doc-type="report" data-search="한빛테크 박서준 주간보고"><span class="doc-type">WK</span><span class="doc-title"><strong>8월 1주차 주간업무 분석</strong><span>확정 일일보고서 5건 통합</span></span><span>영업 1팀</span><span>2026.08.05</span><span class="status draft">검토 대기</span><button class="btn btn-small btn-secondary preview-doc">열기</button></div>
+            <div class="doc-row" data-doc-type="quote" data-search="한빛테크 SalesFlow 견적서"><span class="doc-type">QT</span><span class="doc-title"><strong>SalesFlow Enterprise 제품 견적서</strong><span>SL-QT-2026-0812</span></span><span>한빛테크</span><span>2026.08.04</span><span class="status">확정</span><button class="btn btn-small btn-secondary preview-doc">원본·PDF</button></div>
+            <div class="doc-row" data-doc-type="contract" data-search="새봄솔루션 WorkSync 계약서"><span class="doc-type">CT</span><span class="doc-title"><strong>WorkSync Pro 공급계약서</strong><span>SL-CT-2026-0038</span></span><span>새봄솔루션</span><span>2026.08.03</span><span class="status signing">전자서명 중</span><button class="btn btn-small btn-secondary preview-doc">상태</button></div>
+            <div class="doc-row" data-doc-type="report" data-search="서림커머스 윤가영 미팅보고서"><span class="doc-type">MT</span><span class="doc-title"><strong>서림커머스 미팅보고서</strong><span>14:00 사용 교육 협의</span></span><span>윤가영 운영팀장</span><span>2026.08.03</span><span class="status">확정</span><button class="btn btn-small btn-secondary preview-doc">열기</button></div>
             <div class="doc-row" data-doc-type="report" data-search="8월 4일 일일보고서"><span class="doc-type">DY</span><span class="doc-title"><strong>2026년 8월 4일 일일보고서</strong><span>확정 미팅보고서 3건 통합</span></span><span>김지훈</span><span>2026.08.04</span><span class="status">확정</span><button class="btn btn-small btn-secondary preview-doc">열기</button></div>
           </article>
         </section>
 
         <section class="page" data-page="customers">
-          <div class="page-header"><div><p class="eyebrow">Account history</p><h1>담당 병원과 고객</h1><p>담당 병원과 고객의 기본 정보, 최근 만남, 미팅 기록을 관리합니다.</p></div><div class="page-actions"><button class="btn btn-outline" data-open="customerDialog">＋ 고객명함 등록</button><button class="btn btn-primary" data-open="hospitalDialog">＋ 담당병원 등록</button></div></div>
-          <div class="toolbar"><div class="search-box"><input class="input" id="customerSearch" placeholder="고객, 병원, 직책 검색"></div><button class="chip active" data-account-tab="contacts">담당 고객 5</button><button class="chip" data-account-tab="hospitals">담당 병원 4</button><button class="chip" id="overdueFilter">후속 지연 3</button></div>
+          <div class="page-header"><div><p class="eyebrow">Account history</p><h1>담당 회사와 고객</h1><p>담당 회사와 고객의 기본 정보, 최근 만남, 미팅 기록을 관리합니다.</p></div><div class="page-actions"><button class="btn btn-outline" data-open="customerDialog">＋ 고객명함 등록</button><button class="btn btn-primary" data-open="hospitalDialog">＋ 담당 회사 등록</button></div></div>
+          <div class="section-tabs account-tabs" aria-label="고객·회사 보기 전환">
+            <button class="section-tab account-tab active" data-account-tab="contacts" aria-pressed="true"><span>담당 고객</span><strong data-account-count="contacts">5</strong></button>
+            <button class="section-tab account-tab" data-account-tab="hospitals" aria-pressed="false"><span>담당 회사</span><strong data-account-count="hospitals">4</strong></button>
+            <button class="section-tab account-tab" id="overdueFilter" aria-pressed="false"><span>후속 지연</span><strong data-overdue-count>3</strong></button>
+          </div>
+          <div class="customer-toolbar"><div class="search-box"><input class="input" id="customerSearch" placeholder="고객, 회사, 직책 검색"></div></div>
           <div class="account-panel active" data-account-panel="contacts">
             <div class="customer-layout">
               <article class="card customer-list" id="customerList"></article>
@@ -1469,7 +1664,7 @@
         </section>
 
         <section class="page" data-page="calendar">
-          <div class="page-header"><div><p class="eyebrow">Visit calendar</p><h1>캘린더</h1><p>병원 방문 일정을 등록하고 미완료 후속 업무에서 다음 일정을 추천받습니다.</p></div><div class="page-actions"><button class="btn btn-outline" data-open="leaveDialog">＋ 연차일정 추가</button><button class="btn btn-primary" data-open="scheduleDialog">＋ 방문일정 추가</button></div></div>
+          <div class="page-header"><div><p class="eyebrow">Visit calendar</p><h1>캘린더</h1><p>회사 방문 일정을 등록하고 미완료 후속 업무에서 다음 일정을 추천받습니다.</p></div><div class="page-actions"><button class="btn btn-outline" data-open="leaveDialog">＋ 연차일정 추가</button><button class="btn btn-primary" data-open="scheduleDialog">＋ 방문일정 추가</button></div></div>
           <div class="calendar-layout">
             <article class="card calendar-card">
               <div class="calendar-header"><h2>2026. 08</h2></div>
@@ -1478,9 +1673,9 @@
             <aside class="card">
               <div class="card-head"><div><p class="eyebrow">Follow-up reminder</p><h2>추천 일정</h2></div><span class="tag-pill risk">3건</span></div>
               <div class="card-body recommend-list" id="recommendList">
-                <div class="recommend-item"><div class="rec-top"><strong>새봄정형외과 후속 방문</strong><span class="tag-pill risk">2일 지연</span></div><p>지난 견적 검토 회신 예정일이 지났지만 등록된 일정이 없습니다.</p><div class="rec-reason">추천: 8월 7일 오후 · 오정민 원장</div><div class="rec-actions"><button class="btn btn-small btn-primary approve-rec">일정으로 등록</button><button class="btn btn-small btn-secondary hold-rec">보류</button></div></div>
-                <div class="recommend-item"><div class="rec-top"><strong>한빛대학교병원 구매팀</strong><span class="tag-pill">후속 5일</span></div><p>제품 테스트 후 구매 절차 확인을 위한 미팅이 필요합니다.</p><div class="rec-reason">추천: 8월 12일 오전 · 이민호 구매팀</div><div class="rec-actions"><button class="btn btn-small btn-primary approve-rec">일정으로 등록</button><button class="btn btn-small btn-secondary hold-rec">보류</button></div></div>
-                <div class="recommend-item"><div class="rec-top"><strong>서림메디컬센터 교육 점검</strong><span class="tag-pill good">권장</span></div><p>사용 교육 1주 후 현장 적용 상태를 확인하는 일정입니다.</p><div class="rec-reason">추천: 8월 14일 오후 · 윤가영 간호팀장</div><div class="rec-actions"><button class="btn btn-small btn-primary approve-rec">일정으로 등록</button><button class="btn btn-small btn-secondary hold-rec">보류</button></div></div>
+                <div class="recommend-item"><div class="rec-top"><strong>새봄솔루션 후속 방문</strong><span class="tag-pill risk">2일 지연</span></div><p>지난 견적 검토 회신 예정일이 지났지만 등록된 일정이 없습니다.</p><div class="rec-reason">추천: 8월 7일 오후 · 오정민 대표</div><div class="rec-actions"><button class="btn btn-small btn-primary approve-rec">일정으로 등록</button><button class="btn btn-small btn-secondary hold-rec">보류</button></div></div>
+                <div class="recommend-item"><div class="rec-top"><strong>한빛테크 구매팀</strong><span class="tag-pill">후속 5일</span></div><p>제품 테스트 후 구매 절차 확인을 위한 미팅이 필요합니다.</p><div class="rec-reason">추천: 8월 12일 오전 · 이민호 구매팀</div><div class="rec-actions"><button class="btn btn-small btn-primary approve-rec">일정으로 등록</button><button class="btn btn-small btn-secondary hold-rec">보류</button></div></div>
+                <div class="recommend-item"><div class="rec-top"><strong>서림커머스 교육 점검</strong><span class="tag-pill good">권장</span></div><p>사용 교육 1주 후 현장 적용 상태를 확인하는 일정입니다.</p><div class="rec-reason">추천: 8월 14일 오후 · 윤가영 운영팀장</div><div class="rec-actions"><button class="btn btn-small btn-primary approve-rec">일정으로 등록</button><button class="btn btn-small btn-secondary hold-rec">보류</button></div></div>
               </div>
             </aside>
           </div>
@@ -1500,7 +1695,7 @@
           <div class="po-alert" id="poAlert" hidden></div>
 
           <div class="toolbar">
-            <div class="search-box"><input class="input" id="poSearch" placeholder="발주번호, 병원, 제품, 공급처 검색"></div>
+            <div class="search-box"><input class="input" id="poSearch" placeholder="발주번호, 회사, 제품, 공급처 검색"></div>
             <button class="chip active" data-po-filter="all">전체</button>
             <button class="chip" data-po-filter="승인대기">승인 대기</button>
             <button class="chip" data-po-filter="출고의뢰서 작성완료">출고의뢰서 작성완료</button>
@@ -1511,7 +1706,7 @@
           </div>
 
           <article class="card document-list" id="poList">
-            <div class="doc-row po-row header"><span>구분</span><span>발주</span><span>병원·계약</span><span>수량·금액</span><span>납기</span><span>상태</span><span></span></div>
+            <div class="doc-row po-row header"><span>구분</span><span>발주</span><span>회사·계약</span><span>수량·금액</span><span>납기</span><span>상태</span><span></span></div>
             <div id="poRows"></div>
           </article>
           <p class="po-empty" id="poEmpty" hidden>조건에 맞는 발주 건이 없습니다.</p>
@@ -1519,7 +1714,7 @@
         </section>
 
         <section class="page" data-page="complaints">
-          <div class="page-header"><div><p class="eyebrow">Customer service</p><h1>고객불만 관리</h1><p>병원·고객으로부터 접수된 불만·문의를 확인하고 처리 상태를 관리합니다.</p></div><div class="page-actions"><button class="btn btn-primary" data-open="complaintDialog">＋ 접수 등록</button></div></div>
+          <div class="page-header"><div><p class="eyebrow">Customer service</p><h1>고객불만 관리</h1><p>회사·고객으로부터 접수된 불만·문의를 확인하고 처리 상태를 관리합니다.</p></div><div class="page-actions"><button class="btn btn-primary" data-open="complaintDialog">＋ 접수 등록</button></div></div>
 
           <div class="po-strip">
             <div class="metric"><p class="eyebrow">고객불만 접수</p><strong id="csCountTotal">0</strong><span>전체 누적 건수</span></div>
@@ -1532,7 +1727,7 @@
           <div class="po-alert" id="csAlert" hidden></div>
 
           <div class="toolbar">
-            <div class="search-box"><input class="input" id="csSearch" placeholder="병원, 고객, 제목 검색"></div>
+            <div class="search-box"><input class="input" id="csSearch" placeholder="회사, 고객, 제목 검색"></div>
             <button class="chip active" data-cs-filter="all">전체</button>
             <button class="chip" data-cs-filter="미응답">미응답</button>
             <button class="chip" data-cs-filter="처리중">처리중</button>
@@ -1541,7 +1736,7 @@
           </div>
 
           <article class="card document-list" id="csList">
-            <div class="doc-row cs-row header"><span>구분</span><span>제목</span><span>병원·고객</span><span>접수</span><span>담당자</span><span>상태</span><span></span></div>
+            <div class="doc-row cs-row header"><span>구분</span><span>제목</span><span>회사·고객</span><span>접수</span><span>담당자</span><span>상태</span><span></span></div>
             <div id="csRows"></div>
           </article>
           <p class="po-empty" id="csEmpty" hidden>조건에 맞는 접수 건이 없습니다.</p>
@@ -1549,6 +1744,9 @@
 
         <section class="page" data-page="documents">
           <div class="page-header"><div><p class="eyebrow">Shared document library</p><h1>문서 라이브러리</h1><p>영업팀이 공통으로 쓰는 자료를 올려두고 내려받거나 공유합니다. 고객별 보고서·견적서는 리포트 라이브러리에서 관리합니다.</p></div><div class="page-actions"><button class="btn btn-outline" data-open="quoteDialog">＋ 견적서 작성</button><button class="btn btn-outline" data-open="contractDialog">＋ 계약서 작성</button><button class="btn btn-primary" id="libRequest">자료 요청</button></div></div>
+          <div class="section-tabs" role="tablist" aria-label="문서 라이브러리 구분"><button class="section-tab active" type="button" role="tab" aria-selected="true" data-library-tab="shared">공용 영업자료</button><button class="section-tab" type="button" role="tab" aria-selected="false" data-library-tab="misc">기타 문서</button></div>
+
+          <div id="sharedLibraryPanel">
 
           <div class="lib-stats">
             <div class="metric"><p class="eyebrow">등록 자료</p><strong id="libCountTotal">0</strong><span>공유 범위별 접근 권한 적용</span></div>
@@ -1576,53 +1774,55 @@
           </article>
           <p class="lib-empty" id="libEmpty" hidden>조건에 맞는 자료가 없습니다.</p>
           <p class="muted" style="margin-top:12px;font-size:9px">공유 링크는 사내 계정 로그인 후에만 열립니다. 만료일이 지난 링크는 자동으로 차단됩니다.</p>
-        </section>
+          </div>
 
-        <section class="page" data-page="publication">
-          <div class="page-header"><div><p class="eyebrow">Clinical &amp; research</p><h1>Publication</h1><p>영업 제안에 활용할 수 있는 논문·임상자료를 검색하고 다운로드합니다.</p></div></div>
+          <div id="miscLibraryPanel" hidden>
+          <div class="page-header" style="margin-top:22px"><div><p class="eyebrow">Miscellaneous documents</p><h1>기타 문서</h1><p>시장조사, 경쟁사 비교, 내부 교육, 정책 등 공용 영업 문서를 관리합니다.</p></div><div class="page-actions"><button class="btn btn-primary" type="button" data-open="pubUploadDialog">＋ 문서 등록</button></div></div>
 
           <div class="lib-stats">
-            <div class="metric"><p class="eyebrow">등록 논문</p><strong id="pubCountTotal">0</strong><span>전체 자료</span></div>
+            <div class="metric"><p class="eyebrow">등록 문서</p><strong id="pubCountTotal">0</strong><span>전체 자료</span></div>
             <div class="metric"><p class="eyebrow">이번 달 다운로드</p><strong id="pubCountDownload">0</strong><span>세션 내 집계</span></div>
-            <div class="metric"><p class="eyebrow">최근 3개월 등록</p><strong id="pubCountRecent">0</strong><span>신규 게재 자료</span></div>
-            <div class="metric"><p class="eyebrow">즐겨찾기</p><strong id="pubCountStar">0</strong><span>영업 자료로 자주 인용</span></div>
+            <div class="metric"><p class="eyebrow">최근 3개월 등록</p><strong id="pubCountRecent">0</strong><span>새로 공유된 자료</span></div>
+            <div class="metric"><p class="eyebrow">즐겨찾기</p><strong id="pubCountStar">0</strong><span>자주 보는 자료</span></div>
           </div>
 
           <div class="toolbar">
-            <div class="search-box"><input class="input" id="pubSearch" placeholder="논문명, 저자, 저널, 제품 검색"></div>
+            <div class="search-box"><input class="input" id="pubSearch" placeholder="문서명, 작성자, 출처, 구분 검색"></div>
             <button class="chip active" data-pub-filter="all">전체</button>
-            <button class="chip" data-pub-filter="CardioView X7">CardioView X7</button>
-            <button class="chip" data-pub-filter="SonoFlex Pro">SonoFlex Pro</button>
-            <button class="chip" data-pub-filter="OrthoScan Mini">OrthoScan Mini</button>
-            <button class="chip" data-pub-filter="공통">공통·정책</button>
+            <button class="chip" data-pub-filter="시장조사">시장조사</button>
+            <button class="chip" data-pub-filter="경쟁사 비교">경쟁사 비교</button>
+            <button class="chip" data-pub-filter="교육">교육</button>
+            <button class="chip" data-pub-filter="정책">정책</button>
             <button class="chip" data-pub-filter="star">즐겨찾기</button>
           </div>
 
           <article class="card document-list" id="publicationList">
-            <div class="doc-row lib-row header"><span>유형</span><span>논문</span><span>제품</span><span>저자·저널</span><span>발행일</span><span>인용</span><span>다운로드</span><span></span></div>
+            <div class="doc-row lib-row header"><span>유형</span><span>문서</span><span>구분</span><span>작성자·출처</span><span>등록일</span><span>즐겨찾기</span><span>다운로드</span><span></span></div>
             <div id="publicationRows"></div>
           </article>
-          <p class="lib-empty" id="pubEmpty" hidden>조건에 맞는 논문이 없습니다.</p>
-          <p class="muted" style="margin-top:12px;font-size:9px">외부 저널 원문은 저작권 정책에 따라 초록·서지정보만 제공되며, 원문 열람은 각 저널 사이트에서 확인해야 합니다.</p>
+          <p class="lib-empty" id="pubEmpty" hidden>조건에 맞는 문서가 없습니다.</p>
+          <p class="muted" style="margin-top:12px;font-size:9px">내부 공유 문서는 사용자 권한에 따라 열람·다운로드 범위가 달라질 수 있습니다.</p>
+          </div>
         </section>
 
         <section class="page" data-page="manager">
-          <div class="page-header"><div><p class="eyebrow">Team command center</p><h1>팀장 워크스페이스</h1><p>팀 실적을 확인하고 공통 미팅 목표·개인 매출 목표·당일 공지를 관리합니다.</p></div><div class="page-actions"><button class="btn btn-outline" data-open="salesUploadDialog">매출 자료 등록</button><button class="btn btn-primary" id="exportManager">매출 보고서</button></div></div>
-          <div class="manager-tabs" role="tablist" aria-label="팀장 관리 메뉴"><button class="manager-tab active" type="button" role="tab" aria-selected="true" data-manager-tab="overview">팀 현황</button><button class="manager-tab" type="button" role="tab" aria-selected="false" data-manager-tab="team">팀 관리</button><button class="manager-tab" type="button" role="tab" aria-selected="false" data-manager-tab="issues">팀원 이슈관리</button></div>
-          <div class="manager-panel active" data-manager-panel="overview">
-          <div class="manager-banner"><span class="lock">⌁</span><div><strong>팀장 전용 · 설정 및 조회</strong><br><span>확정된 영업 원본은 조회 전용이며, 팀 목표·월 매출 목표·공지는 팀장이 관리할 수 있습니다.</span></div></div>
+          <div class="page-header"><div><p class="eyebrow" id="managerTabEyebrow">Team reports</p><h1 id="managerTabTitle">팀 업무보고 현황</h1><p id="managerTabDesc">팀원별 업무보고 제출 여부와 핵심 활동, 미확정 기록을 한눈에 확인합니다.</p></div><div class="page-actions"><button class="btn btn-primary" id="exportTeamReports" data-manager-action="reports">업무보고 취합</button><button class="btn btn-outline" data-open="salesUploadDialog" data-manager-action="sales" hidden>매출 자료 등록</button><button class="btn btn-primary" id="exportManager" data-manager-action="sales" hidden>매출 보고서</button><button class="btn btn-primary" id="addTeamMember" data-manager-action="team" hidden>＋ 팀원 추가</button></div></div>
+          <div class="section-tabs" role="tablist" aria-label="팀장 관리 메뉴"><button class="section-tab active" type="button" role="tab" aria-selected="true" data-manager-tab="reports">업무보고 현황</button><button class="section-tab" type="button" role="tab" aria-selected="false" data-manager-tab="sales">매출·계약 현황</button><button class="section-tab" type="button" role="tab" aria-selected="false" data-manager-tab="team">팀 운영 관리</button></div>
+          <div class="manager-panel" data-manager-panel="sales">
+          <div class="manager-banner"><span class="lock">₩</span><div><strong>확정 매출과 계약 진행 상황을 함께 조회합니다.</strong><br><span>매출 원본은 사용자 확인 후 반영되며 계약 만료·갱신 일정까지 함께 집계합니다.</span></div></div>
           <div class="toolbar"><select class="input" id="managerPeriod" style="max-width:170px"><option>2026년 8월</option><option>2026년 3분기</option><option>2026년 누적</option></select><select class="input" id="managerMember" style="max-width:170px"><option>전체 팀원</option><option>김지훈</option><option>이수민</option><option>박도윤</option><option>최가은</option></select><span class="muted" id="managerFilterLabel" style="font-size:10px">2026년 8월 · 전체 팀원</span></div>
-          <div class="manager-kpis"><div class="card manager-kpi"><span>8월 확정 매출</span><strong>₩190.5M</strong><small>팀 목표 ₩300M 기준</small></div><div class="card manager-kpi"><span>팀 매출 목표 달성</span><strong>63.5%</strong><small>확정 매출만 집계</small></div><div class="card manager-kpi"><span>오늘 미팅</span><strong>8 / 10</strong><small>완료 / 예정</small></div><div class="card manager-kpi"><span>주시 필요 팀원</span><strong class="warning">2명</strong><small>목표 미달성 근거 확인 필요</small></div></div>
+          <div class="manager-kpis"><div class="card manager-kpi"><span>8월 확정 매출</span><strong>₩190.5M</strong><small>팀 목표 ₩300M 기준</small></div><div class="card manager-kpi"><span>월 계약 건수</span><strong>7건</strong><small>신규 5건 · 갱신 2건</small></div><div class="card manager-kpi"><span>진행 중 계약</span><strong>11건</strong><small>전자서명 대기 3건</small></div><div class="card manager-kpi"><span>갱신 임박</span><strong class="warning">2건</strong><small>30일 이내 만료</small></div></div>
           <div class="manager-grid">
             <article class="card"><div class="card-head"><div><p class="eyebrow">Revenue overview</p><h2>월별 확정 매출</h2></div><div class="legend"><span><i style="background:#163c34"></i>확정</span></div></div><div class="card-body revenue-chart"><svg viewBox="0 0 700 220" role="img" aria-label="월별 확정 매출 추이"><g stroke="#dce2db" stroke-width="1"><line x1="40" y1="20" x2="680" y2="20"/><line x1="40" y1="70" x2="680" y2="70"/><line x1="40" y1="120" x2="680" y2="120"/><line x1="40" y1="170" x2="680" y2="170"/></g><path d="M40,178 C100,166 130,159 180,153 S285,133 330,141 S440,97 490,106 S590,67 680,78 L680,190 L40,190 Z" fill="rgba(16,43,38,.08)"/><path d="M40,178 C100,166 130,159 180,153 S285,133 330,141 S440,97 490,106 S590,67 680,78" fill="none" stroke="#163c34" stroke-width="4"/><g fill="#163c34"><circle cx="40" cy="178" r="4"/><circle cx="180" cy="153" r="4"/><circle cx="330" cy="141" r="4"/><circle cx="490" cy="106" r="4"/><circle cx="680" cy="78" r="4"/></g><g fill="#75837f" font-size="10"><text x="32" y="212">APR</text><text x="172" y="212">MAY</text><text x="322" y="212">JUN</text><text x="482" y="212">JUL</text><text x="672" y="212">AUG</text></g></svg></div></article>
-            <article class="card"><div class="card-head"><div><p class="eyebrow">Issues to resolve</p><h2>주요 이슈</h2></div><span class="tag-pill risk">팀장 확인 필요</span></div><div class="card-body issue-list"><div class="issue"><div class="issue-top"><strong>김지훈 · 한빛대학교병원 목표 미완료</strong><span class="severity">확인</span></div><p>제품 테스트 미팅에서 구매 승인 담당자를 확인하지 못했습니다.</p><small>근거: 확정된 미팅보고서</small></div><div class="issue"><div class="issue-top"><strong>김지훈 · 새봄정형외과 일정 누락</strong><span class="severity">지연</span></div><p>견적 회신일이 2일 경과했으며 등록된 방문 일정이 없습니다.</p><small>근거: 후속 기한과 캘린더</small></div><div class="issue"><div class="issue-top"><strong>박도윤 · 구매 절차 목표 반복 미완료</strong><span class="severity">확인</span></div><p>최근 확정된 미팅 2건에서 같은 필수 목표가 미완료로 남았습니다.</p><small>근거: 미팅별 목표 결과</small></div></div></article>
+            <article class="card"><div class="card-head"><div><p class="eyebrow">Contract watchlist</p><h2>계약·갱신 현황</h2></div><span class="tag-pill risk">2건 확인 필요</span></div><div class="card-body issue-list"><div class="issue"><div class="issue-top"><strong>새봄솔루션 · WorkSync Pro</strong><span class="severity">D-18</span></div><p>갱신 협의 일정이 등록되지 않았습니다. 담당자 확인이 필요합니다.</p><small>연 계약 ₩36.3M · 담당 김지훈</small></div><div class="issue"><div class="issue-top"><strong>한빛테크 · SalesFlow Enterprise</strong><span class="status signing">전자서명 중</span></div><p>구매팀 최종 서명을 기다리고 있습니다.</p><small>계약 금액 ₩50.2M · 8월 12일 시작</small></div><div class="issue"><div class="issue-top"><strong>정우로지스 · InsightBoard</strong><span class="tag-pill good">정상</span></div><p>견적 승인 후 계약서 초안 작성 단계입니다.</p><small>예상 금액 ₩21.6M · 확률 72%</small></div></div></article>
           </div>
-          <div class="team-strip"><article class="card member-card"><div class="member-top"><span class="avatar">김</span><div><strong>김지훈</strong><span>동부 권역</span></div></div><div class="member-stats"><span>오늘 방문<strong>3</strong></span><span>월 목표<strong>65.5%</strong></span></div></article><article class="card member-card"><div class="member-top"><span class="avatar">이</span><div><strong>이수민</strong><span>서부 권역</span></div></div><div class="member-stats"><span>오늘 방문<strong>2</strong></span><span>월 목표<strong>61.0%</strong></span></div></article><article class="card member-card"><div class="member-top"><span class="avatar">박</span><div><strong>박도윤</strong><span>남부 권역</span></div></div><div class="member-stats"><span>오늘 방문<strong>4</strong></span><span>월 목표<strong>74.0%</strong></span></div></article><article class="card member-card"><div class="member-top"><span class="avatar">최</span><div><strong>최가은</strong><span>북부 권역</span></div></div><div class="member-stats"><span>오늘 방문<strong>1</strong></span><span>월 목표<strong>48.0%</strong></span></div></article></div>
-          <article class="card" style="margin-top:17px"><div class="card-head"><div><p class="eyebrow">Team calendar</p><h2>오늘 팀원 방문 일정</h2></div><span class="tag-pill">조회 전용</span></div><div class="card-body agenda-list"><div class="agenda-item"><div class="agenda-time"><strong>10:30</strong><small>김지훈</small></div><i class="timeline-dot"></i><div class="agenda-copy"><strong>한빛대학교병원 · 제품 도입 협의</strong><span>박서준 교수 · 브리핑 준비 완료</span></div><button class="btn btn-small btn-secondary" data-open="briefingDialog">상세</button></div><div class="agenda-item"><div class="agenda-time"><strong>13:30</strong><small>이수민</small></div><i class="timeline-dot"></i><div class="agenda-copy"><strong>정우병원 · 제품 데모</strong><span>최수아 의공팀 책임 · 이동 중</span></div><button class="btn btn-small btn-secondary team-detail">상세</button></div><div class="agenda-item alert"><div class="agenda-time"><strong>15:00</strong><small>박도윤</small></div><i class="timeline-dot"></i><div class="agenda-copy"><strong>새봄정형외과 · 견적 후속</strong><span>오정민 원장 · 일정 확정 필요</span></div><button class="btn btn-small btn-secondary team-detail">상세</button></div></div></article>
+          <div class="team-strip"><article class="card member-card"><div class="member-top"><span class="avatar">김</span><div><strong>김지훈</strong><span>동부 권역</span></div></div><div class="member-stats"><span>확정 매출<strong>₩52.4M</strong></span><span>계약<strong>2건</strong></span></div></article><article class="card member-card"><div class="member-top"><span class="avatar">이</span><div><strong>이수민</strong><span>서부 권역</span></div></div><div class="member-stats"><span>확정 매출<strong>₩42.7M</strong></span><span>계약<strong>2건</strong></span></div></article><article class="card member-card"><div class="member-top"><span class="avatar">박</span><div><strong>박도윤</strong><span>남부 권역</span></div></div><div class="member-stats"><span>확정 매출<strong>₩66.6M</strong></span><span>계약<strong>2건</strong></span></div></article><article class="card member-card"><div class="member-top"><span class="avatar">최</span><div><strong>최가은</strong><span>북부 권역</span></div></div><div class="member-stats"><span>확정 매출<strong>₩28.8M</strong></span><span>계약<strong>1건</strong></span></div></article></div>
           </div>
 
           <div class="manager-panel" data-manager-panel="team">
-            <div class="manager-banner"><span class="lock">◎</span><div><strong>공통 목표는 다음 미팅 브리핑부터 적용됩니다.</strong><br><span>팀원이 관리하는 병원의 미팅에서 확인해야 할 항목을 설정합니다.</span></div></div>
+            <div class="manager-banner"><span class="lock">◎</span><div><strong>팀원·공지·일정을 한 곳에서 운영합니다.</strong><br><span>팀원을 관리하고 공통 지시를 게시하며 각 팀원의 오늘 일정을 확인할 수 있습니다.</span></div></div>
+            <div class="team-strip" style="margin-top:0"><article class="card member-card"><div class="member-top"><span class="avatar">김</span><div><strong>김지훈</strong><span>동부 권역 · 재직</span></div><button class="link-btn team-detail" type="button" style="margin-left:auto">관리</button></div><div class="member-stats"><span>오늘 일정<strong>3건</strong></span><span>보고서<strong>제출</strong></span></div></article><article class="card member-card"><div class="member-top"><span class="avatar">이</span><div><strong>이수민</strong><span>서부 권역 · 재직</span></div><button class="link-btn team-detail" type="button" style="margin-left:auto">관리</button></div><div class="member-stats"><span>오늘 일정<strong>2건</strong></span><span>보고서<strong>제출</strong></span></div></article><article class="card member-card"><div class="member-top"><span class="avatar">박</span><div><strong>박도윤</strong><span>남부 권역 · 재직</span></div><button class="link-btn team-detail" type="button" style="margin-left:auto">관리</button></div><div class="member-stats"><span>오늘 일정<strong>4건</strong></span><span>보고서<strong>작성 중</strong></span></div></article><article class="card member-card"><div class="member-top"><span class="avatar">최</span><div><strong>최가은</strong><span>북부 권역 · 재직</span></div><button class="link-btn team-detail" type="button" style="margin-left:auto">관리</button></div><div class="member-stats"><span>오늘 일정<strong>1건</strong></span><span>보고서<strong>미제출</strong></span></div></article></div>
+            <article class="card" style="margin-top:17px;margin-bottom:17px"><div class="card-head"><div><p class="eyebrow">Team calendar</p><h2>오늘 팀원 일정</h2></div><span class="tag-pill">조회 전용</span></div><div class="card-body agenda-list"><div class="agenda-item"><div class="agenda-time"><strong>10:30</strong><small>김지훈</small></div><i class="timeline-dot"></i><div class="agenda-copy"><strong>한빛테크 · 제품 도입 협의</strong><span>박서준 부장 · 브리핑 준비 완료</span></div><button class="btn btn-small btn-secondary" data-open="briefingDialog">상세</button></div><div class="agenda-item"><div class="agenda-time"><strong>13:30</strong><small>이수민</small></div><i class="timeline-dot"></i><div class="agenda-copy"><strong>정우로지스 · 제품 데모</strong><span>최수아 IT팀 책임 · 이동 중</span></div><button class="btn btn-small btn-secondary team-detail">상세</button></div><div class="agenda-item alert"><div class="agenda-time"><strong>15:00</strong><small>박도윤</small></div><i class="timeline-dot"></i><div class="agenda-copy"><strong>새봄솔루션 · 견적 후속</strong><span>오정민 대표 · 일정 확정 필요</span></div><button class="btn btn-small btn-secondary team-detail">상세</button></div></div></article>
             <div class="settings-grid">
               <div class="settings-stack">
                 <article class="card">
@@ -1653,9 +1853,9 @@
                   <div class="card-head"><div><p class="eyebrow">Team announcement</p><h2>팀 공지 관리</h2></div><span class="tag-pill good">오늘 게시</span></div>
                   <div class="card-body">
                     <div class="field"><label for="noticeTitle">공지 제목</label><input class="input" id="noticeTitle" value="오후 방문 전 계약 조건 확인"></div>
-                    <div class="field" style="margin-top:11px"><label for="noticeBody">공지 내용</label><textarea class="input" id="noticeBody">오늘 진행하는 모든 병원 미팅에서 예산 집행 시기와 실제 승인 담당자를 우선 확인해 주세요.</textarea></div>
+                    <div class="field" style="margin-top:11px"><label for="noticeBody">공지 내용</label><textarea class="input" id="noticeBody">오늘 진행하는 모든 고객사 미팅에서 예산 집행 시기와 실제 승인 담당자를 우선 확인해 주세요.</textarea></div>
                     <label style="display:flex;align-items:center;gap:8px;margin-top:10px;font-size:8px;color:var(--muted)"><input type="checkbox" id="noticePush" checked> 푸시 알림 함께 보내기</label>
-                    <div class="notice-preview"><strong id="noticePreviewTitle">오후 방문 전 계약 조건 확인</strong><p id="noticePreviewBody">오늘 진행하는 모든 병원 미팅에서 예산 집행 시기와 실제 승인 담당자를 우선 확인해 주세요.</p></div>
+                    <div class="notice-preview"><strong id="noticePreviewTitle">오후 방문 전 계약 조건 확인</strong><p id="noticePreviewBody">오늘 진행하는 모든 고객사 미팅에서 예산 집행 시기와 실제 승인 담당자를 우선 확인해 주세요.</p></div>
                     <button class="btn btn-primary" type="button" id="publishNotice" style="width:100%;margin-top:12px">공지 게시·팀원 대시보드 반영</button>
                   </div>
                 </article>
@@ -1672,21 +1872,21 @@
             </div>
           </div>
 
-          <div class="manager-panel" data-manager-panel="issues">
-            <div class="manager-banner"><span class="lock">!</span><div><strong>주시 필요 팀원과 근거를 확인합니다.</strong><br><span>오늘 완료된 미팅과 필수 목표의 달성 결과를 조회합니다.</span></div></div>
+          <div class="manager-panel active" data-manager-panel="reports">
+            <div class="manager-banner"><span class="lock">✓</span><div><strong>팀원의 업무보고 제출과 핵심 활동을 한눈에 확인합니다.</strong><br><span>확정된 미팅보고서를 기준으로 일일보고서를 취합하고 미제출·미확정 항목을 표시합니다.</span></div></div>
             <div class="issue-summary">
-              <div class="card"><span>오늘 미팅</span><strong>8 / 10</strong><small class="muted">완료 / 예정</small></div>
-              <div class="card"><span>팀 목표 평균</span><strong id="issueKpiGoal">68%</strong><small class="muted">확정된 미팅 기준</small></div>
-              <div class="card"><span>주시 필요</span><strong class="warning" id="issueWatchCount">2명</strong><small class="muted">팀장 확인 필요</small></div>
-              <div class="card"><span>미완료 목표</span><strong>6건</strong><small class="muted">다음 미팅 이월</small></div>
+              <div class="card"><span>오늘 업무보고</span><strong>2 / 4</strong><small class="muted">제출 완료 / 전체 팀원</small></div>
+              <div class="card"><span>확정 미팅보고서</span><strong>8 / 10</strong><small class="muted">확정 / 오늘 미팅</small></div>
+              <div class="card"><span>핵심 목표 달성</span><strong id="issueKpiGoal">68%</strong><small class="muted">확정 보고서 기준</small></div>
+              <div class="card"><span>확인 필요</span><strong class="warning" id="issueWatchCount">2건</strong><small class="muted">미제출·재작성 요청</small></div>
             </div>
-            <div class="toolbar"><button class="chip active" data-issue-filter="all">전체 팀원</button><button class="chip" data-issue-filter="watch">주시 필요</button><button class="chip" data-issue-filter="normal">정상</button><span class="muted" style="font-size:8px">목표가 없는 미팅은 달성률에서 제외</span></div>
+            <div class="toolbar"><button class="chip active" data-issue-filter="all">전체 팀원</button><button class="chip" data-issue-filter="submitted">제출 완료</button><button class="chip" data-issue-filter="pending">확인 필요</button><span class="muted" style="font-size:8px">확정된 미팅보고서만 업무보고 집계에 반영</span></div>
             <article class="card member-issue-table" id="memberIssueTable">
-              <div class="member-issue-row header"><span>팀원</span><span>오늘 미팅</span><span>목표 달성률</span><span>월 매출 목표</span><span>상태·근거</span><span>관리</span></div>
-              <div class="member-issue-row" data-issue-status="watch" data-issue-member="김지훈"><div class="member-issue-name"><span class="avatar">김</span><div><strong>김지훈</strong><span>동부 권역</span></div></div><strong>2 / 3 완료</strong><div class="mini-progress"><strong id="jihoonGoalRate">50%</strong><div class="progress-bar"><span id="jihoonGoalBar" style="width:50%;background:var(--orange)"></span></div></div><div class="mini-progress"><strong>65.5%</strong><div class="progress-bar"><span style="width:65.5%"></span></div></div><div class="attention-note" id="jihoonStatus">결정권자·평균 보유 대수 미확인</div><div><button class="btn btn-small btn-primary coach-member" data-member="김지훈">지시</button></div></div>
-              <div class="member-issue-row" data-issue-status="normal" data-issue-member="이수민"><div class="member-issue-name"><span class="avatar">이</span><div><strong>이수민</strong><span>서부 권역</span></div></div><strong>2 / 2 완료</strong><div class="mini-progress"><strong>83%</strong><div class="progress-bar"><span style="width:83%"></span></div></div><div class="mini-progress"><strong>61%</strong><div class="progress-bar"><span style="width:61%"></span></div></div><span class="tag-pill good">정상</span><button class="btn btn-small btn-secondary issue-detail">상세</button></div>
-              <div class="member-issue-row" data-issue-status="watch" data-issue-member="박도윤"><div class="member-issue-name"><span class="avatar">박</span><div><strong>박도윤</strong><span>남부 권역</span></div></div><strong>3 / 4 완료</strong><div class="mini-progress"><strong>42%</strong><div class="progress-bar"><span style="width:42%;background:var(--orange)"></span></div></div><div class="mini-progress"><strong>74%</strong><div class="progress-bar"><span style="width:74%"></span></div></div><div class="attention-note">2개 미팅 연속 구매 절차 미확인</div><button class="btn btn-small btn-primary coach-member" data-member="박도윤">지시</button></div>
-              <div class="member-issue-row" data-issue-status="normal" data-issue-member="최가은"><div class="member-issue-name"><span class="avatar">최</span><div><strong>최가은</strong><span>북부 권역</span></div></div><strong>1 / 1 완료</strong><div class="mini-progress"><strong>100%</strong><div class="progress-bar"><span style="width:100%"></span></div></div><div class="mini-progress"><strong>48%</strong><div class="progress-bar"><span style="width:48%"></span></div></div><span class="tag-pill good">정상</span><button class="btn btn-small btn-secondary issue-detail">상세</button></div>
+              <div class="member-issue-row header"><span>팀원</span><span>업무보고</span><span>확정 미팅</span><span>핵심 목표</span><span>주요 내용·이슈</span><span>검토</span></div>
+              <div class="member-issue-row" data-issue-status="submitted" data-issue-member="김지훈"><div class="member-issue-name"><span class="avatar">김</span><div><strong>김지훈</strong><span>동부 권역</span></div></div><strong class="positive">제출 완료</strong><strong>2 / 3건</strong><div class="mini-progress"><strong id="jihoonGoalRate">50%</strong><div class="progress-bar"><span id="jihoonGoalBar" style="width:50%;background:var(--orange)"></span></div></div><div class="attention-note" id="jihoonStatus">한빛테크 구매 승인 담당자 미확인</div><button class="btn btn-small btn-secondary issue-detail">보고서</button></div>
+              <div class="member-issue-row" data-issue-status="submitted" data-issue-member="이수민"><div class="member-issue-name"><span class="avatar">이</span><div><strong>이수민</strong><span>서부 권역</span></div></div><strong class="positive">제출 완료</strong><strong>2 / 2건</strong><div class="mini-progress"><strong>83%</strong><div class="progress-bar"><span style="width:83%"></span></div></div><span class="tag-pill good">특이사항 없음</span><button class="btn btn-small btn-secondary issue-detail">보고서</button></div>
+              <div class="member-issue-row" data-issue-status="pending" data-issue-member="박도윤"><div class="member-issue-name"><span class="avatar">박</span><div><strong>박도윤</strong><span>남부 권역</span></div></div><strong class="warning">작성 중</strong><strong>3 / 4건</strong><div class="mini-progress"><strong>42%</strong><div class="progress-bar"><span style="width:42%;background:var(--orange)"></span></div></div><div class="attention-note">1건 미확정 · 구매 절차 반복 미확인</div><button class="btn btn-small btn-primary coach-member" data-member="박도윤">확인 요청</button></div>
+              <div class="member-issue-row" data-issue-status="pending" data-issue-member="최가은"><div class="member-issue-name"><span class="avatar">최</span><div><strong>최가은</strong><span>북부 권역</span></div></div><strong class="warning">미제출</strong><strong>1 / 1건</strong><div class="mini-progress"><strong>100%</strong><div class="progress-bar"><span style="width:100%"></span></div></div><div class="attention-note">업무보고 제출 대기</div><button class="btn btn-small btn-primary coach-member" data-member="최가은">제출 요청</button></div>
             </article>
           </div>
         </section>
@@ -1694,10 +1894,10 @@
         <section class="page" data-page="info">
           <div class="page-header"><div><p class="eyebrow" id="infoTabEyebrow">My page</p><h1 id="infoTabTitle">마이 페이지</h1><p id="infoTabDesc">프로필과 알림 설정을 확인합니다.</p></div></div>
 
-          <div class="toolbar report-tabs" role="tablist" aria-label="상세정보 메뉴">
-            <button class="chip active" data-info-tab="mypage" role="tab" aria-selected="true">마이 페이지</button>
-            <button class="chip" data-info-tab="billing" role="tab" aria-selected="false">결제 및 청구</button>
-            <button class="chip" data-info-tab="support" role="tab" aria-selected="false">고객 지원</button>
+          <div class="section-tabs report-tabs" role="tablist" aria-label="상세정보 메뉴">
+            <button class="section-tab active" data-info-tab="mypage" role="tab" aria-selected="true">마이 페이지</button>
+            <button class="section-tab" data-info-tab="billing" role="tab" aria-selected="false">결제 및 청구</button>
+            <button class="section-tab" data-info-tab="support" role="tab" aria-selected="false">고객 지원</button>
           </div>
 
           <div class="report-panel" id="mypageInfoPanel">
@@ -1716,10 +1916,10 @@
                     <span class="tag-pill good" id="profilePlanBadge">프리미엄 회원</span>
                     <strong id="profileName" hidden>김서현</strong><span id="profileRole" hidden>영업팀장</span>
                   </div>
-                  
+
                   <div class="quote-preview">
                     <div class="quote-line editable-row"><span>이름</span><input class="profile-input" id="profileNameField" value="김서현" aria-label="이름"></div>
-                    <div class="quote-line editable-row"><span>이메일</span><input class="profile-input" id="profileEmailField" value="seohyun.kim@fieldmed.io" aria-label="이메일"></div>
+                    <div class="quote-line editable-row"><span>이메일</span><input class="profile-input" id="profileEmailField" value="seohyun.kim@salesluv.io" aria-label="이메일"></div>
                     <div class="quote-line editable-row"><span>연락처</span><input class="profile-input" id="profilePhoneField" value="010-1234-5678" aria-label="연락처"></div>
                     <div class="quote-line editable-row"><span>소속</span><input class="profile-input" id="profileDeptField" value="영업본부 · 영업 1팀" aria-label="소속"></div>
                     <div class="quote-line editable-row"><span>직급</span><input class="profile-input" id="profileTitleField" value="영업팀장" aria-label="직급"></div>
@@ -1740,7 +1940,7 @@
                   <div class="goal-setting-row"><input type="checkbox" checked id="notifSchedule"><span><strong>방문 일정 알림</strong><small>미팅 30분 전 알림</small></span></div>
                   <div class="goal-setting-row"><input type="checkbox" checked id="notifOrder"><span><strong>발주 상태 변경</strong><small>승인·지연 발생 시 알림</small></span></div>
                   <div class="goal-setting-row"><input type="checkbox" checked id="notifComplaint"><span><strong>고객불만 접수</strong><small>긴급 건 즉시 알림</small></span></div>
-                  <div class="goal-setting-row"><input type="checkbox" id="notifNews"><span><strong>News 업데이트</strong><small>담당 병원 관련 뉴스</small></span></div>
+                  <div class="goal-setting-row"><input type="checkbox" id="notifDeal"><span><strong>딜 단계 변경</strong><small>담당 딜의 단계·기한 변경</small></span></div>
                 </div>
               </aside>
             </div>
@@ -1770,7 +1970,7 @@
               <div class="card-body">
                 <div class="quote-preview">
                   <div class="quote-line"><span>등록된 결제 수단</span><strong id="billingCardLabel2">법인카드 (•••• 4821)</strong></div>
-                  <div class="quote-line"><span>세금계산서 수신 이메일</span><strong>billing@fieldmed.io</strong></div>
+                  <div class="quote-line"><span>세금계산서 수신 이메일</span><strong>billing@salesluv.io</strong></div>
                   <div class="quote-line"><span>사업자 등록 정보</span><strong id="infoTaxInvoice2" style="cursor:pointer;color:var(--blue)">확인 →</strong></div>
                 </div>
                 <button class="btn btn-outline btn-small" type="button" id="infoChangeCard" style="margin-top:14px">결제 수단 변경</button>
@@ -1802,8 +2002,8 @@
               <div class="card-head"><div><p class="eyebrow">Contact &amp; policy</p><h2>문의 및 정책</h2></div></div>
               <div class="card-body">
                 <div class="document-list">
-                  <div class="doc-row" style="grid-template-columns:1fr 2fr"><span class="doc-title"><strong>고객센터</strong></span><span>support@fieldmed.io · 평일 09:00~18:00</span></div>
-                  <div class="doc-row" style="grid-template-columns:1fr 2fr"><span class="doc-title"><strong>영업 문의</strong></span><span>sales@fieldmed.io</span></div>
+                  <div class="doc-row" style="grid-template-columns:1fr 2fr"><span class="doc-title"><strong>고객센터</strong></span><span>support@salesluv.io · 평일 09:00~18:00</span></div>
+                  <div class="doc-row" style="grid-template-columns:1fr 2fr"><span class="doc-title"><strong>영업 문의</strong></span><span>sales@salesluv.io</span></div>
                   <div class="doc-row" style="grid-template-columns:1fr 2fr"><span class="doc-title"><strong>이용약관</strong></span><span><button class="link-btn" type="button" id="infoTerms">보기 →</button></span></div>
                   <div class="doc-row" style="grid-template-columns:1fr 2fr"><span class="doc-title"><strong>개인정보처리방침</strong></span><span><button class="link-btn" type="button" id="infoPrivacy">보기 →</button></span></div>
                 </div>
@@ -1817,16 +2017,16 @@
   </div>
 
   <dialog id="briefingDialog">
-    <div class="dialog-head"><div><p class="eyebrow">AI pre-visit briefing</p><h2>한빛대학교병원 방문 브리핑</h2><p>일정·고객·미팅 기록·뉴스를 기준으로 미리 생성됨</p></div><button class="close" data-close aria-label="닫기">×</button></div>
+    <div class="dialog-head"><div><p class="eyebrow">AI pre-visit briefing</p><h2>한빛테크 방문 브리핑</h2><p>일정·고객·영업기회·미팅 기록을 기준으로 미리 생성됨</p></div><button class="close" data-close aria-label="닫기">×</button></div>
     <div class="dialog-body">
       <div class="draft-note">● AI 추천은 초안입니다. 원문 근거를 확인하고 실제 영업 판단은 사용자가 수행합니다.</div>
-      <div class="match-box" style="margin-bottom:14px"><strong>병원과 자동 매칭된 고객</strong><p>직책·최근 연락·미완료 업무를 근거로 박서준 교수를 우선 추천했습니다. 사용자가 다른 고객을 선택할 수 있습니다.</p><select class="input" id="briefingCustomer"><option>박서준 교수 · 추천</option><option>이민호 구매팀 과장</option><option>정하린 구매팀 대리</option></select></div>
+      <div class="match-box" style="margin-bottom:14px"><strong>회사와 자동 매칭된 고객</strong><p>직책·최근 연락·미완료 업무를 근거로 박서준 부장을 우선 추천했습니다. 사용자가 다른 고객을 선택할 수 있습니다.</p><select class="input" id="briefingCustomer"><option>박서준 부장 · 추천</option><option>이민호 구매팀 과장</option><option>정하린 구매팀 대리</option></select></div>
       <div class="form-grid">
         <div class="card" style="padding:16px"><p class="eyebrow">Previous meeting</p><strong style="font-size:12px">이전 만남 요약</strong><p class="muted" style="font-size:9px;line-height:1.6">7월 29일 제품 테스트에서 화면 가독성은 긍정적이었고 유지보수 비용에 대한 설명을 요청받았습니다.</p></div>
         <div class="card" style="padding:16px"><p class="eyebrow">Preparation</p><strong style="font-size:12px">이번 방문 준비물</strong><p class="muted" style="font-size:9px;line-height:1.6">비교 견적서, 유지보수 범위표, 제품 테스트 결과를 준비하세요.</p></div>
         <div class="card full" style="padding:16px"><p class="eyebrow">Meeting checklist</p><strong style="font-size:12px">이번 방문에서 확인할 사항</strong><ol style="font-size:10px;line-height:1.9;color:var(--ink-2);padding-left:20px"><li>실제 구매 승인 담당자</li><li>예산 집행 가능 시기</li><li>다음 연락 담당자와 기한</li></ol></div>
-        <div class="card full" style="padding:16px"><p class="eyebrow">Team-assigned goals</p><strong style="font-size:12px">팀장 지정 필수 목표와 이전 미완료 항목</strong><div class="goal-brief-list" id="briefingGoalList"></div><p class="next-directive" id="briefingNextDirective">지난 미팅에서 평균 의료기기 보유 대수를 확인하지 못했습니다. 이번에는 현재 보유 수량과 3년 내 교체 예정 수량을 함께 확인하세요.</p></div>
-        <div class="card full" style="padding:16px"><p class="eyebrow">Related news</p><div class="news-mini"><div class="news-mini-item"><div class="news-date">AUG 05</div><div><h4>심혈관 통합진료센터 확대 계획</h4><p>병원 공식 뉴스룸 · 09:12 수집</p></div></div><div class="news-mini-item"><div class="news-date">AUG 04</div><div><h4>의료기기 유지보수 계약 기준 개정 논의</h4><p>산업협회 · 17:40 수집</p></div></div></div></div>
+        <div class="card full" style="padding:16px"><p class="eyebrow">Team-assigned goals</p><strong style="font-size:12px">팀장 지정 필수 목표와 이전 미완료 항목</strong><div class="goal-brief-list" id="briefingGoalList"></div><p class="next-directive" id="briefingNextDirective">지난 미팅에서 예상 사용 규모를 확인하지 못했습니다. 이번에는 예상 사용자 수와 향후 확장 계획을 함께 확인하세요.</p></div>
+        <div class="card full" style="padding:16px"><p class="eyebrow">Open deal</p><strong style="font-size:12px">진행 중 딜 · SalesFlow Enterprise 도입 협의</strong><div class="quote-line"><span>현재 단계</span><strong>계약 협의 · 72%</strong></div><div class="quote-line"><span>예상 금액·마감</span><strong>₩50.2M · 8월 20일</strong></div></div>
       </div>
     </div>
     <div class="dialog-foot"><button class="btn btn-primary" data-close>방문 준비 확인</button></div>
@@ -1837,23 +2037,23 @@
     <div class="dialog-body">
       <div class="draft-note">● 분석 결과는 확정 전까지 고객 History와 공식 보고서에 반영되지 않습니다.</div>
       <div class="upload-zone"><strong>녹취 파일을 선택하세요</strong><span>MP3, WAV, M4A, TXT · 앱 내 직접 녹음은 제공하지 않음 · STT API 처리 예정</span><input id="meetingFile" type="file" accept="audio/*,.txt"></div>
-      <div class="field" style="margin-top:16px"><label for="meetingText">또는 미팅 내용을 직접 입력</label><textarea class="input" id="meetingText">박서준 교수님과 CardioView X7 테스트 결과를 확인했다. 화면 가독성은 좋았지만 유지보수 비용이 기존 장비보다 높다는 의견이 있었다. 구매팀 이민호 과장에게 다음 주 화요일까지 비교 견적과 유지보수 범위표를 보내기로 했다. 예산은 4분기에 집행 가능하다고 했다.</textarea></div>
+      <div class="field" style="margin-top:16px"><label for="meetingText">또는 미팅 내용을 직접 입력</label><textarea class="input" id="meetingText">박서준 부장님과 SalesFlow Enterprise 테스트 결과를 확인했다. 화면 가독성은 좋았지만 유지보수 비용이 기존 솔루션보다 높다는 의견이 있었다. 구매팀 이민호 과장에게 다음 주 화요일까지 비교 견적과 유지보수 범위표를 보내기로 했다. 예산은 4분기에 집행 가능하다고 했다.</textarea></div>
       <div style="display:flex;align-items:center;justify-content:space-between;gap:12px"><span class="loader" id="meetingLoader"><i class="spinner"></i> Meeting Report Agent가 근거를 연결하고 있습니다...</span><button class="btn btn-primary" id="analyzeMeeting">AI로 구조화</button></div>
       <div class="analysis-result" id="meetingResult">
         <h3>추출 결과 · 사용자 확인 필요</h3>
-        <div class="result-grid"><div class="result-item"><small>참석자</small><strong>박서준 교수 · 이민호 구매팀 과장</strong></div><div class="result-item"><small>고객 반응</small><strong>가독성 긍정 · 유지보수 비용 우려</strong></div><div class="result-item"><small>결정사항</small><strong>비교 견적과 유지보수 범위표 전달</strong></div><div class="result-item"><small>기한·다음 행동</small><strong>8월 11일까지 자료 전달 · 후속 미팅 추천</strong></div></div>
+        <div class="result-grid"><div class="result-item"><small>참석자</small><strong>박서준 부장 · 이민호 구매팀 과장</strong></div><div class="result-item"><small>고객 반응</small><strong>가독성 긍정 · 유지보수 비용 우려</strong></div><div class="result-item"><small>결정사항</small><strong>비교 견적과 유지보수 범위표 전달</strong></div><div class="result-item"><small>기한·다음 행동</small><strong>8월 11일까지 자료 전달 · 후속 미팅 추천</strong></div></div>
         <div style="margin-top:14px;padding-top:13px;border-top:1px solid #cad6c5"><p class="eyebrow">Manager goal check · <span id="meetingGoalScore">3 / 4</span></p><div class="goal-brief-list" id="meetingGoalChecks"></div><p class="next-directive" id="meetingNextDirective"></p></div>
-        <div class="evidence">원문 근거: “이민호 과장에게”, “예산은 4분기에 집행 가능”, “다음 주 화요일까지”. 평균 의료기기 보유 대수에 대한 발화는 찾지 못했습니다.</div>
+        <div class="evidence">원문 근거: “이민호 과장에게”, “예산은 4분기에 집행 가능”, “다음 주 화요일까지”. 예상 사용 규모에 대한 발화는 찾지 못했습니다.</div>
       </div>
     </div>
     <div class="dialog-foot"><button class="btn btn-outline" data-close>취소</button><button class="btn btn-primary" id="confirmMeeting" disabled>검토 후 확정·보고서 생성</button></div>
   </dialog>
 
   <dialog id="customerDialog">
-    <div class="dialog-head"><div><p class="eyebrow">New contact</p><h2>고객명함 등록</h2><p>OCR 추출값과 병원 후보를 사용자가 최종 확인합니다.</p></div><button class="close" data-close aria-label="닫기">×</button></div>
+    <div class="dialog-head"><div><p class="eyebrow">New contact</p><h2>고객명함 등록</h2><p>OCR 추출값과 회사 후보를 사용자가 최종 확인합니다.</p></div><button class="close" data-close aria-label="닫기">×</button></div>
     <form id="customerForm">
       <div class="dialog-body">
-        <div class="ocr-preview"><div class="business-card"><span class="company">HANBIT UNIVERSITY HOSPITAL</span><div><strong>정하린</strong><br><span>의료기기 구매팀 · 대리</span></div><span>02-000-1048 · harin.j@demo.test</span></div><div><div class="upload-zone" style="padding:18px"><strong>명함 이미지 업로드</strong><span>JPG, PNG · 시안에서는 샘플 값을 추출합니다.</span><input type="file" accept="image/jpeg,image/png"><button type="button" class="btn btn-small btn-secondary" id="runOcr">샘플 OCR 실행</button></div><div class="match-box" style="margin-top:10px"><strong>병원 자동 매칭 후보</strong><p>한빛대학교병원</p><select class="input" id="customerHospital"><option>한빛대학교병원</option><option>한빛종합병원</option><option>직접 선택</option></select></div></div></div>
+        <div class="ocr-preview"><div class="business-card"><span class="company">HANBIT TECH</span><div><strong>정하린</strong><br><span>구매팀 · 대리</span></div><span>02-000-1048 · harin.j@demo.test</span></div><div><div class="upload-zone" style="padding:18px"><strong>명함 이미지 업로드</strong><span>JPG, PNG · 시안에서는 샘플 값을 추출합니다.</span><input type="file" accept="image/jpeg,image/png"><button type="button" class="btn btn-small btn-secondary" id="runOcr">샘플 OCR 실행</button></div><div class="match-box" style="margin-top:10px"><strong>회사 자동 매칭 후보</strong><p>한빛테크</p><select class="input" id="customerHospital"><option>한빛테크</option><option>한빛테크 계열사</option><option>직접 선택</option></select></div></div></div>
         <div class="form-grid" style="margin-top:17px"><div class="field"><label for="customerName">이름</label><input class="input" id="customerName" required></div><div class="field"><label for="customerTitle">직책·부서</label><input class="input" id="customerTitle" required></div><div class="field"><label for="customerPhone">연락처</label><input class="input" id="customerPhone" inputmode="tel"></div><div class="field"><label for="customerEmail">이메일</label><input class="input" id="customerEmail" type="email"></div></div>
       </div>
       <div class="dialog-foot"><button class="btn btn-outline" type="button" data-close>취소</button><button class="btn btn-primary" type="submit">확인하고 고객 저장</button></div>
@@ -1861,27 +2061,27 @@
   </dialog>
 
   <dialog id="hospitalDialog">
-    <div class="dialog-head"><div><p class="eyebrow">Assigned hospital</p><h2>담당병원 등록</h2><p>영업 담당 병원과 초기 관리 정보를 연결합니다.</p></div><button class="close" data-close aria-label="닫기">×</button></div>
+    <div class="dialog-head"><div><p class="eyebrow">Assigned company</p><h2>담당 회사 등록</h2><p>영업 담당 회사와 초기 관리 정보를 연결합니다.</p></div><button class="close" data-close aria-label="닫기">×</button></div>
     <form id="hospitalForm">
       <div class="dialog-body">
-        <div class="draft-note">● 병원 등록 후 명함 고객과 미팅 기록을 연결하면 병원 단위 History가 자동 구성됩니다.</div>
+        <div class="draft-note">● 회사 등록 후 명함 고객과 미팅 기록을 연결하면 회사 단위 History가 자동 구성됩니다.</div>
         <div class="form-grid">
-          <div class="field"><label for="hospitalName">병원명</label><input class="input" id="hospitalName" value="푸른서울병원" required></div>
-          <div class="field"><label for="hospitalType">병원 유형</label><select class="input" id="hospitalType"><option>종합병원</option><option>상급종합병원</option><option>전문병원</option><option>의원</option></select></div>
+          <div class="field"><label for="hospitalName">회사명</label><input class="input" id="hospitalName" value="푸른테크" required></div>
+          <div class="field"><label for="hospitalType">회사 유형</label><select class="input" id="hospitalType"><option>중견기업</option><option>대기업</option><option>중소기업</option><option>스타트업</option></select></div>
           <div class="field"><label for="hospitalRegion">권역·지역</label><input class="input" id="hospitalRegion" value="서울 동부" required></div>
           <div class="field"><label for="hospitalOwner">담당 팀원</label><select class="input" id="hospitalOwner"><option>김지훈</option><option>이수민</option><option>박도윤</option><option>최가은</option></select></div>
-          <div class="field"><label for="hospitalContact">주요 고객</label><input class="input" id="hospitalContact" value="한예린 의공팀장"></div>
-          <div class="field"><label for="hospitalProduct">관심 제품</label><select class="input" id="hospitalProduct"><option>CardioView X7</option><option>SonoFlex Pro</option><option>OrthoScan Mini</option></select></div>
+          <div class="field"><label for="hospitalContact">주요 고객</label><input class="input" id="hospitalContact" value="한예린 IT팀장"></div>
+          <div class="field"><label for="hospitalProduct">관심 제품</label><select class="input" id="hospitalProduct"><option>SalesFlow Enterprise</option><option>WorkSync Pro</option><option>InsightBoard</option></select></div>
           <div class="field full"><label for="hospitalNextVisit">첫 방문 예정일</label><input class="input" id="hospitalNextVisit" type="date" value="2026-08-18"></div>
         </div>
       </div>
-      <div class="dialog-foot"><button class="btn btn-outline" type="button" data-close>취소</button><button class="btn btn-primary" type="submit">담당 병원 저장</button></div>
+      <div class="dialog-foot"><button class="btn btn-outline" type="button" data-close>취소</button><button class="btn btn-primary" type="submit">담당 회사 저장</button></div>
     </form>
   </dialog>
 
   <dialog id="scheduleDialog">
-    <div class="dialog-head"><div><p class="eyebrow">Calendar event</p><h2>병원 방문 일정 등록</h2><p>확정된 일정은 대시보드에 반영되고 방문 전 푸시 알림을 예약합니다.</p></div><button class="close" data-close aria-label="닫기">×</button></div>
-    <form id="scheduleForm"><div class="dialog-body"><div class="form-grid"><div class="field"><label for="scheduleHospital">방문 병원</label><select class="input" id="scheduleHospital"><option>한빛대학교병원</option><option>서림메디컬센터</option><option>새봄정형외과</option><option>정우병원</option></select></div><div class="field"><label for="scheduleCustomer">고객</label><select class="input" id="scheduleCustomer"><option>박서준 교수</option><option>윤가영 간호팀장</option><option>오정민 원장</option><option>정하린 구매팀 대리</option></select></div><div class="field"><label for="scheduleDate">날짜</label><input class="input" id="scheduleDate" type="date" value="2026-08-07" required></div><div class="field"><label for="scheduleTime">시간</label><input class="input" id="scheduleTime" type="time" value="14:00" required></div><div class="field full"><label for="schedulePurpose">미팅 목적</label><input class="input" id="schedulePurpose" value="견적 검토 후속 협의" required></div><div class="field full"><label for="scheduleMemo">준비사항·메모</label><textarea class="input" id="scheduleMemo" style="min-height:75px">비교 견적서와 유지보수 범위표 준비</textarea></div></div></div><div class="dialog-foot"><button class="btn btn-outline" type="button" data-close>취소</button><button class="btn btn-primary" type="submit">일정 확정·푸시 예약</button></div></form>
+    <div class="dialog-head"><div><p class="eyebrow">Calendar event</p><h2 id="scheduleDialogTitle">회사 방문 일정 등록</h2><p>확정된 일정은 대시보드에 반영되고 방문 전 푸시 알림을 예약합니다.</p></div><button class="close" data-close aria-label="닫기">×</button></div>
+    <form id="scheduleForm"><div class="dialog-body"><div class="form-grid"><div class="field"><label for="scheduleHospital">방문 회사</label><select class="input" id="scheduleHospital"><option>한빛테크</option><option>서림커머스</option><option>새봄솔루션</option><option>정우로지스</option></select></div><div class="field"><label for="scheduleCustomer">고객</label><select class="input" id="scheduleCustomer"><option>박서준 부장</option><option>윤가영 운영팀장</option><option>오정민 대표</option><option>정하린 구매팀 대리</option><option>최수아 IT팀 책임</option></select></div><div class="field"><label for="scheduleDate">날짜</label><input class="input" id="scheduleDate" type="date" value="2026-08-07" required></div><div class="field"><label for="scheduleTime">시간</label><input class="input" id="scheduleTime" type="time" value="14:00" required></div><div class="field full"><label for="schedulePurpose">미팅 목적</label><input class="input" id="schedulePurpose" value="견적 검토 후속 협의" required></div><div class="field full"><label for="scheduleMemo">준비사항·메모</label><textarea class="input" id="scheduleMemo" style="min-height:75px">비교 견적서와 유지보수 범위표 준비</textarea></div></div></div><div class="dialog-foot"><button class="btn btn-outline" type="button" data-close>취소</button><button class="btn btn-primary" id="scheduleSubmitButton" type="submit">일정 확정·푸시 예약</button></div></form>
   </dialog>
 
   <dialog id="leaveDialog">
@@ -1910,12 +2110,12 @@
 
   <dialog id="quoteDialog">
     <div class="dialog-head"><div><p class="eyebrow">Deterministic document engine</p><h2>견적서 자동 작성</h2><p>LLM 없이 정해진 계산식과 양식 필드로 생성합니다.</p></div><button class="close" data-close aria-label="닫기">×</button></div>
-    <form id="quoteForm"><div class="dialog-body"><div class="draft-note">● 미리보기에서 확정하기 전에는 공식 파일로 저장·다운로드할 수 없습니다.</div><div class="form-grid"><div class="field"><label for="quoteHospital">수신 병원</label><select class="input" id="quoteHospital"><option>한빛대학교병원</option><option>서림메디컬센터</option><option>새봄정형외과</option></select></div><div class="field"><label for="quoteProduct">제품</label><select class="input" id="quoteProduct"><option value="24000000">CardioView X7</option><option value="16500000">SonoFlex Pro</option><option value="9800000">OrthoScan Mini</option></select></div><div class="field"><label for="quoteQty">수량</label><input class="input" id="quoteQty" type="number" value="2" min="1"></div><div class="field"><label for="quoteDiscount">할인율 (%)</label><input class="input" id="quoteDiscount" type="number" value="5" min="0" max="30"></div><div class="field full"><label for="quoteTerms">납품·결제 조건</label><input class="input" id="quoteTerms" value="계약 후 30일 이내 납품 · 검수 후 30일 이내 결제"></div></div><div class="quote-preview"><p class="eyebrow">Live preview</p><div class="quote-line"><span>공급가액</span><strong id="quoteSubtotal">₩45,600,000</strong></div><div class="quote-line"><span>부가세 10%</span><strong id="quoteVat">₩4,560,000</strong></div><div class="quote-line total"><span>합계</span><strong id="quoteTotal">₩50,160,000</strong></div></div></div><div class="dialog-foot"><button class="btn btn-outline" type="button" data-close>취소</button><button class="btn btn-primary" type="submit">미리보기 확인·확정 저장</button></div></form>
+    <form id="quoteForm"><div class="dialog-body"><div class="draft-note">● 미리보기에서 확정하기 전에는 공식 파일로 저장·다운로드할 수 없습니다.</div><div class="form-grid"><div class="field"><label for="quoteHospital">수신 고객사</label><select class="input" id="quoteHospital"><option>한빛테크</option><option>서림커머스</option><option>새봄솔루션</option></select></div><div class="field"><label for="quoteProduct">제품</label><select class="input" id="quoteProduct"><option value="24000000">SalesFlow Enterprise</option><option value="16500000">WorkSync Pro</option><option value="9800000">InsightBoard</option></select></div><div class="field"><label for="quoteQty">수량</label><input class="input" id="quoteQty" type="number" value="2" min="1"></div><div class="field"><label for="quoteDiscount">할인율 (%)</label><input class="input" id="quoteDiscount" type="number" value="5" min="0" max="30"></div><div class="field full"><label for="quoteTerms">납품·결제 조건</label><input class="input" id="quoteTerms" value="계약 후 30일 이내 납품 · 검수 후 30일 이내 결제"></div></div><div class="quote-preview"><p class="eyebrow">Live preview</p><div class="quote-line"><span>공급가액</span><strong id="quoteSubtotal">₩45,600,000</strong></div><div class="quote-line"><span>부가세 10%</span><strong id="quoteVat">₩4,560,000</strong></div><div class="quote-line total"><span>합계</span><strong id="quoteTotal">₩50,160,000</strong></div></div></div><div class="dialog-foot"><button class="btn btn-outline" type="button" data-close>취소</button><button class="btn btn-primary" type="submit">미리보기 확인·확정 저장</button></div></form>
   </dialog>
 
   <dialog id="contractDialog">
     <div class="dialog-head"><div><p class="eyebrow">Contract & e-sign</p><h2>계약서 자동 작성</h2><p>고정 양식 입력 후 확정본에 전자서명을 요청합니다.</p></div><button class="close" data-close aria-label="닫기">×</button></div>
-    <form id="contractForm"><div class="dialog-body"><div class="draft-note">● 계약 조항은 제공된 회사 양식을 사용하며 AI가 임의로 작성하지 않습니다.</div><div class="form-grid"><div class="field"><label for="contractHospital">계약 병원</label><select class="input" id="contractHospital"><option>한빛대학교병원</option><option>서림메디컬센터</option><option>새봄정형외과</option></select></div><div class="field"><label for="contractProduct">공급 제품</label><select class="input" id="contractProduct"><option>CardioView X7</option><option>SonoFlex Pro</option><option>OrthoScan Mini</option></select></div><div class="field"><label for="contractAmount">계약금액</label><input class="input" id="contractAmount" type="number" value="50160000" min="0"></div><div class="field"><label for="contractDate">계약 시작일</label><input class="input" id="contractDate" type="date" value="2026-08-17"></div><div class="field"><label for="contractSigner">병원 서명자</label><input class="input" id="contractSigner" value="이민호 구매팀 과장"></div><div class="field"><label for="contractPeriod">유지보수 기간</label><select class="input" id="contractPeriod"><option>12개월</option><option>24개월</option><option>36개월</option></select></div></div><div class="quote-preview"><div class="quote-line"><span>적용 양식</span><strong>제공된 의료기기 공급계약서</strong></div><div class="quote-line"><span>필수 필드</span><strong class="positive">12 / 12 완료</strong></div><div class="quote-line"><span>전자서명</span><strong>확정 후 요청 가능</strong></div></div></div><div class="dialog-foot"><button class="btn btn-outline" type="button" data-close>취소</button><button class="btn btn-primary" type="submit">확정 저장·전자서명 요청</button></div></form>
+    <form id="contractForm"><div class="dialog-body"><div class="draft-note">● 계약 조항은 제공된 회사 양식을 사용하며 AI가 임의로 작성하지 않습니다.</div><div class="form-grid"><div class="field"><label for="contractHospital">계약 고객사</label><select class="input" id="contractHospital"><option>한빛테크</option><option>서림커머스</option><option>새봄솔루션</option></select></div><div class="field"><label for="contractProduct">공급 제품</label><select class="input" id="contractProduct"><option>SalesFlow Enterprise</option><option>WorkSync Pro</option><option>InsightBoard</option></select></div><div class="field"><label for="contractAmount">계약금액</label><input class="input" id="contractAmount" type="number" value="50160000" min="0"></div><div class="field"><label for="contractDate">계약 시작일</label><input class="input" id="contractDate" type="date" value="2026-08-17"></div><div class="field"><label for="contractSigner">고객사 서명자</label><input class="input" id="contractSigner" value="이민호 구매팀 과장"></div><div class="field"><label for="contractPeriod">유지보수 기간</label><select class="input" id="contractPeriod"><option>12개월</option><option>24개월</option><option>36개월</option></select></div></div><div class="quote-preview"><div class="quote-line"><span>적용 양식</span><strong>제공된 솔루션 공급계약서</strong></div><div class="quote-line"><span>필수 필드</span><strong class="positive">12 / 12 완료</strong></div><div class="quote-line"><span>전자서명</span><strong>확정 후 요청 가능</strong></div></div></div><div class="dialog-foot"><button class="btn btn-outline" type="button" data-close>취소</button><button class="btn btn-primary" type="submit">확정 저장·전자서명 요청</button></div></form>
   </dialog>
 
   <dialog id="poDialog">
@@ -1924,11 +2124,11 @@
       <div class="draft-note">● 등록 시 팀장 승인 대기 상태로 저장되며, 승인 후 공급처로 전달됩니다.</div>
       <div class="form-grid" style="margin-top:14px">
         <div class="field"><label for="poContract">연결 계약</label><select class="input" id="poContract"></select></div>
-        <div class="field"><label for="poSupplier">공급처</label><select class="input" id="poSupplier"><option>본사 생산팀</option><option>외부 벤더 (메디파츠)</option><option>외부 벤더 (한성의료기)</option></select></div>
+        <div class="field"><label for="poSupplier">공급처</label><select class="input" id="poSupplier"><option>본사 생산팀</option><option>외부 벤더 (파인파트너스)</option><option>외부 벤더 (한성솔루션)</option></select></div>
         <div class="field"><label for="poRequestDate">납기 희망일</label><input class="input" id="poRequestDate" type="date" value="2026-08-20" required></div>
         <div class="field"><label for="poExpectDate">예상 입고일</label><input class="input" id="poExpectDate" type="date" value="2026-08-24" required></div>
         <div class="field"><label for="poApprover">승인자</label><select class="input" id="poApprover"><option>김서현 영업팀장</option><option>영업본부장</option></select></div>
-        <div class="field"><label for="poHospital">납품 병원</label><input class="input" id="poHospital" readonly></div>
+        <div class="field"><label for="poHospital">납품처</label><input class="input" id="poHospital" readonly></div>
       </div>
 
       <div class="section-title" style="margin-top:18px"><h3>발주 품목</h3><button class="link-btn" type="button" id="poAddItem">＋ 품목 추가</button></div>
@@ -1961,11 +2161,11 @@
     <div class="dialog-head"><div><p class="eyebrow">New complaint</p><h2>고객불만·문의 접수</h2><p>접수 즉시 담당자에게 알림이 전달됩니다.</p></div><button class="close" data-close aria-label="닫기">×</button></div>
     <form id="complaintForm"><div class="dialog-body">
       <div class="form-grid">
-        <div class="field"><label for="csHospital">병원</label><select class="input" id="csHospital"><option>한빛대학교병원</option><option>서림메디컬센터</option><option>새봄정형외과</option><option>정우병원</option></select></div>
-        <div class="field"><label for="csContact">고객</label><input class="input" id="csContact" placeholder="예: 오정민 원장" required></div>
+        <div class="field"><label for="csHospital">회사</label><select class="input" id="csHospital"><option>한빛테크</option><option>서림커머스</option><option>새봄솔루션</option><option>정우로지스</option></select></div>
+        <div class="field"><label for="csContact">고객</label><input class="input" id="csContact" placeholder="예: 오정민 대표" required></div>
         <div class="field"><label for="csPriority">우선순위</label><select class="input" id="csPriority"><option value="긴급">긴급</option><option value="일반" selected>일반</option></select></div>
         <div class="field"><label for="csOwner">담당자</label><select class="input" id="csOwner"><option>김지훈</option><option>이수민</option><option>박도윤</option></select></div>
-        <div class="field full"><label for="csTitle">제목</label><input class="input" id="csTitle" placeholder="예: 제품 초기 캘리브레이션 오류" required></div>
+        <div class="field full"><label for="csTitle">제목</label><input class="input" id="csTitle" placeholder="예: 제품 초기 설정 오류" required></div>
         <div class="field full"><label for="csDesc">내용</label><textarea class="input" id="csDesc" style="min-height:80px" placeholder="접수된 불만·문의 내용을 입력하세요"></textarea></div>
       </div>
     </div><div class="dialog-foot"><button class="btn btn-outline" type="button" data-close>취소</button><button class="btn btn-primary" type="submit">접수 등록</button></div></form>
@@ -1987,7 +2187,7 @@
       <div class="draft-note">● 동일 자료명이 있으면 새 버전으로 등록되고 이전 버전은 보관 처리됩니다.</div>
       <div class="upload-zone"><strong>파일을 선택하세요</strong><span>XLSX, PDF, PPTX, DOCX, JPG, PNG · 개당 50MB</span><input type="file" id="libFile" accept=".xlsx,.xls,.pdf,.pptx,.docx,image/*"><div class="lib-meta" id="libFilePicked" style="margin-top:10px">선택된 파일 없음</div></div>
       <div class="form-grid" style="margin-top:14px">
-        <div class="field"><label for="libTitle">자료명</label><input class="input" id="libTitle" placeholder="예: CardioView X7 제품 카탈로그" required></div>
+        <div class="field"><label for="libTitle">자료명</label><input class="input" id="libTitle" placeholder="예: SalesFlow Enterprise 제품 카탈로그" required></div>
         <div class="field"><label for="libCategory">분류</label><select class="input" id="libCategory"><option value="catalog">제품자료</option><option value="price">가격·정책</option><option value="cert">인허가·인증</option><option value="form">표준양식</option><option value="edu">교육자료</option></select></div>
         <div class="field"><label for="libProduct">제품·구분</label><input class="input" id="libProduct" value="공통"></div>
         <div class="field"><label for="libVersion">버전</label><input class="input" id="libVersion" value="v1.0"></div>
@@ -2018,30 +2218,30 @@
   </dialog>
 
   <dialog id="pubUploadDialog">
-    <div class="dialog-head"><div><p class="eyebrow">New publication</p><h2>논문 자료 등록</h2><p>서지정보와 초록을 입력하면 목록에 즉시 반영됩니다.</p></div><button class="close" data-close aria-label="닫기">×</button></div>
+    <div class="dialog-head"><div><p class="eyebrow">New document</p><h2>기타 문서 등록</h2><p>문서의 기본 정보와 요약을 입력하면 목록에 즉시 반영됩니다.</p></div><button class="close" data-close aria-label="닫기">×</button></div>
     <form id="pubUploadForm"><div class="dialog-body">
       <div class="form-grid">
-        <div class="field full"><label for="pubTitle">논문명</label><input class="input" id="pubTitle" placeholder="예: CardioView X7 임상 적용 사례 연구" required></div>
-        <div class="field"><label for="pubAuthor">저자</label><input class="input" id="pubAuthor" placeholder="예: 김민석 외 3인" required></div>
-        <div class="field"><label for="pubJournal">저널·학회</label><input class="input" id="pubJournal" placeholder="예: 대한심장학회지" required></div>
-        <div class="field"><label for="pubDate">발행일</label><input class="input" id="pubDate" type="date"></div>
-        <div class="field"><label for="pubProduct">연관 제품</label><select class="input" id="pubProduct"><option>CardioView X7</option><option>SonoFlex Pro</option><option>OrthoScan Mini</option><option>공통</option></select></div>
-        <div class="field full"><label for="pubSummary">초록·요약</label><textarea class="input" id="pubSummary" style="min-height:74px" placeholder="영업 제안에 인용할 핵심 내용을 요약하세요"></textarea></div>
+        <div class="field full"><label for="pubTitle">문서명</label><input class="input" id="pubTitle" placeholder="예: 2026 B2B 영업 트렌드 리포트" required></div>
+        <div class="field"><label for="pubAuthor">작성자</label><input class="input" id="pubAuthor" placeholder="예: 전략기획팀" required></div>
+        <div class="field"><label for="pubJournal">출처·부서</label><input class="input" id="pubJournal" placeholder="예: 사내 리서치" required></div>
+        <div class="field"><label for="pubDate">등록일</label><input class="input" id="pubDate" type="date"></div>
+        <div class="field"><label for="pubProduct">문서 구분</label><select class="input" id="pubProduct"><option>시장조사</option><option>경쟁사 비교</option><option>교육</option><option>정책</option></select></div>
+        <div class="field full"><label for="pubSummary">문서 요약</label><textarea class="input" id="pubSummary" style="min-height:74px" placeholder="실무자가 빠르게 확인할 핵심 내용을 요약하세요"></textarea></div>
       </div>
     </div><div class="dialog-foot"><button class="btn btn-outline" type="button" data-close>취소</button><button class="btn btn-primary" type="submit">등록</button></div></form>
   </dialog>
 
   <dialog id="salesUploadDialog">
     <div class="dialog-head"><div><p class="eyebrow">Multimodal revenue intake</p><h2>실제 매출 자료 업로드</h2><p>Excel·PDF·문서 이미지에서 매출 초안을 추출합니다.</p></div><button class="close" data-close aria-label="닫기">×</button></div>
-    <div class="dialog-body"><div class="draft-note">● 추출된 매출은 사용자가 확인·확정하기 전까지 팀 매출 집계에서 제외됩니다.</div><div class="upload-zone"><strong>매출 파일을 선택하세요</strong><span>XLSX, PDF, JPG, PNG · 시안에서는 샘플 3개 행을 추출합니다.</span><input type="file" id="salesFile" accept=".xlsx,.xls,.pdf,image/*"><div style="margin-top:12px"><button class="btn btn-small btn-secondary" id="extractSales" type="button">샘플 추출 실행</button></div></div><div class="analysis-result" id="salesResult"><h3>추출된 매출 초안 · 3행</h3><div class="quote-line"><span>2026.08.03 · 한빛대학교병원 · CardioView X7</span><strong>₩50,160,000</strong></div><div class="quote-line"><span>2026.08.04 · 서림메디컬센터 · SonoFlex Pro</span><strong>₩36,300,000</strong></div><div class="quote-line"><span>2026.08.05 · 정우병원 · OrthoScan Mini</span><strong>₩21,560,000</strong></div><div class="evidence">원본 근거: 매출자료_2026-08.xlsx · 매출원장 시트 · 14~16행</div></div></div>
+    <div class="dialog-body"><div class="draft-note">● 추출된 매출은 사용자가 확인·확정하기 전까지 팀 매출 집계에서 제외됩니다.</div><div class="upload-zone"><strong>매출 파일을 선택하세요</strong><span>XLSX, PDF, JPG, PNG · 시안에서는 샘플 3개 행을 추출합니다.</span><input type="file" id="salesFile" accept=".xlsx,.xls,.pdf,image/*"><div style="margin-top:12px"><button class="btn btn-small btn-secondary" id="extractSales" type="button">샘플 추출 실행</button></div></div><div class="analysis-result" id="salesResult"><h3>추출된 매출 초안 · 3행</h3><div class="quote-line"><span>2026.08.03 · 한빛테크 · SalesFlow Enterprise</span><strong>₩50,160,000</strong></div><div class="quote-line"><span>2026.08.04 · 서림커머스 · WorkSync Pro</span><strong>₩36,300,000</strong></div><div class="quote-line"><span>2026.08.05 · 정우로지스 · InsightBoard</span><strong>₩21,560,000</strong></div><div class="evidence">원본 근거: 매출자료_2026-08.xlsx · 매출대표 시트 · 14~16행</div></div></div>
     <div class="dialog-foot"><button class="btn btn-outline" data-close>초안으로 두기</button><button class="btn btn-primary" id="confirmSales" disabled>검토 후 매출 확정</button></div>
   </dialog>
 
-  <aside class="drawer" id="notificationDrawer" aria-label="FieldMed 알림">
-    <div class="drawer-head"><div><p class="eyebrow">Notifications</p><h2>FieldMed 알림</h2></div><button class="icon-btn" id="closeDrawer" aria-label="알림 닫기">×</button></div>
+  <aside class="drawer" id="notificationDrawer" aria-label="SalesLuv 알림">
+    <div class="drawer-head"><div><p class="eyebrow">Notifications</p><h2>SalesLuv 알림</h2></div><button class="icon-btn" id="closeDrawer" aria-label="알림 닫기">×</button></div>
     <div id="notificationMessages">
-      <div class="notification-message new"><div class="notification-meta"><span>방금</span></div><h3>한빛대학교병원 방문 1시간 전</h3><p>구매팀 담당자와 예산 편성 시기가 아직 확인되지 않았습니다. 유지보수 비용 비교표를 준비하세요.</p><div class="notification-actions"><button class="btn btn-small btn-primary" data-open="briefingDialog">브리핑 열기</button></div></div>
-      <div class="notification-message"><div class="notification-meta"><span>09:10</span></div><h3>후속 방문 일정이 누락됐습니다</h3><p>새봄정형외과의 견적 검토 회신일이 2일 지났습니다.</p><div class="notification-actions"><button class="btn btn-small btn-primary" data-open="scheduleDialog">일정 등록</button></div></div>
+      <div class="notification-message new"><div class="notification-meta"><span>방금</span></div><h3>한빛테크 방문 1시간 전</h3><p>구매팀 담당자와 예산 편성 시기가 아직 확인되지 않았습니다. 유지보수 비용 비교표를 준비하세요.</p><div class="notification-actions"><button class="btn btn-small btn-primary" data-open="briefingDialog">브리핑 열기</button></div></div>
+      <div class="notification-message"><div class="notification-meta"><span>09:10</span></div><h3>후속 방문 일정이 누락됐습니다</h3><p>새봄솔루션의 견적 검토 회신일이 2일 지났습니다.</p><div class="notification-actions"><button class="btn btn-small btn-primary" data-open="scheduleDialog">일정 등록</button></div></div>
       <div class="notification-message"><div class="notification-meta"><span>어제</span></div><h3>일일보고서 초안이 생성됐습니다</h3><p>확정된 미팅보고서 3건을 통합했습니다. 검토 후 확정해 주세요.</p><div class="notification-actions"><button class="btn btn-small btn-primary" data-route="reports">보고서 검토</button></div></div>
     </div>
   </aside>
@@ -2049,41 +2249,41 @@
   <div class="toast" id="toast" role="status" aria-live="polite"></div>
 
   <script>
-    const pageNames = { dashboard: "영업 대시보드", news: "News", reports: "리포트 라이브러리", customers: "고객 관리", calendar: "업무 캘린더", daily: "업무보고 관리", orders: "발주 관리", complaints: "고객불만 관리", documents: "문서 라이브러리", publication: "Publication", manager: "팀장", info: "상세정보" };
+    const pageNames = { dashboard: "영업 대시보드", deals: "딜 파이프라인", reports: "견적·계약·리포트", customers: "고객·회사 관리", calendar: "업무 캘린더", daily: "업무보고", orders: "발주 관리", complaints: "고객 요청·이슈", documents: "문서 라이브러리", manager: "팀 대시보드", info: "설정 및 지원" };
     const customers = [
-      { id: 1, name: "박서준", title: "순환기내과 교수", hospital: "한빛대학교병원", initial: "박", last: "7일 전", next: "오늘 10:30", overdue: false, phone: "02-000-1840", email: "seojun.park@demo.test" },
-      { id: 2, name: "윤가영", title: "간호팀장", hospital: "서림메디컬센터", initial: "윤", last: "2일 전", next: "오늘 14:00", overdue: false, phone: "02-000-2731", email: "gayoung.y@demo.test" },
-      { id: 3, name: "오정민", title: "병원장", hospital: "새봄정형외과", initial: "오", last: "14일 전", next: "일정 등록 필요", overdue: true, phone: "02-000-3677", email: "jm.oh@demo.test" },
-      { id: 4, name: "이민호", title: "구매팀 과장", hospital: "한빛대학교병원", initial: "이", last: "미접촉", next: "8월 12일 추천", overdue: true, phone: "02-000-1098", email: "minho.lee@demo.test" },
-      { id: 5, name: "최수아", title: "의공팀 책임", hospital: "정우병원", initial: "최", last: "5일 전", next: "8월 21일", overdue: false, phone: "02-000-4432", email: "sua.choi@demo.test" }
+      { id: 1, name: "박서준", title: "전략기획실 부장", hospital: "한빛테크", initial: "박", last: "7일 전", next: "오늘 10:30", overdue: false, phone: "02-000-1840", email: "seojun.park@demo.test" },
+      { id: 2, name: "윤가영", title: "운영팀장", hospital: "서림커머스", initial: "윤", last: "2일 전", next: "오늘 14:00", overdue: false, phone: "02-000-2731", email: "gayoung.y@demo.test" },
+      { id: 3, name: "오정민", title: "대표", hospital: "새봄솔루션", initial: "오", last: "14일 전", next: "일정 등록 필요", overdue: true, phone: "02-000-3677", email: "jm.oh@demo.test" },
+      { id: 4, name: "이민호", title: "구매팀 과장", hospital: "한빛테크", initial: "이", last: "미접촉", next: "8월 12일 추천", overdue: true, phone: "02-000-1098", email: "minho.lee@demo.test" },
+      { id: 5, name: "최수아", title: "IT팀 책임", hospital: "정우로지스", initial: "최", last: "5일 전", next: "8월 21일", overdue: false, phone: "02-000-4432", email: "sua.choi@demo.test" }
     ];
     const hospitals = [
-      { id: 1, name: "한빛대학교병원", type: "상급종합병원", region: "서울 동부", owner: "김지훈", last: "7일 전", next: "오늘 10:30", overdue: false, revenue: 50160000, status: "계약 협의", product: "CardioView X7", openGoals: 2 },
-      { id: 2, name: "서림메디컬센터", type: "종합병원", region: "서울 서부", owner: "김지훈", last: "2일 전", next: "오늘 14:00", overdue: false, revenue: 36300000, status: "교육 진행", product: "SonoFlex Pro", openGoals: 1 },
-      { id: 3, name: "새봄정형외과", type: "전문병원", region: "서울 남부", owner: "김지훈", last: "14일 전", next: "일정 등록 필요", overdue: true, revenue: 0, status: "후속 필요", product: "SonoFlex Pro", openGoals: 3 },
-      { id: 4, name: "정우병원", type: "종합병원", region: "경기 북부", owner: "김지훈", last: "5일 전", next: "8월 21일", overdue: false, revenue: 21560000, status: "제품 데모", product: "OrthoScan Mini", openGoals: 2 }
+      { id: 1, name: "한빛테크", type: "대기업", region: "서울 동부", owner: "김지훈", last: "7일 전", next: "오늘 10:30", overdue: false, revenue: 50160000, status: "계약 협의", product: "SalesFlow Enterprise", openGoals: 2 },
+      { id: 2, name: "서림커머스", type: "중견기업", region: "서울 서부", owner: "김지훈", last: "2일 전", next: "오늘 14:00", overdue: false, revenue: 36300000, status: "교육 진행", product: "WorkSync Pro", openGoals: 1 },
+      { id: 3, name: "새봄솔루션", type: "중소기업", region: "서울 남부", owner: "김지훈", last: "14일 전", next: "일정 등록 필요", overdue: true, revenue: 0, status: "후속 필요", product: "WorkSync Pro", openGoals: 3 },
+      { id: 4, name: "정우로지스", type: "중견기업", region: "경기 북부", owner: "김지훈", last: "5일 전", next: "8월 21일", overdue: false, revenue: 21560000, status: "제품 데모", product: "InsightBoard", openGoals: 2 }
     ];
     const teamGoals = [
       { id: 1, title: "실제 구매 승인 담당자 파악", detail: "이름·직책·최종 승인 권한", active: true },
-      { id: 2, title: "평균 의료기기 보유 대수 파악", detail: "현재 수량·3년 내 교체 예정 수량", active: true },
+      { id: 2, title: "예상 사용 규모 파악", detail: "예상 사용자 수·향후 확장 계획", active: true },
       { id: 3, title: "예산 편성·집행 시기 파악", detail: "예산 분기와 집행 가능 시점", active: true },
       { id: 4, title: "다음 행동과 기한 확정", detail: "담당자·일자까지 약속", active: true }
     ];
     const teamState = {
       targets: { "김지훈": 80000000, "이수민": 70000000, "박도윤": 90000000, "최가은": 60000000 },
       confirmedSales: { "김지훈": 52400000, "이수민": 42700000, "박도윤": 66600000, "최가은": 28800000 },
-      notice: { title: "오후 방문 전 계약 조건 확인", body: "오늘 진행하는 모든 병원 미팅에서 예산 집행 시기와 실제 승인 담당자를 우선 확인해 주세요.", time: "08:40" },
+      notice: { title: "오후 방문 전 계약 조건 확인", body: "오늘 진행하는 모든 고객사 미팅에서 예산 집행 시기와 실제 승인 담당자를 우선 확인해 주세요.", time: "08:40" },
       achievedGoalIds: [3, 4],
       meetingGoalRate: 50
     };
     const schedules = [
-      { day: 5, title: "10:30 한빛대병원", type: "visit" },
-      { day: 5, title: "14:00 서림메디컬", type: "visit" },
-      { day: 7, title: "15:00 새봄정형외과", type: "risk" },
+      { day: 5, title: "10:30 한빛테크", type: "visit" },
+      { day: 5, title: "14:00 서림커머스", type: "visit" },
+      { day: 7, title: "15:00 새봄솔루션", type: "risk" },
       { day: 11, title: "비교 견적 전달", type: "" },
       { day: 14, title: "교육 후속 점검", type: "visit" },
       { day: 17, title: "계약 시작 예정", type: "" },
-      { day: 21, title: "정우병원 데모", type: "visit" },
+      { day: 21, title: "정우로지스 데모", type: "visit" },
       { day: 27, title: "월간 팀 회의", type: "" }
     ];
     let activeCustomerId = 1;
@@ -2091,9 +2291,11 @@
     let activeAccountTab = "contacts";
     let overdueOnly = false;
     let currentRole = "manager";
+    let activeManagerTab = "reports";
     let toastTimer;
     let analyzedGoalRate = 50;
     let analyzedOpenGoalCount = 2;
+    let editingScheduleIndex = null;
 
     const won = value => new Intl.NumberFormat("ko-KR", { style: "currency", currency: "KRW", maximumFractionDigits: 0 }).format(value);
     const wonShort = value => `₩${(value / 1000000).toLocaleString("ko-KR", { maximumFractionDigits: 1 })}M`;
@@ -2126,8 +2328,10 @@
       if (name === "manager" && currentRole !== "manager") { toast("팀장 권한이 필요한 메뉴입니다."); name = "dashboard"; }
       location.hash = name;
       $$(".page").forEach(page => page.classList.toggle("active", page.dataset.page === name));
-      $$(".nav-btn").forEach(btn => btn.classList.toggle("active", btn.dataset.route === name));
+      const managerView = activeManagerTab === "team" ? "team" : "reports";
+      $$(".nav-btn").forEach(btn => btn.classList.toggle("active", btn.dataset.route === name && (!btn.dataset.managerView || btn.dataset.managerView === managerView)));
       $("#currentPageName").textContent = pageNames[name];
+      if (name === "manager") setManagerTab(activeManagerTab);
       window.scrollTo({ top: 0, behavior: "smooth" });
       $("#notificationDrawer").classList.remove("open");
     }
@@ -2149,6 +2353,12 @@
       if (dialog?.open) dialog.close();
     }
 
+    function resetScheduleDialog() {
+      editingScheduleIndex = null;
+      $("#scheduleDialogTitle").textContent = "회사 방문 일정 등록";
+      $("#scheduleSubmitButton").textContent = "일정 확정·푸시 예약";
+    }
+
     function renderTeamGoals() {
       const activeGoals = teamGoals.filter(goal => goal.active);
       $("#teamGoalList").innerHTML = teamGoals.map(goal => `<div class="goal-setting-row"><input type="checkbox" ${goal.active ? "checked" : ""} data-team-goal="${goal.id}" aria-label="${goal.title} 활성화"><span><strong>${goal.title}</strong><small>${goal.detail}</small></span><span class="tag-pill">필수</span></div>`).join("");
@@ -2156,7 +2366,7 @@
       const completed = goal => teamState.achievedGoalIds.includes(goal.id);
       const goalHtml = activeGoals.map(goal => `<div class="goal-brief-item ${completed(goal) ? "" : "unmet"}"><span>${goal.title}</span><strong>${completed(goal) ? "이전 달성" : "이번 필수"}</strong></div>`).join("") || `<p class="muted" style="font-size:8px">현재 활성화된 공통 목표가 없습니다.</p>`;
       $("#briefingGoalList").innerHTML = goalHtml;
-      const directive = teamState.achievedGoalIds.includes(1) ? "구매 담당자·예산·기한은 확인했습니다. 다음에는 평균 의료기기 보유 대수와 남은 팀 목표를 확인하세요." : "이전 미팅에서 확인하지 못한 평균 의료기기 보유 대수와 구매 승인 구조를 확인하세요.";
+      const directive = teamState.achievedGoalIds.includes(1) ? "구매 담당자·예산·기한은 확인했습니다. 다음에는 예상 사용 규모와 남은 팀 목표를 확인하세요." : "이전 미팅에서 확인하지 못한 예상 사용 규모와 구매 승인 구조를 확인하세요.";
       $("#briefingNextDirective").textContent = directive;
     }
 
@@ -2174,50 +2384,29 @@
     }
 
     function renderMemberDashboard() {
-      const target = teamState.targets["김지훈"] || 0;
-      const sales = teamState.confirmedSales["김지훈"] || 0;
-      const rate = target > 0 ? Math.min(100, sales / target * 100) : 0;
-      $("#memberSalesPercent").textContent = target ? `${rate.toFixed(1)}%` : "미설정";
-      $("#memberSalesValue").textContent = `${wonShort(sales)} / ${target ? wonShort(target) : "목표 없음"}`;
+      const isManager = currentRole === "manager";
+      const target = isManager ? Object.values(teamState.targets).reduce((sum, value) => sum + value, 0) : teamState.targets["김지훈"];
+      const sales = isManager ? Object.values(teamState.confirmedSales).reduce((sum, value) => sum + value, 0) : teamState.confirmedSales["김지훈"];
+      const rate = target ? Math.min(100, sales / target * 100) : 0;
+      $("#memberSalesScope").textContent = isManager ? "영업 1팀" : "김지훈 · 개인";
+      $("#memberSalesPercent").textContent = `${rate.toFixed(1)}%`;
+      $("#memberSalesValue").textContent = `${wonShort(sales)} / ${wonShort(target)}`;
       $("#memberSalesProgress").style.width = `${rate}%`;
-      $("#memberSalesRemaining").textContent = target ? `목표까지 ${wonShort(Math.max(0, target - sales))} 남았습니다 · 확정 매출 기준` : "팀장이 월 매출 목표를 설정하지 않았습니다.";
       $("#memberNoticeTitle").textContent = teamState.notice.title;
       $("#memberNoticeBody").textContent = teamState.notice.body;
       $("#memberNoticeMeta").textContent = `김서현 팀장 · ${teamState.notice.time}`;
       renderTeamGoals();
-      renderMemberPoSummary();
       if ($("#jihoonGoalRate")) {
         $("#jihoonGoalRate").textContent = `${teamState.meetingGoalRate}%`;
         $("#jihoonGoalBar").style.width = `${teamState.meetingGoalRate}%`;
         $("#issueKpiGoal").textContent = teamState.meetingGoalRate > 50 ? "70%" : "68%";
-        $("#jihoonStatus").textContent = teamState.achievedGoalIds.includes(1) ? "평균 보유 대수 등 남은 목표 미확인" : "결정권자·평균 보유 대수 미확인";
+        $("#jihoonStatus").textContent = teamState.achievedGoalIds.includes(1) ? "예상 사용 규모 등 남은 목표 미확인" : "결정권자·예상 사용 규모 미확인";
       }
     }
 
-    function renderMemberPoSummary() {
-      const card = $("#memberPoSummary");
-      if (!card || typeof purchaseOrders === "undefined") return;
-      const wait = purchaseOrders.filter(order => order.status === "승인대기").length;
-      const ready = purchaseOrders.filter(order => order.status === "출고의뢰서 작성완료").length;
-      const prog = purchaseOrders.filter(order => ["승인", "출고의뢰서 작성완료", "생산중", "출고"].includes(order.status)).length;
-      const week = purchaseOrders.filter(order => order.status !== "입고완료" && order.status !== "취소" && poDday(order) >= 0 && poDday(order) <= 7).length;
-      const late = purchaseOrders.filter(isPoLate).length;
-      card.innerHTML = `
-        <div class="goal-brief-item ${wait ? "unmet" : ""}"><span>승인 대기</span><strong>${wait}건</strong></div>
-        <div class="goal-brief-item"><span>출고의뢰서 처리</span><strong>${ready}건</strong></div>
-        <div class="goal-brief-item"><span>생산·출고 진행 중</span><strong>${prog}건</strong></div>
-        <div class="goal-brief-item"><span>이번 주 입고 예정</span><strong>${week}건</strong></div>
-        <div class="goal-brief-item ${late ? "unmet" : ""}"><span>납기 지연</span><strong>${late}건</strong></div>`;
-      $("#memberPoLateTag").textContent = `${late}건 지연`;
-      $("#memberPoLateTag").className = late ? "tag-pill risk" : "tag-pill";
-      const nextLate = purchaseOrders.find(isPoLate);
-      $("#memberPoDirective").textContent = nextLate
-        ? `${nextLate.no} (${nextLate.hospital}) 납기가 지났습니다 · 공급처 확인이 필요합니다.`
-        : "발주 등록·상태 변경은 발주관리에서 처리하세요.";
-    }
-
     function renderCustomers(query = "") {
-      $("[data-account-tab='contacts']").textContent = `담당 고객 ${customers.length}`;
+      $("[data-account-count='contacts']").textContent = customers.length;
+      $("[data-overdue-count]").textContent = customers.filter(customer => customer.overdue).length + hospitals.filter(hospital => hospital.overdue).length;
       const term = query.trim().toLowerCase();
       const rows = customers.filter(c => `${c.name} ${c.title} ${c.hospital}`.toLowerCase().includes(term) && (!overdueOnly || c.overdue));
       $("#customerList").innerHTML = rows.map(c => `<button class="customer-row ${c.id === activeCustomerId ? "active" : ""}" data-customer-id="${c.id}"><span class="initial">${c.initial}</span><span><strong>${c.name}</strong><span>${c.hospital} · ${c.title}</span></span><span class="last-touch">${c.last}</span></button>`).join("") || `<p class="muted" style="padding:25px;text-align:center">검색 결과가 없습니다.</p>`;
@@ -2228,14 +2417,14 @@
       const c = customers.find(item => item.id === activeCustomerId) || customers[0];
       $("#customerDetail").innerHTML = `
         <div class="customer-cover"><div class="customer-identity"><span class="initial">${c.initial}</span><div><h2>${c.name}</h2><p>${c.hospital} · ${c.title}</p></div></div><div class="customer-actions"><button class="btn btn-small btn-hero-outline" data-detail-action="meeting">미팅 기록</button><button class="btn btn-small btn-lime" data-detail-action="schedule">일정 등록</button></div></div>
-        <div class="customer-summary"><div><small>최근 만남</small><strong>${c.last}</strong></div><div><small>다음 일정</small><strong>${c.next}</strong></div><div><small>소속 병원</small><strong>${c.hospital}</strong></div></div>
+        <div class="customer-summary"><div><small>최근 만남</small><strong>${c.last}</strong></div><div><small>다음 일정</small><strong>${c.next}</strong></div><div><small>소속 회사</small><strong>${c.hospital}</strong></div></div>
         <div class="detail-body"><div class="detail-grid"><section><div class="section-title"><h3>연락 정보</h3></div><div class="match-box"><strong>${c.phone || "연락처 미등록"}</strong><p>${c.email || "이메일 미등록"}</p></div><p class="next-directive">다음 일정: ${c.next}</p></section>
-        <section><div class="section-title"><h3>최근 History</h3></div><div class="history"><div class="history-item"><time>2026.07.29 · 미팅</time><strong>제품 테스트 결과 확인</strong><p>가독성은 긍정적, 유지보수 비용은 추가 설명 요청.</p></div><div class="history-item"><time>2026.07.22 · 견적</time><strong>1차 견적서 전달</strong><p>CardioView X7 2대 · 총액 50,160,000원.</p></div><div class="history-item"><time>2026.07.15 · 방문</time><strong>도입 요구사항 인터뷰</strong><p>순환기센터 확대에 따른 검사 효율화 필요 확인.</p></div></div></section></div></div>`;
+        <section><div class="section-title"><h3>최근 History</h3></div><div class="history"><div class="history-item"><time>2026.07.29 · 미팅</time><strong>제품 테스트 결과 확인</strong><p>가독성은 긍정적, 유지보수 비용은 추가 설명 요청.</p></div><div class="history-item"><time>2026.07.22 · 견적</time><strong>1차 견적서 전달</strong><p>SalesFlow Enterprise 2식 · 총액 50,160,000원.</p></div><div class="history-item"><time>2026.07.15 · 방문</time><strong>도입 요구사항 인터뷰</strong><p>사업부 확대에 따른 업무 효율화 필요 확인.</p></div></div></section></div></div>`;
       $$('[data-detail-action]', $("#customerDetail")).forEach(btn => btn.addEventListener("click", () => openDialog(btn.dataset.detailAction === "meeting" ? "meetingDialog" : "scheduleDialog")));
     }
 
     function renderHospitals(query = "") {
-      $("[data-account-tab='hospitals']").textContent = `담당 병원 ${hospitals.length}`;
+      $("[data-account-count='hospitals']").textContent = hospitals.length;
       const term = query.trim().toLowerCase();
       const rows = hospitals.filter(hospital => `${hospital.name} ${hospital.type} ${hospital.region} ${hospital.product}`.toLowerCase().includes(term) && (!overdueOnly || hospital.overdue));
       $("#hospitalList").innerHTML = rows.map(hospital => `<button class="customer-row ${hospital.id === activeHospitalId ? "active" : ""}" data-hospital-id="${hospital.id}"><span class="initial">${hospital.name[0]}</span><span><strong>${hospital.name}</strong><span>${hospital.type} · ${hospital.region} · ${hospital.owner}</span></span><span class="last-touch">${hospital.status}</span></button>`).join("") || `<p class="muted" style="padding:25px;text-align:center">검색 결과가 없습니다.</p>`;
@@ -2313,50 +2502,102 @@
         else if (routeBtn.dataset.route === "daily" && routeBtn.classList.contains("nav-btn")) setReportTab("daily");
         if (routeBtn.dataset.infoTab) setInfoTab(routeBtn.dataset.infoTab);
         else if (routeBtn.dataset.route === "info" && routeBtn.classList.contains("nav-btn")) setInfoTab("mypage");
+        if (routeBtn.dataset.managerView) setManagerTab(routeBtn.dataset.managerView);
       }
       const openBtn = event.target.closest("[data-open]");
-      if (openBtn) openDialog(openBtn.dataset.open);
+      if (openBtn) {
+        if (openBtn.dataset.open === "scheduleDialog") resetScheduleDialog();
+        openDialog(openBtn.dataset.open);
+      }
       const closeBtn = event.target.closest("[data-close]");
       if (closeBtn) closeDialog(closeBtn.closest("dialog"));
     });
     $("#roleSelect").addEventListener("change", event => updateRole(event.target.value));
     $("#logoutButton").addEventListener("click", () => { $("#app").hidden = true; $("#loginView").hidden = false; location.hash = ""; toast("안전하게 로그아웃했습니다."); });
+    $$(".nav-section-toggle").forEach(toggle => toggle.addEventListener("click", () => {
+      const collapsed = toggle.closest(".nav-section").classList.toggle("is-collapsed");
+      toggle.setAttribute("aria-expanded", String(!collapsed));
+    }));
 
     // Notifications
     $("#notificationButton").addEventListener("click", () => $("#notificationDrawer").classList.add("open"));
     $("#closeDrawer").addEventListener("click", () => $("#notificationDrawer").classList.remove("open"));
     $("#briefingCustomer").addEventListener("change", event => toast(`${event.target.value} 고객 기준으로 브리핑을 전환했습니다.`));
 
-    // News
-    let activeNewsFilter = "all";
-    function filterNews() {
-      const term = $("#newsSearch").value.toLowerCase();
-      $$(".news-card").forEach(card => card.hidden = !((activeNewsFilter === "all" || card.dataset.category === activeNewsFilter) && card.dataset.search.toLowerCase().includes(term)));
-      const visible = group => $$(`#newsSection${group} .news-card`).filter(card => !card.hidden).length;
-      [["News", "newsCountNews", "newsEmptyNews"], ["People", "newsCountPeople", "newsEmptyPeople"]].forEach(([group, countId, emptyId]) => {
-        const count = visible(group);
-        $("#" + countId).textContent = `${count}건`;
-        $("#" + emptyId).hidden = count > 0;
-        $("#newsSection" + group).hidden = activeNewsFilter === "people" ? group !== "People" : activeNewsFilter !== "all" && group !== "News";
+    // Deal pipeline
+    const dealStages = ["lead", "discovery", "proposal", "negotiation", "approval", "won"];
+    const dealProbabilities = { lead: 10, discovery: 30, proposal: 50, negotiation: 70, approval: 85, won: 100 };
+    let activeDealFilter = "all";
+
+    function renderDeals() {
+      const term = $("#dealSearch").value.trim().toLowerCase();
+      const sortBy = $("#dealSort").value;
+      $$("[data-deal-stack]").forEach(stack => [...stack.children]
+        .sort((a, b) => sortBy === "value" ? Number(b.dataset.value) - Number(a.dataset.value) : a.dataset.close.localeCompare(b.dataset.close))
+        .forEach(card => stack.append(card)));
+      const cards = $$("[data-deal-card]");
+      cards.forEach(card => {
+        const filterMatch = activeDealFilter === "all"
+          || activeDealFilter === "open" && !["won", "lost"].includes(card.dataset.stage)
+          || activeDealFilter === "won" && card.dataset.stage === "won"
+          || activeDealFilter === "lost" && card.dataset.stage === "lost"
+          || activeDealFilter === "mine" && card.dataset.owner === "김지훈"
+          || activeDealFilter === "risk" && card.dataset.risk === "true"
+          || activeDealFilter === "month" && !["won", "lost"].includes(card.dataset.stage) && card.dataset.close <= "2026-08-31";
+        card.hidden = !(filterMatch && card.dataset.search.toLowerCase().includes(term));
       });
+      $$("[data-deal-column]").forEach(column => {
+        const visible = $$('[data-deal-card]', column).filter(card => !card.hidden);
+        column.classList.toggle("is-empty", visible.length === 0);
+        $("[data-deal-count]", column).textContent = `${visible.length}건`;
+        $("[data-deal-value]", column).textContent = wonShort(visible.reduce((sum, card) => sum + Number(card.dataset.value), 0));
+      });
+      const open = cards.filter(card => !["won", "lost"].includes(card.dataset.stage));
+      $("#dealMetricOpen").textContent = wonShort(open.reduce((sum, card) => sum + Number(card.dataset.value), 0));
+      $("#dealMetricWeighted").textContent = wonShort(open.reduce((sum, card) => sum + Number(card.dataset.value) * Number(card.dataset.probability) / 100, 0));
+      $("#dealMetricMonth").textContent = wonShort(open.filter(card => card.dataset.close <= "2026-08-31").reduce((sum, card) => sum + Number(card.dataset.value), 0));
+      $("#dealMetricRisk").textContent = `${open.filter(card => card.dataset.risk === "true").length}건`;
     }
-    $$("[data-news-filter]").forEach(chip => chip.addEventListener("click", () => { $$("[data-news-filter]").forEach(c => c.classList.remove("active")); chip.classList.add("active"); activeNewsFilter = chip.dataset.newsFilter; filterNews(); }));
-    $("#newsSearch").addEventListener("input", filterNews);
-    filterNews();
-    $("#refreshNews").addEventListener("click", event => { event.currentTarget.textContent = "갱신 중..."; setTimeout(() => { event.currentTarget.textContent = "✓ 10:31 갱신 완료"; toast("지정 출처의 최신 정보를 확인했습니다."); }, 900); });
+
+    $$("[data-deal-filter]").forEach(chip => chip.addEventListener("click", () => {
+      $$("[data-deal-filter]").forEach(item => item.classList.remove("active"));
+      chip.classList.add("active");
+      activeDealFilter = chip.dataset.dealFilter;
+      renderDeals();
+    }));
+    $("#dealSearch").addEventListener("input", renderDeals);
+    $("#dealSort").addEventListener("change", renderDeals);
+    $("#dealPipeline").addEventListener("click", event => {
+      const move = event.target.closest("[data-deal-move]");
+      if (!move || move.disabled) return;
+      const card = move.closest("[data-deal-card]");
+      const nextIndex = dealStages.indexOf(card.dataset.stage) + Number(move.dataset.dealMove);
+      const nextStage = dealStages[nextIndex];
+      if (!nextStage) return;
+      card.dataset.stage = nextStage;
+      card.dataset.probability = dealProbabilities[nextStage];
+      $(".deal-probability", card).textContent = `${dealProbabilities[nextStage]}%`;
+      $("[data-deal-stack]", $(`[data-deal-column="${nextStage}"]`)).append(card);
+      $("[data-deal-move='-1']", card).disabled = nextIndex === 0;
+      $("[data-deal-move='1']", card).disabled = nextIndex === dealStages.length - 1;
+      renderDeals();
+      toast(`${$("h3", card).textContent} 딜 단계를 변경했습니다.`);
+    });
+    $("#newDealButton").addEventListener("click", () => toast("새 딜 등록 화면은 다음 상세 설계에서 연결합니다."));
+    renderDeals();
 
     // Customer
     $$('[data-account-tab]').forEach(button => button.addEventListener("click", () => {
       activeAccountTab = button.dataset.accountTab;
-      $$('[data-account-tab]').forEach(tab => tab.classList.toggle("active", tab === button));
+      $$('[data-account-tab]').forEach(tab => { tab.classList.toggle("active", tab === button); tab.setAttribute("aria-pressed", String(tab === button)); });
       $$('[data-account-panel]').forEach(panel => panel.classList.toggle("active", panel.dataset.accountPanel === activeAccountTab));
-      $("#customerSearch").placeholder = activeAccountTab === "contacts" ? "고객, 병원, 직책 검색" : "병원명, 유형, 지역, 제품 검색";
+      $("#customerSearch").placeholder = activeAccountTab === "contacts" ? "고객, 회사, 직책 검색" : "회사명, 유형, 지역, 제품 검색";
       $("#customerSearch").value = "";
       activeAccountTab === "contacts" ? renderCustomers() : renderHospitals();
     }));
     $("#customerSearch").addEventListener("input", event => activeAccountTab === "contacts" ? renderCustomers(event.target.value) : renderHospitals(event.target.value));
-    $("#overdueFilter").addEventListener("click", event => { overdueOnly = !overdueOnly; event.currentTarget.classList.toggle("active", overdueOnly); activeAccountTab === "contacts" ? renderCustomers($("#customerSearch").value) : renderHospitals($("#customerSearch").value); toast(overdueOnly ? "후속 일정이 지연된 항목만 표시합니다." : "전체 담당 항목을 표시합니다."); });
-    $("#runOcr").addEventListener("click", () => { $("#customerName").value = "정하린"; $("#customerTitle").value = "의료기기 구매팀 대리"; $("#customerPhone").value = "02-000-1048"; $("#customerEmail").value = "harin.j@demo.test"; toast("명함에서 4개 필드를 추출했습니다. 확인 후 저장하세요."); });
+    $("#overdueFilter").addEventListener("click", event => { overdueOnly = !overdueOnly; event.currentTarget.classList.toggle("active", overdueOnly); event.currentTarget.setAttribute("aria-pressed", String(overdueOnly)); activeAccountTab === "contacts" ? renderCustomers($("#customerSearch").value) : renderHospitals($("#customerSearch").value); toast(overdueOnly ? "후속 일정이 지연된 항목만 표시합니다." : "전체 담당 항목을 표시합니다."); });
+    $("#runOcr").addEventListener("click", () => { $("#customerName").value = "정하린"; $("#customerTitle").value = "구매팀 대리"; $("#customerPhone").value = "02-000-1048"; $("#customerEmail").value = "harin.j@demo.test"; toast("명함에서 4개 필드를 추출했습니다. 확인 후 저장하세요."); });
     $("#customerForm").addEventListener("submit", event => { event.preventDefault(); const name = $("#customerName").value.trim(); const title = $("#customerTitle").value.trim(); if (!name || !title) return; const item = { id: Date.now(), name, title, hospital: $("#customerHospital").value, initial: name[0], last: "신규", next: "미등록", overdue: false, phone: $("#customerPhone").value, email: $("#customerEmail").value }; customers.unshift(item); activeCustomerId = item.id; renderCustomers(); renderCustomerDetail(); renderHospitals(); renderHospitalDetail(); const contactTab = $("[data-account-tab='contacts']"); closeDialog($("#customerDialog")); event.target.reset(); contactTab.click(); toast(`${name} 고객을 사용자 확인값으로 저장했습니다.`); });
     $("#hospitalForm").addEventListener("submit", event => {
       event.preventDefault();
@@ -2371,17 +2612,17 @@
       closeDialog($("#hospitalDialog"));
       $("[data-account-tab='hospitals']").click();
       renderHospitalDetail();
-      toast(`${name}을 담당 병원으로 저장했습니다.`);
+      toast(`${name}을 담당 회사로 저장했습니다.`);
     });
 
     // Calendar
     // Daily report
     let dailyActivities = [
-      { id: "a1", source: "캘린더", title: "10:30 한빛대학교병원 방문", desc: "박서준 교수 · 제품 테스트 결과 확인", on: true },
-      { id: "a2", source: "미팅보고서", title: "한빛대학교병원 미팅 기록 확정", desc: "필수 목표 5개 중 4개 달성 · 유지보수 조건 추가 설명 요청", on: true },
-      { id: "a3", source: "캘린더", title: "14:00 서림메디컬센터 방문", desc: "윤가영 간호팀장 · 사용 교육 일정 협의", on: true },
-      { id: "a4", source: "문서", title: "CardioView X7 견적서 발송", desc: "FM-QT-2026-0812 · 총액 50,160,000원", on: true },
-      { id: "a5", source: "후속", title: "새봄정형외과 후속 방문 미등록", desc: "견적 검토 회신 예정일 2일 경과", on: false }
+      { id: "a1", source: "캘린더", title: "10:30 한빛테크 방문", desc: "박서준 부장 · 제품 테스트 결과 확인", on: true },
+      { id: "a2", source: "미팅보고서", title: "한빛테크 미팅 기록 확정", desc: "필수 목표 5개 중 4개 달성 · 유지보수 조건 추가 설명 요청", on: true },
+      { id: "a3", source: "캘린더", title: "14:00 서림커머스 방문", desc: "윤가영 운영팀장 · 사용 교육 일정 협의", on: true },
+      { id: "a4", source: "문서", title: "SalesFlow Enterprise 견적서 발송", desc: "SL-QT-2026-0812 · 총액 50,160,000원", on: true },
+      { id: "a5", source: "후속", title: "새봄솔루션 후속 방문 미등록", desc: "견적 검토 회신 예정일 2일 경과", on: false }
     ];
     let dailyManual = [];
     let dailySubmitted = false;
@@ -2451,7 +2692,7 @@
 
     $("#dailyReload").addEventListener("click", () => {
       $("#dailySummary").value = dailyDraftSummary();
-      $("#dailyNext").value = "새봄정형외과 후속 방문 일정 등록, 한빛대학교병원 유지보수 조건 자료 회신";
+      $("#dailyNext").value = "새봄솔루션 후속 방문 일정 등록, 한빛테크 유지보수 조건 자료 회신";
       dailySubmitted = false;
       renderDaily();
       toast("캘린더와 확정 미팅보고서에서 초안을 다시 불러왔습니다.");
@@ -2472,7 +2713,7 @@
     });
 
     $("#dailySummary").value = dailyDraftSummary();
-    $("#dailyNext").value = "새봄정형외과 후속 방문 일정 등록, 한빛대학교병원 유지보수 조건 자료 회신";
+    $("#dailyNext").value = "새봄솔루션 후속 방문 일정 등록, 한빛테크 유지보수 조건 자료 회신";
     renderDaily();
 
     // Report tabs (일간 / 주간 / 월간)
@@ -2482,11 +2723,11 @@
       monthly: { title: "월간업무 분석", eyebrow: "Monthly report", desc: "주간업무 분석 결과를 자동으로 모아 이번 달 실적을 보여줍니다." }
     };
     const weeklyRollup = [
-      { day: "월 8/3", activity: "정우병원 제품 데모 준비", visits: "1곳", submitted: true, summary: "정우병원 최수아 의공팀 책임 대상 제품 데모 사전 점검 완료", issue: "" },
-      { day: "화 8/4", activity: "한빛대학교병원 사전 미팅", visits: "2곳", submitted: true, summary: "한빛대학교병원 박서준 교수 사전 미팅, CardioView X7 제안 방향 확정", issue: "" },
-      { day: "수 8/5", activity: "한빛대학교병원 · 서림메디컬센터", visits: "2곳", submitted: false, summary: "", issue: "" },
-      { day: "목 8/6", activity: "예정 없음", visits: "0곳", submitted: false, summary: "", issue: "새봄정형외과 후속 방문 일정 미등록 (2일 지연)" },
-      { day: "금 8/7", activity: "새봄정형외과 후속 방문(권장)", visits: "1곳", submitted: false, summary: "", issue: "" }
+      { day: "월 8/3", activity: "정우로지스 제품 데모 준비", visits: "1곳", submitted: true, summary: "정우로지스 최수아 IT팀 책임 대상 제품 데모 사전 점검 완료", issue: "" },
+      { day: "화 8/4", activity: "한빛테크 사전 미팅", visits: "2곳", submitted: true, summary: "한빛테크 박서준 부장 사전 미팅, SalesFlow Enterprise 제안 방향 확정", issue: "" },
+      { day: "수 8/5", activity: "한빛테크 · 서림커머스", visits: "2곳", submitted: false, summary: "", issue: "" },
+      { day: "목 8/6", activity: "예정 없음", visits: "0곳", submitted: false, summary: "", issue: "새봄솔루션 후속 방문 일정 미등록 (2일 지연)" },
+      { day: "금 8/7", activity: "새봄솔루션 후속 방문(권장)", visits: "1곳", submitted: false, summary: "", issue: "" }
     ];
     const monthlyRollup = [
       { week: "1주차 (8/3~8/7)", visits: "9건", revenue: "₩18.2M", contracts: "1건", note: "정상 진행", status: "제출완료" },
@@ -2618,12 +2859,58 @@
       toast(conflicts.length ? `연차를 등록했습니다. 기간 내 기존 일정 ${conflicts.length}건은 재조정이 필요합니다.` : `${label} ${deduct}일을 등록하고 결재를 요청했습니다.`);
     });
 
-    $("#scheduleForm").addEventListener("submit", event => { event.preventDefault(); const date = new Date(`${$("#scheduleDate").value}T00:00:00`); const day = date.getDate(); const hospital = $("#scheduleHospital").value; const time = $("#scheduleTime").value; schedules.push({ day, title: `${time} ${hospital.replace("대학교병원", "대병원").replace("메디컬센터", "메디컬")}`, type: "visit" }); renderCalendar(); closeDialog($("#scheduleDialog")); addNotification("방문 일정이 등록됐습니다", `${date.getMonth() + 1}월 ${day}일 ${time} · ${hospital} · 방문 전 브리핑이 미리 생성됩니다.`); toast("일정을 확정하고 방문 전 푸시 알림을 예약했습니다."); });
+    $("#scheduleForm").addEventListener("submit", event => {
+      event.preventDefault();
+      const date = new Date(`${$("#scheduleDate").value}T00:00:00`);
+      const day = date.getDate();
+      const company = $("#scheduleHospital").value;
+      const customer = $("#scheduleCustomer").value;
+      const purpose = $("#schedulePurpose").value;
+      const time = $("#scheduleTime").value;
+      if (editingScheduleIndex !== null) {
+        const item = todaySchedules[editingScheduleIndex];
+        item.time = time;
+        item.title = company;
+        item.meta = `${customer} · ${purpose}`;
+        renderTodaySchedule();
+        resetScheduleDialog();
+        closeDialog($("#scheduleDialog"));
+        toast("오늘 일정을 수정했습니다.");
+        return;
+      }
+      schedules.push({ day, title: `${time} ${company}`, type: "visit" });
+      renderCalendar();
+      closeDialog($("#scheduleDialog"));
+      addNotification("방문 일정이 등록됐습니다", `${date.getMonth() + 1}월 ${day}일 ${time} · ${company} · 방문 전 브리핑이 미리 생성됩니다.`);
+      toast("일정을 확정하고 방문 전 푸시 알림을 예약했습니다.");
+    });
     $$(".approve-rec").forEach(btn => btn.addEventListener("click", () => { const item = btn.closest(".recommend-item"); schedules.push({ day: schedules.length === 8 ? 7 : 12, title: item.querySelector("strong").textContent, type: "visit" }); renderCalendar(); item.remove(); toast("추천 일정을 사용자 승인 후 캘린더에 등록했습니다."); }));
     $$(".hold-rec").forEach(btn => btn.addEventListener("click", () => { btn.closest(".recommend-item").style.opacity = ".45"; btn.closest(".rec-actions").innerHTML = '<span class="tag-pill">보류됨</span>'; toast("추천 일정을 보류했습니다."); }));
     // Meeting
     $("#analyzeMeeting").addEventListener("click", () => { $("#meetingLoader").classList.add("show"); $("#meetingResult").classList.remove("show"); $("#confirmMeeting").disabled = true; setTimeout(() => { renderMeetingGoalAnalysis(); $("#meetingLoader").classList.remove("show"); $("#meetingResult").classList.add("show"); $("#confirmMeeting").disabled = false; toast("원문 근거와 활성 팀 목표를 함께 대조했습니다."); }, 1100); });
-    $("#confirmMeeting").addEventListener("click", () => { const activeGoals = teamGoals.filter(goal => goal.active); teamState.meetingGoalRate = analyzedGoalRate; teamState.achievedGoalIds = activeGoals.filter(goal => [1, 3, 4].includes(goal.id)).map(goal => goal.id); const hanbit = hospitals.find(hospital => hospital.name === "한빛대학교병원"); if (hanbit) { hanbit.openGoals = analyzedOpenGoalCount; hanbit.last = "방금"; } renderMemberDashboard(); renderHospitals(); renderHospitalDetail(); addDocument("report", "한빛대학교병원 미팅보고서", "박서준 교수"); closeDialog($("#meetingDialog")); $("#meetingResult").classList.remove("show"); $("#confirmMeeting").disabled = true; const achievedCount = activeGoals.length - analyzedOpenGoalCount; addNotification("미팅보고서가 확정됐습니다", `필수 목표 ${activeGoals.length}개 중 ${achievedCount}개를 달성했습니다. 미완료 ${analyzedOpenGoalCount}개는 다음 미팅 지시 초안으로 이월했습니다.`); toast("미팅 목표 결과를 확정하고 미완료 항목을 다음 지시로 이월했습니다."); });
+    $("#confirmMeeting").addEventListener("click", () => {
+      const activeGoals = teamGoals.filter(goal => goal.active);
+      teamState.meetingGoalRate = analyzedGoalRate;
+      teamState.achievedGoalIds = activeGoals.filter(goal => [1, 3, 4].includes(goal.id)).map(goal => goal.id);
+      const hanbit = hospitals.find(hospital => hospital.name === "한빛테크");
+      if (hanbit) { hanbit.openGoals = analyzedOpenGoalCount; hanbit.last = "방금"; }
+      if (reportScheduleIndex !== null) {
+        todaySchedules[reportScheduleIndex].completed = true;
+        todayScheduleIndex = reportScheduleIndex;
+        reportScheduleIndex = null;
+        renderTodaySchedule();
+      }
+      renderMemberDashboard();
+      renderHospitals();
+      renderHospitalDetail();
+      addDocument("report", "한빛테크 미팅보고서", "박서준 부장");
+      closeDialog($("#meetingDialog"));
+      $("#meetingResult").classList.remove("show");
+      $("#confirmMeeting").disabled = true;
+      const achievedCount = activeGoals.length - analyzedOpenGoalCount;
+      addNotification("미팅보고서가 확정됐습니다", `필수 목표 ${activeGoals.length}개 중 ${achievedCount}개를 달성했습니다. 미완료 ${analyzedOpenGoalCount}개는 다음 미팅 지시 초안으로 이월했습니다.`);
+      toast("업무보고서를 확정하고 오늘 일정을 완료했습니다.");
+    });
 
     // Documents
     let activeDocFilter = "all";
@@ -2634,17 +2921,17 @@
     // Purchase order
     const TODAY_PO = "2026-08-05";
     const poContracts = [
-      { id: "FM-CT-2026-0038", hospital: "새봄정형외과", product: "SonoFlex Pro", qty: 1, price: 28400000 },
-      { id: "FM-CT-2026-0035", hospital: "한빛대학교병원", product: "CardioView X7", qty: 2, price: 24000000 },
-      { id: "FM-CT-2026-0031", hospital: "서림메디컬센터", product: "OrthoScan Mini", qty: 3, price: 8600000 },
-      { id: "", hospital: "직접 입력 (계약 없음)", product: "CardioView X7", qty: 1, price: 24000000 }
+      { id: "SL-CT-2026-0038", hospital: "새봄솔루션", product: "WorkSync Pro", qty: 1, price: 28400000 },
+      { id: "SL-CT-2026-0035", hospital: "한빛테크", product: "SalesFlow Enterprise", qty: 2, price: 24000000 },
+      { id: "SL-CT-2026-0031", hospital: "서림커머스", product: "InsightBoard", qty: 3, price: 8600000 },
+      { id: "", hospital: "직접 입력 (계약 없음)", product: "SalesFlow Enterprise", qty: 1, price: 24000000 }
     ];
     const poStatusClass = { "승인대기": "po-wait", "승인": "po-prog", "출고의뢰서 작성완료": "po-prog", "생산중": "po-prog", "출고": "po-prog", "입고완료": "po-done", "취소": "draft" };
     let purchaseOrders = [
-      { no: "FM-PO-2026-0021", contract: "FM-CT-2026-0038", hospital: "새봄정형외과", supplier: "본사 생산팀", ordered: "2026-08-01", due: "2026-08-08", expect: "2026-08-07", arrival: "", status: "출고", memo: "설치 공간 사전 확인 완료", items: [{ product: "SonoFlex Pro", qty: 1, price: 28400000 }] },
-      { no: "FM-PO-2026-0020", contract: "FM-CT-2026-0035", hospital: "한빛대학교병원", supplier: "본사 생산팀", ordered: "2026-07-28", due: "2026-08-04", expect: "2026-08-03", arrival: "", status: "생산중", memo: "분할 납품 1차", items: [{ product: "CardioView X7", qty: 2, price: 24000000 }] },
-      { no: "FM-PO-2026-0019", contract: "FM-CT-2026-0031", hospital: "서림메디컬센터", supplier: "외부 벤더 (메디파츠)", ordered: "2026-07-20", due: "2026-07-31", expect: "2026-07-30", arrival: "2026-07-29", status: "입고완료", memo: "", items: [{ product: "OrthoScan Mini", qty: 3, price: 8600000 }] },
-      { no: "FM-PO-2026-0022", contract: "", hospital: "한빛대학교병원", supplier: "외부 벤더 (한성의료기)", ordered: "2026-08-04", due: "2026-08-18", expect: "2026-08-20", arrival: "", status: "승인대기", memo: "소모품 선발주", items: [{ product: "전극 패드 (소모품)", qty: 40, price: 32000 }] }
+      { no: "SL-PO-2026-0021", contract: "SL-CT-2026-0038", hospital: "새봄솔루션", supplier: "본사 생산팀", ordered: "2026-08-01", due: "2026-08-08", expect: "2026-08-07", arrival: "", status: "출고", memo: "설치 공간 사전 확인 완료", items: [{ product: "WorkSync Pro", qty: 1, price: 28400000 }] },
+      { no: "SL-PO-2026-0020", contract: "SL-CT-2026-0035", hospital: "한빛테크", supplier: "본사 생산팀", ordered: "2026-07-28", due: "2026-08-04", expect: "2026-08-03", arrival: "", status: "생산중", memo: "분할 납품 1차", items: [{ product: "SalesFlow Enterprise", qty: 2, price: 24000000 }] },
+      { no: "SL-PO-2026-0019", contract: "SL-CT-2026-0031", hospital: "서림커머스", supplier: "외부 벤더 (파인파트너스)", ordered: "2026-07-20", due: "2026-07-31", expect: "2026-07-30", arrival: "2026-07-29", status: "입고완료", memo: "", items: [{ product: "InsightBoard", qty: 3, price: 8600000 }] },
+      { no: "SL-PO-2026-0022", contract: "", hospital: "한빛테크", supplier: "외부 벤더 (한성솔루션)", ordered: "2026-08-04", due: "2026-08-18", expect: "2026-08-20", arrival: "", status: "승인대기", memo: "추가 라이선스 선발주", items: [{ product: "사용자 라이선스 추가", qty: 40, price: 32000 }] }
     ];
     let activePoFilter = "all";
     let poItems = [];
@@ -2723,7 +3010,7 @@
       const contract = poContracts[Number($("#poContract").value)];
       $("#poHospital").value = contract.id ? contract.hospital : "";
       $("#poHospital").readOnly = Boolean(contract.id);
-      $("#poHospital").placeholder = contract.id ? "" : "병원명을 입력하세요";
+      $("#poHospital").placeholder = contract.id ? "" : "회사명을 입력하세요";
       poItems = [{ product: contract.product, qty: contract.qty, price: contract.price }];
       renderPoItems();
     }
@@ -2755,10 +3042,10 @@
       if (poItems.length === 0) { toast("발주 품목을 1건 이상 추가하세요."); return; }
       if (poItems.some(item => !item.product.trim())) { toast("품목의 제품명을 입력하세요."); return; }
       const hospital = $("#poHospital").value.trim();
-      if (!hospital) { toast("납품 병원을 입력하세요."); return; }
+      if (!hospital) { toast("납품처를 입력하세요."); return; }
       const contract = poContracts[Number($("#poContract").value)];
       const order = {
-        no: `FM-PO-2026-${String(23 + purchaseOrders.length - 4).padStart(4, "0")}`,
+        no: `SL-PO-2026-${String(23 + purchaseOrders.length - 4).padStart(4, "0")}`,
         contract: contract.id,
         hospital,
         supplier: $("#poSupplier").value,
@@ -2824,12 +3111,12 @@
     });
 
     $("#poExport").addEventListener("click", () => {
-      const header = ["발주번호", "병원", "계약", "공급처", "제품", "수량", "금액", "발주일", "예상입고일", "상태"];
+      const header = ["발주번호", "회사", "계약", "공급처", "제품", "수량", "금액", "발주일", "예상입고일", "상태"];
       const lines = purchaseOrders.flatMap(order => order.items.map(item => [order.no, order.hospital, order.contract || "선발주", order.supplier, item.product, item.qty, item.qty * item.price, order.ordered, order.expect, isPoLate(order) ? "지연" : order.status].join(",")));
       const url = URL.createObjectURL(new Blob(["\uFEFF" + [header.join(","), ...lines].join("\n")], { type: "text/csv;charset=utf-8" }));
       const link = document.createElement("a");
       link.href = url;
-      link.download = "fieldmed-purchase-orders.csv";
+      link.download = "salesluv-purchase-orders.csv";
       document.body.appendChild(link);
       link.click();
       link.remove();
@@ -2841,10 +3128,10 @@
 
     // Customer complaints (C/S)
     let complaints = [
-      { id: "CS-2026-0041", hospital: "새봄정형외과", contact: "오정민 원장", title: "SonoFlex Pro 초기 캘리브레이션 오류", desc: "설치 직후 초기 캘리브레이션 단계에서 오류 메시지가 반복 발생한다는 문의입니다.", priority: "긴급", status: "미응답", owner: "김지훈", receivedAt: "2026.08.05 09:40", response: "" },
-      { id: "CS-2026-0040", hospital: "한빛대학교병원", contact: "박서준 교수", title: "유지보수 방문 일정 지연 문의", desc: "예정된 유지보수 방문이 지연되는 사유를 확인해 달라는 요청입니다.", priority: "일반", status: "미응답", owner: "김지훈", receivedAt: "2026.08.04 16:20", response: "" },
-      { id: "CS-2026-0039", hospital: "서림메디컬센터", contact: "윤가영 간호팀장", title: "사용 교육 자료 오탈자 확인 요청", desc: "배포된 사용 교육 자료 3페이지에 오탈자가 있다는 제보입니다.", priority: "일반", status: "처리중", owner: "이수민", receivedAt: "2026.08.03 11:05", response: "자료 수정본 준비 중이며 8/6까지 재배포 예정임을 안내했습니다." },
-      { id: "CS-2026-0038", hospital: "정우병원", contact: "최수아 의공팀 책임", title: "CardioView X7 소모품 재고 문의", desc: "소모품 재고 상황과 재주문 절차를 문의했습니다.", priority: "일반", status: "처리중", owner: "박도윤", receivedAt: "2026.08.02 14:15", response: "발주관리에서 재고 확인 후 회신 예정임을 안내했습니다." }
+      { id: "CS-2026-0041", hospital: "새봄솔루션", contact: "오정민 대표", title: "WorkSync Pro 초기 설정 오류", desc: "설치 직후 초기 캘리브레이션 단계에서 오류 메시지가 반복 발생한다는 문의입니다.", priority: "긴급", status: "미응답", owner: "김지훈", receivedAt: "2026.08.05 09:40", response: "" },
+      { id: "CS-2026-0040", hospital: "한빛테크", contact: "박서준 부장", title: "유지보수 방문 일정 지연 문의", desc: "예정된 유지보수 방문이 지연되는 사유를 확인해 달라는 요청입니다.", priority: "일반", status: "미응답", owner: "김지훈", receivedAt: "2026.08.04 16:20", response: "" },
+      { id: "CS-2026-0039", hospital: "서림커머스", contact: "윤가영 운영팀장", title: "사용 교육 자료 오탈자 확인 요청", desc: "배포된 사용 교육 자료 3페이지에 오탈자가 있다는 제보입니다.", priority: "일반", status: "처리중", owner: "이수민", receivedAt: "2026.08.03 11:05", response: "자료 수정본 준비 중이며 8/6까지 재배포 예정임을 안내했습니다." },
+      { id: "CS-2026-0038", hospital: "정우로지스", contact: "최수아 IT팀 책임", title: "SalesFlow Enterprise 소모품 재고 문의", desc: "소모품 재고 상황과 재주문 절차를 문의했습니다.", priority: "일반", status: "처리중", owner: "박도윤", receivedAt: "2026.08.02 14:15", response: "발주관리에서 재고 확인 후 회신 예정임을 안내했습니다." }
     ];
     let activeCsFilter = "all";
     let csDetailTarget = null;
@@ -2946,54 +3233,105 @@
 
     renderCsList();
 
-    // Next hospital briefing — paging
-    const heroBriefings = [
+    // Today's schedule — card paging and report completion
+    const todaySchedules = [
       {
-        time: "10:30 · 1시간 20분 후",
-        title: "한빛대학교병원",
-        meta: "순환기내과 · 박서준 교수 외 2명 · CardioView X7 도입 협의",
-        summary: `지난 미팅에서 제품 테스트는 긍정적이었지만 <mark>구매팀 담당자</mark>와 <mark>예산 편성 시기</mark>가 확인되지 않았습니다. 오늘은 구매 절차를 확인하고 유지보수 비용 비교표를 제시하세요.`
+        time: "10:30",
+        timing: "1시간 20분 후",
+        title: "한빛테크",
+        meta: "박서준 부장 외 2명 · SalesFlow Enterprise 도입 협의 · 본사 3층",
+        briefing: `제품 테스트는 긍정적이었지만 <mark>구매팀 담당자</mark>와 <mark>예산 편성 시기</mark>가 미확인입니다. 비교 견적서와 유지보수 범위표를 준비하세요.`,
+        history: "7일 전 제품 테스트를 진행했고 화면 가독성은 긍정적이었습니다. 유지보수 비용 설명을 요청받았습니다.",
+        completed: false
       },
       {
-        time: "14:00 · 오늘 두 번째 방문",
-        title: "서림메디컬센터",
-        meta: "간호부 · 윤가영 간호팀장 · SonoFlex Pro 사용 교육",
-        summary: `지난 방문에서 <mark>사용 교육 자료</mark> 준비를 완료했습니다. 오늘은 현장 적용 상태를 확인하고 <mark>후속 점검 일정</mark>을 제안하세요.`
+        time: "14:00",
+        timing: "오늘 두 번째 방문",
+        title: "서림커머스",
+        meta: "윤가영 운영팀장 · WorkSync Pro 사용 교육 · 교육실",
+        briefing: `교육 자료는 준비됐습니다. <mark>현장 적용 상태</mark>와 <mark>후속 점검 일정</mark>을 확인하세요.`,
+        history: "2일 전 사용 교육 범위와 참석자를 확정했습니다. 운영팀의 정착 지원 요청이 있었습니다.",
+        completed: false
       },
       {
-        time: "지연 2일 · 일정 미등록",
-        title: "새봄정형외과",
-        meta: "정형외과 · 오정민 원장 · SonoFlex Pro 후속 협의",
-        summary: `<mark>견적 검토 회신 예정일</mark>이 2일 지났습니다. 구매 절차 확인을 위한 방문 일정을 이번 주 안에 등록하세요.`
+        time: "16:30",
+        timing: "오늘 세 번째 방문",
+        title: "정우로지스",
+        meta: "최수아 IT팀 책임 · InsightBoard 제품 데모 · 회의실",
+        briefing: `보안 요구사항 확인이 남았습니다. <mark>데이터 접근 권한</mark>과 도입 승인 절차를 확인하세요.`,
+        history: "5일 전 첫 미팅에서 제품 데모를 요청받았고 기존 시스템 연동 범위를 논의했습니다.",
+        completed: false
       }
     ];
-    let heroBriefIndex = 0;
+    let todayScheduleIndex = 0;
+    let reportScheduleIndex = null;
 
-    function renderHeroBriefing() {
-      const item = heroBriefings[heroBriefIndex];
-      $("#briefHeroTime").innerHTML = `<i class="pulse-dot"></i> ${item.time}`;
-      $("#briefHeroTitle").textContent = item.title;
-      $("#briefHeroMeta").textContent = item.meta;
-      $("#briefHeroSummary").innerHTML = item.summary;
-      $("#briefHeroDots").innerHTML = heroBriefings.map((_, i) => `<span class="${i === heroBriefIndex ? "active" : ""}"></span>`).join("");
+    function renderTodaySchedule() {
+      const item = todaySchedules[todayScheduleIndex];
+      const completedCount = todaySchedules.filter(schedule => schedule.completed).length;
+      $("#todayScheduleProgress").textContent = `${todayScheduleIndex + 1} / ${todaySchedules.length} · 완료 ${completedCount}건`;
+      $("#todayScheduleCard").classList.toggle("completed", item.completed);
+      $("#todayScheduleCard").innerHTML = `
+        <button class="btn btn-small btn-outline schedule-edit" type="button" data-schedule-edit>수정</button>
+        <div class="schedule-card-head">
+          <span class="schedule-status">${item.completed ? "업무보고 완료" : `${item.time} · ${item.timing}`}</span>
+          <h2>${item.title}</h2>
+          <p>${item.meta}</p>
+        </div>
+        <div class="schedule-insights">
+          <section class="schedule-insight">
+            <div class="schedule-insight-head"><h3>AI 미팅 브리핑</h3><button class="link-btn" type="button" data-open="briefingDialog">전체 보기 →</button></div>
+            <p>${item.briefing}</p>
+          </section>
+          <section class="schedule-insight">
+            <div class="schedule-insight-head"><h3>고객 히스토리</h3><button class="link-btn" type="button" data-route="customers">상세 보기 →</button></div>
+            <p>${item.history}</p>
+          </section>
+        </div>
+        <div class="schedule-card-foot">
+          <div class="schedule-dots" aria-label="일정 ${todayScheduleIndex + 1} / ${todaySchedules.length}">${todaySchedules.map((_, index) => `<span class="${index === todayScheduleIndex ? "active" : ""}"></span>`).join("")}</div>
+          <button class="btn btn-primary" type="button" ${item.completed ? 'data-route="daily"' : "data-schedule-report"}>${item.completed ? "완료된 업무보고서 보기" : "업무보고서 작성"}</button>
+        </div>`;
     }
-    $("#briefHeroNext").addEventListener("click", () => {
-      heroBriefIndex = (heroBriefIndex + 1) % heroBriefings.length;
-      renderHeroBriefing();
+    $("#todaySchedulePrev").addEventListener("click", () => {
+      todayScheduleIndex = (todayScheduleIndex - 1 + todaySchedules.length) % todaySchedules.length;
+      renderTodaySchedule();
     });
-    renderHeroBriefing();
+    $("#todayScheduleNext").addEventListener("click", () => {
+      todayScheduleIndex = (todayScheduleIndex + 1) % todaySchedules.length;
+      renderTodaySchedule();
+    });
+    $("#todayScheduleCard").addEventListener("click", event => {
+      if (event.target.closest("[data-schedule-edit]")) {
+        const item = todaySchedules[todayScheduleIndex];
+        const [customer, purpose] = item.meta.split(" · ");
+        editingScheduleIndex = todayScheduleIndex;
+        $("#scheduleDialogTitle").textContent = "오늘 방문 일정 수정";
+        $("#scheduleSubmitButton").textContent = "수정 내용 저장";
+        $("#scheduleHospital").value = item.title;
+        $("#scheduleCustomer").value = customer;
+        $("#scheduleDate").value = "2026-08-05";
+        $("#scheduleTime").value = item.time;
+        $("#schedulePurpose").value = purpose;
+        return openDialog("scheduleDialog");
+      }
+      if (!event.target.closest("[data-schedule-report]")) return;
+      reportScheduleIndex = todayScheduleIndex;
+      openDialog("meetingDialog");
+    });
+    renderTodaySchedule();
 
     // Document library
     const libCategories = { catalog: ["제품자료", "CT"], price: ["가격·정책", "PR"], cert: ["인허가·인증", "CF"], form: ["표준양식", "FM"], edu: ["교육자료", "ED"] };
     const libStatusLabel = { "": "최신", draft: "갱신 예정", signing: "개정 검토 중" };
     let libraryDocs = [
-      { id: 1, cat: "catalog", title: "CardioView X7 제품 카탈로그", desc: "사양표·설치 조건 포함", product: "CardioView X7", version: "v3.2", owner: "김서현", size: "8.4MB", ext: "PDF", date: "2026.07.28", state: "", scope: "영업본부 전체", downloads: 42, mine: false },
-      { id: 2, cat: "catalog", title: "SonoFlex Pro 제품 소개서", desc: "경쟁 제품 비교표 포함", product: "SonoFlex Pro", version: "v2.0", owner: "이도현", size: "6.1MB", ext: "PDF", date: "2026.06.15", state: "", scope: "영업본부 전체", downloads: 27, mine: false },
+      { id: 1, cat: "catalog", title: "SalesFlow Enterprise 제품 카탈로그", desc: "사양표·설치 조건 포함", product: "SalesFlow Enterprise", version: "v3.2", owner: "김서현", size: "8.4MB", ext: "PDF", date: "2026.07.28", state: "", scope: "영업본부 전체", downloads: 42, mine: false },
+      { id: 2, cat: "catalog", title: "WorkSync Pro 제품 소개서", desc: "경쟁 제품 비교표 포함", product: "WorkSync Pro", version: "v2.0", owner: "이도현", size: "6.1MB", ext: "PDF", date: "2026.06.15", state: "", scope: "영업본부 전체", downloads: 27, mine: false },
       { id: 3, cat: "price", title: "2026 하반기 표준 가격표", desc: "할인 승인 한도·팀장 승인 기준", product: "전 제품", version: "v1.4", owner: "김서현", size: "612KB", ext: "XLSX", date: "2026.07.01", state: "", scope: "영업본부 전체", downloads: 88, mine: false },
-      { id: 4, cat: "cert", title: "CardioView X7 의료기기 허가증", desc: "입찰 제출용 사본", product: "CardioView X7", version: "v1.0", owner: "박민재", size: "1.2MB", ext: "PDF", date: "2026.05.20", state: "draft", scope: "영업본부 전체", downloads: 19, mine: false },
+      { id: 4, cat: "cert", title: "SalesFlow Enterprise 보안 인증서", desc: "입찰 제출용 사본", product: "SalesFlow Enterprise", version: "v1.0", owner: "박민재", size: "1.2MB", ext: "PDF", date: "2026.05.20", state: "draft", scope: "영업본부 전체", downloads: 19, mine: false },
       { id: 5, cat: "form", title: "표준 공급계약서 양식", desc: "법무 검토 완료본 · 수정 시 재검토 필요", product: "계약", version: "v2.1", owner: "법무팀", size: "340KB", ext: "DOCX", date: "2026.04.10", state: "", scope: "영업본부 전체", downloads: 55, mine: false },
       { id: 6, cat: "form", title: "견적서 표준 양식", desc: "리포트 라이브러리 자동 생성과 동일 양식", product: "견적", version: "v2.1", owner: "법무팀", size: "285KB", ext: "XLSX", date: "2026.04.10", state: "", scope: "영업본부 전체", downloads: 61, mine: false },
-      { id: 7, cat: "edu", title: "SonoFlex Pro 사용 교육 자료", desc: "현장 교육 슬라이드 32매", product: "SonoFlex Pro", version: "v1.3", owner: "이도현", size: "22.7MB", ext: "PPTX", date: "2026.03.22", state: "signing", scope: "영업 1팀", downloads: 14, mine: false },
+      { id: 7, cat: "edu", title: "WorkSync Pro 사용 교육 자료", desc: "현장 교육 슬라이드 32매", product: "WorkSync Pro", version: "v1.3", owner: "이도현", size: "22.7MB", ext: "PPTX", date: "2026.03.22", state: "signing", scope: "영업 1팀", downloads: 14, mine: false },
       { id: 8, cat: "edu", title: "영업 프로세스 온보딩 가이드", desc: "방문·보고·견적 절차 요약", product: "공통", version: "v1.1", owner: "김서현", size: "3.8MB", ext: "PDF", date: "2026.02.05", state: "", scope: "영업본부 전체", downloads: 33, mine: false }
     ];
     let activeLibFilter = "all";
@@ -3032,7 +3370,7 @@
 
     function downloadLibraryDoc(doc) {
       const body = [
-        `FieldMed 공통 문서 라이브러리`,
+        `SalesLuv 공통 문서 라이브러리`,
         `자료명: ${doc.title} (${doc.version})`,
         `분류: ${libCategories[doc.cat][0]} · ${doc.product}`,
         `등록자: ${doc.owner} · ${doc.date} · ${doc.ext} ${doc.size}`,
@@ -3073,7 +3411,7 @@
       if (action === "share") {
         shareTargetId = id;
         $("#shareDocTitle").textContent = `${doc.title} 공유`;
-        $("#shareLink").value = `https://fieldmed.demo/library/${doc.id}?v=${doc.version.replace(".", "-")}`;
+        $("#shareLink").value = `https://salesluv.demo/library/${doc.id}?v=${doc.version.replace(".", "-")}`;
         openDialog("libShareDialog");
       }
       if (action === "delete") {
@@ -3163,14 +3501,21 @@
 
     renderLibrary();
 
-    // Publication
+    $$("[data-library-tab]").forEach(tab => tab.addEventListener("click", () => {
+      const misc = tab.dataset.libraryTab === "misc";
+      $$("[data-library-tab]").forEach(item => { item.classList.toggle("active", item === tab); item.setAttribute("aria-selected", String(item === tab)); });
+      $("#sharedLibraryPanel").hidden = misc;
+      $("#miscLibraryPanel").hidden = !misc;
+    }));
+
+    // Miscellaneous documents
     let publications = [
-      { id: 1, title: "CardioView X7 임상 적용 사례: 대학병원 순환기내과 도입 결과", author: "김민석 외 3인", journal: "대한심장학회지", date: "2026.03.12", product: "CardioView X7", summary: "3차 대학병원 도입 6개월 결과, 진단 소요시간 단축과 판독 일치도 향상을 보고", downloads: 24, star: true },
-      { id: 2, title: "SonoFlex Pro 초음파 진단 정확도 비교 연구", author: "이하은 외 2인", journal: "Journal of Medical Imaging", date: "2025.11.02", product: "SonoFlex Pro", summary: "기존 장비 대비 병변 검출 민감도·특이도 비교 결과 수록", downloads: 18, star: true },
-      { id: 3, title: "OrthoScan Mini 소형 정형외과 스캐너의 임상 유용성 평가", author: "박지훈 외 4인", journal: "대한정형외과학회지", date: "2025.08.20", product: "OrthoScan Mini", summary: "외래 환경에서의 휴대성과 촬영 정확도에 대한 전향적 평가", downloads: 11, star: false },
-      { id: 4, title: "의료기기 유지보수 주기와 진단 정확도의 상관관계", author: "최영진", journal: "의료기기저널", date: "2025.06.15", product: "공통", summary: "정기 유지보수 미이행 시 장비 오차율 증가 경향을 다기관 데이터로 분석", downloads: 9, star: false },
-      { id: 5, title: "CardioView X7 vs 경쟁 제품 비교 리뷰", author: "정수아", journal: "심혈관영상학회지", date: "2025.04.05", product: "CardioView X7", summary: "동급 제품 3종과의 스펙·판독 편의성 비교 리뷰", downloads: 31, star: false },
-      { id: 6, title: "SonoFlex Pro 사용자 만족도 조사", author: "김태희 외 5인", journal: "임상초음파학회지", date: "2025.02.18", product: "SonoFlex Pro", summary: "현장 사용자 82명 대상 설문, 조작 편의성과 화질 만족도 결과", downloads: 15, star: false }
+      { id: 1, title: "2026 B2B 영업 트렌드 리포트", author: "전략기획팀", journal: "사내 리서치", date: "2026.08.02", product: "시장조사", summary: "국내 B2B 구매 여정과 영업 생산성 변화의 핵심 지표를 정리", downloads: 24, star: true },
+      { id: 2, title: "국내 Sales CRM 기능 비교표", author: "Sales Ops", journal: "경쟁사 분석", date: "2026.07.28", product: "경쟁사 비교", summary: "주요 CRM의 파이프라인·자동화·보고 기능과 가격 정책을 비교", downloads: 31, star: true },
+      { id: 3, title: "고객 인터뷰 질문 가이드", author: "영업교육팀", journal: "신규 담당자 교육", date: "2026.07.15", product: "교육", summary: "첫 미팅에서 고객 니즈·예산·의사결정 구조를 확인하는 질문 모음", downloads: 18, star: false },
+      { id: 4, title: "할인·결재 기준 안내", author: "영업관리팀", journal: "내부 운영 정책", date: "2026.06.30", product: "정책", summary: "할인율별 승인권자와 견적·계약 결재 절차를 한눈에 정리", downloads: 15, star: true },
+      { id: 5, title: "신규 영업 담당자 온보딩 노트", author: "People Ops", journal: "사내 교육", date: "2026.05.22", product: "교육", summary: "고객 등록부터 미팅 기록, 보고서 제출까지 기본 업무 흐름을 안내", downloads: 11, star: false },
+      { id: 6, title: "분기 영업 회고 템플릿", author: "Revenue Ops", journal: "공용 템플릿", date: "2026.04.18", product: "정책", summary: "파이프라인 전환율과 실패 원인을 팀 단위로 회고하는 양식", downloads: 9, star: false }
     ];
     let activePubFilter = "all";
     let sessionPubDownloads = 0;
@@ -3185,7 +3530,7 @@
       });
       $("#publicationRows").innerHTML = rows.map(pub => `
         <div class="doc-row lib-row" data-pub-id="${pub.id}">
-          <span class="doc-type">PB</span>
+          <span class="doc-type">DOC</span>
           <span class="doc-title"><strong>${pub.title}</strong><span>${pub.summary}</span></span>
           <span class="po-meta">${pub.product}</span>
           <span class="po-meta"><b>${pub.author}</b>${pub.journal}</span>
@@ -3227,15 +3572,15 @@
       }
       if (action === "download") {
         const body = [
-          `FieldMed Publication`,
-          `논문명: ${pub.title}`,
-          `저자: ${pub.author}`,
-          `저널·학회: ${pub.journal} (${pub.date})`,
-          `연관 제품: ${pub.product}`,
+          `SalesLuv 기타 문서`,
+          `문서명: ${pub.title}`,
+          `작성자: ${pub.author}`,
+          `출처: ${pub.journal} (${pub.date})`,
+          `구분: ${pub.product}`,
           ``,
           `요약: ${pub.summary}`,
           ``,
-          `이 파일은 시연용 자리표시자입니다. 실제 환경에서는 초록·서지정보 PDF가 내려받아집니다.`
+          `이 파일은 시연용 자리표시자입니다. 실제 환경에서는 등록된 원본 문서가 내려받아집니다.`
         ].join("\n");
         const url = URL.createObjectURL(new Blob([body], { type: "text/plain;charset=utf-8" }));
         const link = document.createElement("a");
@@ -3248,7 +3593,7 @@
         pub.downloads += 1;
         sessionPubDownloads += 1;
         renderPublications();
-        toast(`${pub.title} 서지정보를 내려받았습니다.`);
+        toast(`${pub.title} 문서를 내려받았습니다.`);
       }
     });
 
@@ -3257,7 +3602,7 @@
       const title = $("#pubTitle").value.trim();
       const author = $("#pubAuthor").value.trim();
       const journal = $("#pubJournal").value.trim();
-      if (!title || !author || !journal) { toast("논문명, 저자, 저널을 입력하세요."); return; }
+      if (!title || !author || !journal) { toast("문서명, 작성자, 출처를 입력하세요."); return; }
       const pub = {
         id: Date.now(),
         title, author, journal,
@@ -3271,8 +3616,8 @@
       renderPublications();
       closeDialog($("#pubUploadDialog"));
       event.target.reset();
-      addNotification("논문 자료가 등록됐습니다", `${pub.title} · ${pub.product}`);
-      toast(`${pub.title} 자료를 등록했습니다.`);
+      addNotification("기타 문서가 등록됐습니다", `${pub.title} · ${pub.product}`);
+      toast(`${pub.title} 문서를 등록했습니다.`);
     });
 
     renderPublications();
@@ -3364,8 +3709,8 @@
 
     // Plan upgrade
     const plans = [
-      { id: "basic", name: "일반회원", seats: "개인 구독", price: 45000, features: ["고객·병원 관리", "발주 관리", "업무 캘린더", "업무보고 관리"] },
-      { id: "premium", name: "프리미엄 회원", seats: "개인 구독", price: 65000, features: ["일반회원 전체 기능", "고객불만 관리", "업무보고 자동 분석", "Publication 열람"] }
+      { id: "basic", name: "일반회원", seats: "개인 구독", price: 45000, features: ["고객·회사 관리", "발주 관리", "업무 캘린더", "업무보고 관리"] },
+      { id: "premium", name: "프리미엄 회원", seats: "개인 구독", price: 65000, features: ["일반회원 전체 기능", "고객불만 관리", "업무보고 자동 분석", "기타 문서 열람"] }
     ];
     let currentPlanId = "premium";
 
@@ -3407,7 +3752,26 @@
     $("#contractForm").addEventListener("submit", event => { event.preventDefault(); const hospital = $("#contractHospital").value; const product = $("#contractProduct").value; addDocument("contract", `${product} 공급계약서`, hospital, "전자서명 중"); closeDialog($("#contractDialog")); addNotification("전자서명을 요청했습니다", `${hospital} ${$("#contractSigner").value}님에게 계약서 서명 요청을 보냈습니다.`); toast("계약서 확정본을 저장하고 전자서명을 요청했습니다."); });
 
     // Team manager settings
-    $$('[data-manager-tab]').forEach(tab => tab.addEventListener("click", () => { $$('[data-manager-tab]').forEach(button => { button.classList.toggle("active", button === tab); button.setAttribute("aria-selected", button === tab); }); $$('[data-manager-panel]').forEach(panel => panel.classList.toggle("active", panel.dataset.managerPanel === tab.dataset.managerTab)); }));
+    const managerTabCopy = {
+      reports: { title: "팀 업무보고 현황", eyebrow: "Team reports", desc: "팀원별 업무보고 제출 여부와 핵심 활동, 미확정 기록을 한눈에 확인합니다." },
+      sales: { title: "팀 매출·계약 현황", eyebrow: "Sales & contracts", desc: "확정 매출과 계약 건수, 갱신이 필요한 고객사를 함께 확인합니다." },
+      team: { title: "팀 운영 관리", eyebrow: "Team operations", desc: "팀원과 공통 목표를 관리하고 공지와 오늘 일정을 확인합니다." }
+    };
+    function setManagerTab(tab) {
+      activeManagerTab = tab;
+      $$('[data-manager-tab]').forEach(button => { const active = button.dataset.managerTab === tab; button.classList.toggle("active", active); button.setAttribute("aria-selected", String(active)); });
+      $$('[data-manager-panel]').forEach(panel => panel.classList.toggle("active", panel.dataset.managerPanel === tab));
+      $$('[data-manager-action]').forEach(button => button.hidden = button.dataset.managerAction !== tab);
+      $("#managerTabTitle").textContent = managerTabCopy[tab].title;
+      $("#managerTabEyebrow").textContent = managerTabCopy[tab].eyebrow;
+      $("#managerTabDesc").textContent = managerTabCopy[tab].desc;
+      if (location.hash === "#manager") {
+        const managerView = tab === "team" ? "team" : "reports";
+        $$('[data-manager-view]').forEach(button => button.classList.toggle("active", button.dataset.managerView === managerView));
+        $("#currentPageName").textContent = managerTabCopy[tab].title;
+      }
+    }
+    $$('[data-manager-tab]').forEach(tab => tab.addEventListener("click", () => setManagerTab(tab.dataset.managerTab)));
     $("#addTeamGoal").addEventListener("click", () => { const title = $("#newTeamGoal").value.trim(); if (!title) return toast("추가할 필수 목표를 입력해 주세요."); teamGoals.push({ id: Date.now(), title, detail: "팀장이 추가한 공통 미팅 목표", active: true }); $("#newTeamGoal").value = ""; renderTeamGoals(); toast("새 필수 목표를 활성 목록에 추가했습니다."); });
     $("#newTeamGoal").addEventListener("keydown", event => { if (event.key === "Enter") { event.preventDefault(); $("#addTeamGoal").click(); } });
     $("#saveTeamGoals").addEventListener("click", () => { const activeIds = new Set($$('[data-team-goal]:checked').map(input => Number(input.dataset.teamGoal))); teamGoals.forEach(goal => goal.active = activeIds.has(goal.id)); renderMemberDashboard(); renderHospitalDetail(); addNotification("팀 공통 미팅 목표가 변경됐습니다", `${teamGoals.filter(goal => goal.active).length}개 필수 목표가 다음 미팅 브리핑부터 적용됩니다.`); toast("활성 목표를 저장하고 팀원 브리핑에 반영했습니다."); });
@@ -3415,8 +3779,10 @@
     ["noticeTitle", "noticeBody"].forEach(id => $("#" + id).addEventListener("input", () => { $("#noticePreviewTitle").textContent = $("#noticeTitle").value || "제목 없음"; $("#noticePreviewBody").textContent = $("#noticeBody").value || "내용을 입력하세요."; }));
     $("#publishNotice").addEventListener("click", () => { const title = $("#noticeTitle").value.trim(); const body = $("#noticeBody").value.trim(); if (!title || !body) return toast("공지 제목과 내용을 모두 입력해 주세요."); teamState.notice = { title, body, time: new Date().toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit", hour12: false }) }; renderMemberDashboard(); if ($("#noticePush").checked) addNotification(title, body); toast("공지를 게시하고 팀원 대시보드에 반영했습니다."); });
     $$('[data-issue-filter]').forEach(chip => chip.addEventListener("click", () => { $$('[data-issue-filter]').forEach(button => button.classList.toggle("active", button === chip)); $$('[data-issue-status]').forEach(row => row.hidden = chip.dataset.issueFilter !== "all" && row.dataset.issueStatus !== chip.dataset.issueFilter); }));
-    $$(".coach-member").forEach(button => button.addEventListener("click", () => { addNotification(`${button.dataset.member}님 다음 미팅 지시`, "미완료된 필수 목표와 원문 근거를 확인하고 다음 방문에서 우선 해결해 주세요."); toast(`${button.dataset.member}님에게 후속 지시를 전달했습니다.`); }));
-    $$(".issue-detail").forEach(button => button.addEventListener("click", () => toast("팀원의 미팅별 목표 달성 근거를 열었습니다.")));
+    $$(".coach-member").forEach(button => button.addEventListener("click", () => { addNotification(`${button.dataset.member}님 업무보고 확인 요청`, "미제출 또는 미확정 항목을 확인하고 오늘 업무보고를 완료해 주세요."); toast(`${button.dataset.member}님에게 업무보고 확인 요청을 보냈습니다.`); }));
+    $$(".issue-detail").forEach(button => button.addEventListener("click", () => toast("팀원의 업무보고와 연결된 미팅 기록을 열었습니다.")));
+    $("#exportTeamReports").addEventListener("click", () => toast("제출된 팀원 업무보고를 하나의 팀 현황으로 취합했습니다."));
+    $("#addTeamMember").addEventListener("click", () => toast("팀원 초대·권한 설정 화면은 다음 상세 설계에서 연결합니다."));
     $("#exportManager").addEventListener("click", () => toast("팀장 월간 보고서 PDF 생성을 시작했습니다."));
     ["managerPeriod", "managerMember"].forEach(id => $("#" + id).addEventListener("change", () => { $("#managerFilterLabel").textContent = `${$("#managerPeriod").value} · ${$("#managerMember").value}`; toast("팀장 지표와 일정 필터를 적용했습니다."); }));
     $$(".team-detail").forEach(btn => btn.addEventListener("click", () => toast("팀원 일정의 브리핑·미팅 결과·후속 업무를 조회했습니다.")));


### PR DESCRIPTION
## 변경 요약

- 기존 demo/layout_v1.html을 PR #6 병합 전 원본 상태로 복원했습니다.
- SalesLuv 영업 CRM 수정본은 demo/demo-jeseop.html로 별도 추가했습니다.

## 변경 이유

- 개인 데모 작업은 기존 공용 데모 파일을 수정하지 않고 사용자별 파일로 분리해야 합니다.
- 이전 PR에서 layout_v1.html을 직접 변경한 범위 오류를 바로잡습니다.

## 검증

- 복원된 layout_v1.html의 Git 객체 해시가 기존 원본 커밋과 일치함을 확인했습니다.
- layout_v1.html과 demo-jeseop.html의 인라인 JavaScript 구문 검사 통과
- git diff --check 통과

## 영향 및 주의 사항

- 기존 공용 layout_v1.html의 동작과 내용은 원상 복구됩니다.
- SalesLuv 수정본은 demo-jeseop.html에서 계속 확인할 수 있습니다.
- 조사 문서와 OCR 임시 파일은 포함하지 않았습니다.

## 관련 이슈

- PR #6의 파일 배치 정정