### PR TITLE
Salesforce 리뷰 수집 및 비식별 집계 추가

### DIFF
--- a/docs/research/crm/salesforce-google-play-review-aggregate-2026-08-11.csv
+++ b/docs/research/crm/salesforce-google-play-review-aggregate-2026-08-11.csv
@@ -1,0 +1,230 @@
+﻿section,segment,metric,value,unit,denominator,period_start_utc,period_end_utc,note,source_sha256
+scope,snapshot,review_count,18474,count,,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+scope,snapshot,substantive_text_count,18459,count,18474,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+scope,snapshot,reviewed_at_start,2011-03-08T20:58:30+00:00,timestamp,,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+scope,snapshot,reviewed_at_end,2026-08-10T03:22:30+00:00,timestamp,,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+scope,snapshot,nonempty_language_stream_count,46,count,,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+scope,snapshot,language_stream_assignments,18484,count,,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+scope,snapshot,duplicate_stream_assignments,10,count,,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+engagement,all,developer_reply_count,2011,count,18474,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+engagement,all,developer_reply_share,10.8856,percent,18474,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+engagement,all,thumbs_up_total,15179,count,,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+engagement,all,reviews_with_thumbs_up,4451,count,18474,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+overall,all,review_count,18474,count,,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+overall,all,mean_rating,3.8633,stars,,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+overall,all,low_review_count,4217,count,,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+overall,all,low_review_share,22.8267,percent,18474,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+overall,all,positive_review_count,12986,count,,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+overall,all,positive_review_share,70.2934,percent,18474,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+rating,1,review_count,3318,count,18474,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+rating,1,review_share,17.9604,percent,18474,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+rating,2,review_count,899,count,18474,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+rating,2,review_share,4.8663,percent,18474,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+rating,3,review_count,1271,count,18474,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+rating,3,review_share,6.8799,percent,18474,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+rating,4,review_count,2489,count,18474,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+rating,4,review_share,13.473,percent,18474,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+rating,5,review_count,10497,count,18474,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+rating,5,review_share,56.8204,percent,18474,,,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+period,recent_90_days,review_count,419,count,,2026-05-13T00:00:00+00:00,2026-08-11T00:00:00+00:00,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+period,recent_90_days,mean_rating,3.611,stars,,2026-05-13T00:00:00+00:00,2026-08-11T00:00:00+00:00,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+period,recent_90_days,low_review_count,138,count,,2026-05-13T00:00:00+00:00,2026-08-11T00:00:00+00:00,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+period,recent_90_days,low_review_share,32.9356,percent,419,2026-05-13T00:00:00+00:00,2026-08-11T00:00:00+00:00,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+period,recent_90_days,positive_review_count,268,count,,2026-05-13T00:00:00+00:00,2026-08-11T00:00:00+00:00,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+period,recent_90_days,positive_review_share,63.9618,percent,419,2026-05-13T00:00:00+00:00,2026-08-11T00:00:00+00:00,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+period,previous_90_days,review_count,392,count,,2026-02-12T00:00:00+00:00,2026-05-13T00:00:00+00:00,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+period,previous_90_days,mean_rating,4.1684,stars,,2026-02-12T00:00:00+00:00,2026-05-13T00:00:00+00:00,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+period,previous_90_days,low_review_count,68,count,,2026-02-12T00:00:00+00:00,2026-05-13T00:00:00+00:00,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+period,previous_90_days,low_review_share,17.3469,percent,392,2026-02-12T00:00:00+00:00,2026-05-13T00:00:00+00:00,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+period,previous_90_days,positive_review_count,308,count,,2026-02-12T00:00:00+00:00,2026-05-13T00:00:00+00:00,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+period,previous_90_days,positive_review_share,78.5714,percent,392,2026-02-12T00:00:00+00:00,2026-05-13T00:00:00+00:00,,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,en,review_count,13134,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,en,mean_rating,3.8529,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,en,low_review_count,3092,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,en,low_review_share,23.542,percent,13134,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,en,positive_review_count,9216,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,en,positive_review_share,70.169,percent,13134,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,es,review_count,2013,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,es,mean_rating,4.3631,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,es,low_review_count,175,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,es,low_review_share,8.6935,percent,2013,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,es,positive_review_count,1682,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,es,positive_review_share,83.5569,percent,2013,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,pt,review_count,903,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,pt,mean_rating,4.2946,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,pt,low_review_count,103,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,pt,low_review_share,11.4064,percent,903,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,pt,positive_review_count,734,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,pt,positive_review_share,81.2846,percent,903,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ja,review_count,380,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ja,mean_rating,2.0658,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ja,low_review_count,260,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ja,low_review_share,68.4211,percent,380,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ja,positive_review_count,85,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ja,positive_review_share,22.3684,percent,380,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,it,review_count,347,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,it,mean_rating,3.1758,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,it,low_review_count,130,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,it,low_review_share,37.464,percent,347,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,it,positive_review_count,171,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,it,positive_review_share,49.2795,percent,347,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,fr,review_count,321,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,fr,mean_rating,3.4735,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,fr,low_review_count,101,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,fr,low_review_share,31.4642,percent,321,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,fr,positive_review_count,195,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,fr,positive_review_share,60.7477,percent,321,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,id,review_count,191,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,id,mean_rating,4.2984,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,id,low_review_count,23,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,id,low_review_share,12.0419,percent,191,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,id,positive_review_count,157,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,id,positive_review_share,82.199,percent,191,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,th,review_count,185,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,th,mean_rating,4.4541,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,th,low_review_count,13,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,th,low_review_share,7.027,percent,185,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,th,positive_review_count,160,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,th,positive_review_share,86.4865,percent,185,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,de,review_count,152,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,de,mean_rating,3.2303,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,de,low_review_count,56,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,de,low_review_share,36.8421,percent,152,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,de,positive_review_count,80,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,de,positive_review_share,52.6316,percent,152,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ko,review_count,120,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ko,mean_rating,3.5917,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ko,low_review_count,31,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ko,low_review_share,25.8333,percent,120,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ko,positive_review_count,73,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ko,positive_review_share,60.8333,percent,120,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ru,review_count,93,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ru,mean_rating,3.2151,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ru,low_review_count,36,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ru,low_review_share,38.7097,percent,93,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ru,positive_review_count,48,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ru,positive_review_share,51.6129,percent,93,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,nl,review_count,81,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,nl,mean_rating,3.1235,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,nl,low_review_count,33,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,nl,low_review_share,40.7407,percent,81,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,nl,positive_review_count,42,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,nl,positive_review_share,51.8519,percent,81,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,tr,review_count,77,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,tr,mean_rating,4.0779,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,tr,low_review_count,12,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,tr,low_review_share,15.5844,percent,77,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,tr,positive_review_count,57,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,tr,positive_review_share,74.026,percent,77,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ar,review_count,67,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ar,mean_rating,3.6418,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ar,low_review_count,19,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ar,low_review_share,28.3582,percent,67,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ar,positive_review_count,41,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ar,positive_review_share,61.194,percent,67,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,vi,review_count,59,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,vi,mean_rating,4.3729,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,vi,low_review_count,6,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,vi,low_review_share,10.1695,percent,59,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,vi,positive_review_count,50,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,vi,positive_review_share,84.7458,percent,59,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,pl,review_count,56,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,pl,mean_rating,3.3036,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,pl,low_review_count,21,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,pl,low_review_share,37.5,percent,56,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,pl,positive_review_count,32,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,pl,positive_review_share,57.1429,percent,56,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,zh-CN,review_count,49,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,zh-CN,mean_rating,2.5714,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,zh-CN,low_review_count,26,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,zh-CN,low_review_share,53.0612,percent,49,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,zh-CN,positive_review_count,16,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,zh-CN,positive_review_share,32.6531,percent,49,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,zh-TW,review_count,49,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,zh-TW,mean_rating,2.8163,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,zh-TW,low_review_count,23,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,zh-TW,low_review_share,46.9388,percent,49,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,zh-TW,positive_review_count,21,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,zh-TW,positive_review_share,42.8571,percent,49,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,he,review_count,38,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,he,mean_rating,3.4737,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,he,low_review_count,11,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,he,low_review_share,28.9474,percent,38,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,he,positive_review_count,20,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,he,positive_review_share,52.6316,percent,38,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ro,review_count,17,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ro,mean_rating,4.0588,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ro,low_review_count,3,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ro,low_review_share,17.6471,percent,17,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ro,positive_review_count,13,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,ro,positive_review_share,76.4706,percent,17,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,sv,review_count,17,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,sv,mean_rating,3.4118,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,sv,low_review_count,5,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,sv,low_review_share,29.4118,percent,17,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,sv,positive_review_count,10,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,sv,positive_review_share,58.8235,percent,17,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,fi,review_count,15,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,fi,mean_rating,1.8667,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,fi,low_review_count,13,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,fi,low_review_share,86.6667,percent,15,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,fi,positive_review_count,2,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,fi,positive_review_share,13.3333,percent,15,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,no,review_count,15,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,no,mean_rating,3.4667,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,no,low_review_count,5,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,no,low_review_share,33.3333,percent,15,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,no,positive_review_count,9,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,no,positive_review_share,60.0,percent,15,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,cs,review_count,14,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,cs,mean_rating,3.0,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,cs,low_review_count,5,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,cs,low_review_share,35.7143,percent,14,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,cs,positive_review_count,5,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,cs,positive_review_share,35.7143,percent,14,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,hu,review_count,14,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,hu,mean_rating,3.2857,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,hu,low_review_count,5,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,hu,low_review_share,35.7143,percent,14,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,hu,positive_review_count,8,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,hu,positive_review_share,57.1429,percent,14,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,hi,review_count,13,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,hi,mean_rating,4.6154,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,hi,low_review_count,1,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,hi,low_review_share,7.6923,percent,13,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,hi,positive_review_count,12,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,hi,positive_review_share,92.3077,percent,13,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,uk,review_count,11,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,uk,mean_rating,4.2727,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,uk,low_review_count,2,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,uk,low_review_share,18.1818,percent,11,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,uk,positive_review_count,9,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,uk,positive_review_share,81.8182,percent,11,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,da,review_count,10,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,da,mean_rating,3.2,stars,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,da,low_review_count,4,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,da,low_review_share,40.0,percent,10,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,da,positive_review_count,6,count,,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,da,positive_review_share,60.0,percent,10,,,queried locale; not detected review language,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+language_stream,suppressed,stream_count,18,count,,,,streams with fewer than 10 reviews,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+low_review_theme,english_stream,denominator,3092,count,,,,1-2 stars; multi-label keyword matching,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+low_review_theme,reliability_performance,matched_count,1316,count,3092,,,English stream; multi-label keyword matching,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+low_review_theme,reliability_performance,matched_share,42.5614,percent,3092,,,English stream; multi-label keyword matching,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+low_review_theme,authentication_access,matched_count,346,count,3092,,,English stream; multi-label keyword matching,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+low_review_theme,authentication_access,matched_share,11.1902,percent,3092,,,English stream; multi-label keyword matching,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+low_review_theme,ux_navigation,matched_count,346,count,3092,,,English stream; multi-label keyword matching,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+low_review_theme,ux_navigation,matched_share,11.1902,percent,3092,,,English stream; multi-label keyword matching,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+low_review_theme,missing_mobile_capability,matched_count,207,count,3092,,,English stream; multi-label keyword matching,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+low_review_theme,missing_mobile_capability,matched_share,6.6947,percent,3092,,,English stream; multi-label keyword matching,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+low_review_theme,data_sync_entry,matched_count,194,count,3092,,,English stream; multi-label keyword matching,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+low_review_theme,data_sync_entry,matched_share,6.2743,percent,3092,,,English stream; multi-label keyword matching,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+low_review_theme,search_list_filter,matched_count,96,count,3092,,,English stream; multi-label keyword matching,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+low_review_theme,search_list_filter,matched_share,3.1048,percent,3092,,,English stream; multi-label keyword matching,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+low_review_theme,files_media,matched_count,67,count,3092,,,English stream; multi-label keyword matching,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+low_review_theme,files_media,matched_share,2.1669,percent,3092,,,English stream; multi-label keyword matching,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+low_review_theme,notifications,matched_count,43,count,3092,,,English stream; multi-label keyword matching,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+low_review_theme,notifications,matched_share,1.3907,percent,3092,,,English stream; multi-label keyword matching,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+low_review_theme,update_regression,matched_count,95,count,3092,,,English stream; multi-label keyword matching,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+low_review_theme,update_regression,matched_share,3.0724,percent,3092,,,English stream; multi-label keyword matching,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+low_review_theme,field_work_context,matched_count,271,count,3092,,,English stream; multi-label keyword matching,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292
+low_review_theme,field_work_context,matched_share,8.7646,percent,3092,,,English stream; multi-label keyword matching,a9a83c3186adc6016d0b59b5b2454ce3206ed6b4573e919ddb76f1c809970292

--- a/docs/research/crm/salesforce-google-play-review-aggregate.md
+++ b/docs/research/crm/salesforce-google-play-review-aggregate.md
@@ -1,0 +1,60 @@
+# Salesforce 모바일 Google Play 리뷰 집계
+
+대상 앱: [Salesforce Android 앱](https://play.google.com/store/apps/details?id=com.salesforce.chatter)
+스냅샷 기준일: 2026-08-11 UTC
+
+이 문서는 해석이나 프로젝트 타당성 판단을 포함하지 않는다. 수집 방법, 집계 정의, 재현 방법만 기록한다. 개별 리뷰 본문·작성자·리뷰 ID·개발자 답변 원문은 Git에 포함하지 않는다.
+
+## 추적 파일
+
+- `scripts/google_play_reviews.py`: 공개 리뷰 수집, 본문·별점 CSV 생성, 비식별 집계
+- `docs/research/crm/salesforce-google-play-review-aggregate-2026-08-11.csv`: 비식별 집계 결과
+
+원본 JSONL과 본문·별점 CSV는 각각 `data/raw/`, `data/processed/`에 생성되며 저장소 정책과 `.gitignore`에 따라 로컬에만 보관한다.
+
+## 재현 명령
+
+```bash
+python3 scripts/google_play_reviews.py self-test
+
+python3 scripts/google_play_reviews.py crawl \
+  --app-id com.salesforce.chatter
+
+python3 scripts/google_play_reviews.py summarize \
+  data/raw/salesforce_chatter_google_play_reviews.jsonl \
+  --as-of 2026-08-11 \
+  --output data/processed/salesforce-google-play-review-aggregate.csv
+```
+
+`crawl`은 표준 라이브러리만 사용한다. 기본 77개 언어 스트림을 최신순으로 조회하며, 중국어 간체(`zh-CN`)와 번체(`zh-TW`)는 별도 스트림으로 처리한다. 각 스트림은 continuation token이 없어질 때까지 조회하고, 반복 token은 오류로 중단한다. 실행 manifest에는 언어별 페이지 수·반환 건수·정상 종료 여부·실패 여부가 남는다.
+
+수집 JSONL은 중복 제거를 위한 `reviewId`를 로컬에 저장하지만 `userName`, `userImage`, `replyContent`는 수집하지 않는다. 스프레드시트 CSV는 `리뷰내용`, `별점` 두 열이며 수식으로 해석될 수 있는 본문은 앞에 작은따옴표를 붙인다.
+
+## 집계 CSV 정의
+
+| 열 | 정의 |
+|---|---|
+| `section` | 집계 영역: 범위, 전체, 평점, 기간, 언어 스트림, 저평점 주제 등 |
+| `segment` | 영역 안의 구간 또는 분류 키 |
+| `metric` | 측정 항목 |
+| `value` | 집계값 |
+| `unit` | `count`, `percent`, `stars`, `timestamp` |
+| `denominator` | 비율 또는 분류 건수의 분모 |
+| `period_start_utc` | 기간 시작, 포함 |
+| `period_end_utc` | 기간 종료, 미포함 |
+| `note` | 집계 조건 |
+| `source_sha256` | 모든 행에 적용된 로컬 원본 스냅샷 SHA-256 |
+
+- 저평점은 1~2점, 긍정 평점은 4~5점으로 정의한다.
+- 기간은 UTC `[시작, 종료)`로 계산한다.
+- `language_stream`은 실제 작성 언어 감지가 아니라 Google Play 조회 locale이다.
+- `low_review_theme`은 영어 스트림의 1~2점 리뷰에 고정 정규식을 적용한 다중 라벨 건수다. 한 리뷰가 여러 주제에 포함될 수 있다.
+- 언어 스트림 표본이 10건 미만이면 개별 집계를 출력하지 않고 `suppressed` 건수로만 기록한다.
+- 집계 CSV에는 리뷰 본문, 작성자, 리뷰 ID, 프로필 이미지, 개발자 답변 원문을 출력하지 않는다.
+
+## 범위 제한
+
+- Google Play의 문서화되지 않은 공개 웹 UI 응답을 집계한 스냅샷이다. 앱 화면의 전체 별점 수와 동일한 모집단이 아니다.
+- 비공개·삭제·노출 제한·별점만 남긴 평가는 포함되지 않을 수 있다.
+- 공개 UI와 RPC 형식은 예고 없이 바뀔 수 있다.
+- 앱 소유자가 Play Console에서 받는 전체 이력과 제3자가 공개 UI에서 조회할 수 있는 범위는 다르다. 관련 공식 안내: [Google Play 리뷰 작업 가이드](https://developers.google.com/android-publisher/reply-to-reviews?hl=ko), [지원 스토어 언어](https://support.google.com/googleplay/android-developer/answer/9844778?hl=ko)

--- a/scripts/google_play_reviews.py
+++ b/scripts/google_play_reviews.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Collect public Google Play reviews locally and export aggregate-only statistics."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import re
+import time
+from collections import Counter
+from datetime import date, datetime, time as datetime_time, timedelta, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+RPC_ID = "UsvDTd"
+ENDPOINT = "https://play.google.com/_/PlayStoreUi/data/batchexecute"
+LANGUAGE_STREAMS = (
+    "en", "af", "am", "ar", "as", "az", "be", "bg", "bn", "bs", "ca", "cs", "da",
+    "de", "el", "es", "et", "eu", "fa", "fi", "fil", "fr", "gl", "gsw", "gu", "he",
+    "hi", "hr", "hu", "hy", "id", "is", "it", "ja", "ka", "kk", "km", "kn", "ko",
+    "ky", "ln", "lo", "lt", "lv", "mk", "ml", "mn", "mr", "ms", "my", "ne", "nl",
+    "no", "or", "pa", "pl", "pt", "ro", "ru", "si", "sk", "sl", "sq", "sr", "sv",
+    "sw", "ta", "te", "th", "tr", "uk", "ur", "uz", "vi", "zh-CN", "zh-TW", "zu",
+)
+THEMES = {
+    "reliability_performance": re.compile(
+        r"\bslow\w*|\blag\w*|\bload\w*|\bcrash\w*|\bfreez\w*|\bfrozen\b|\bglitch\w*|"
+        r"\bbug\w*|\berror\w*|blank (?:white )?screen|white screen|\bstuck\b|\bhang(?:s|ing)?\b|"
+        r"unresponsive|doesn['’]?t work|does not work|not working|won['’]?t (?:open|load|work)|"
+        r"never (?:open|load|work)s?|\bbroken\b|\bunusable\b|force close|clear (?:the )?cache|"
+        r"restart|reinstall",
+        re.I,
+    ),
+    "authentication_access": re.compile(
+        r"\blog[ -]?in\b|\blogging in\b|\blogged (?:in|out)\b|\bsign[ -]?in\b|password|authenticat|"
+        r"verification|verify|\bmfa\b|\b2fa\b|passcode|passkey|custom domain|session|locked out|"
+        r"stay logged|kicked out",
+        re.I,
+    ),
+    "ux_navigation": re.compile(
+        r"user[ -]?friendly|not intuitive|unintuitive|confus\w*|complicat\w*|difficult|hard to use|"
+        r"clunky|\bnavigation\b|\bnavigate\w*|back button|too many clicks|\bmenu\w*|\binterface\b|"
+        r"\bui\b|\bux\b|\blayout\b|small screen|\bscroll\w*|landscape|portrait|hard to find",
+        re.I,
+    ),
+    "missing_mobile_capability": re.compile(
+        r"desktop version|web version|browser version|mobile web|full site|\blimited\b|"
+        r"lack(?:s|ing)? (?:basic )?(?:feature|function)|missing (?:feature|function|tab|button|option)|"
+        r"no access to|no ability to|can['’]?t (?:add|edit|create|upload|download)|"
+        r"cannot (?:add|edit|create|upload|download)|\breports?\b|\bdashboards?\b|\bsetup\b|landscape",
+        re.I,
+    ),
+    "data_sync_entry": re.compile(
+        r"\bsync\w*|\bsav(?:e|es|ed|ing)\b|data (?:loss|lost|missing)|records? (?:missing|disappear)|"
+        r"\brefresh\w*|update (?:a |the )?(?:record|data|account|case|opportunit)|enter(?:ing)? data|"
+        r"data entry|\binput\b|\bedit(?:ing)?\b|\boffline\b|no internet|network|connectivity|connection",
+        re.I,
+    ),
+    "search_list_filter": re.compile(
+        r"\bsearch\w*|\bfilter\w*|\bsort(?:ing)?\b|list view|can['’]?t find|cannot find|hard to find|"
+        r"lists? (?:don['’]?t|doesn['’]?t|not|won['’]?t)",
+        re.I,
+    ),
+    "files_media": re.compile(
+        r"\bfiles?\b|\bphotos?\b|\bimages?\b|\battachments?\b|\bupload\w*|\bcamera\b|\bpdf\b|"
+        r"\bdocuments?\b",
+        re.I,
+    ),
+    "notifications": re.compile(r"\bnotifications?\b|\balerts?\b|\breminders?\b|push notification", re.I),
+    "update_regression": re.compile(
+        r"latest update|last update|recent update|after (?:the )?update|since (?:the )?update|new version|"
+        r"used to work|worked before|update (?:has )?(?:broke|broken|ruined)|update.*not (?:work|load)",
+        re.I,
+    ),
+    "field_work_context": re.compile(
+        r"\bfield\b|on the go|clock(?:ing)? in|clock(?:ing)? out|punch(?:ing)? (?:in|out)|time ?sheet|"
+        r"check[ -]?in|\bvisits?\b|\bcustomers?\b|sales rep|field rep|\baccounts?\b|"
+        r"\bopportunit(?:y|ies)\b|work orders?",
+        re.I,
+    ),
+}
+AGGREGATE_FIELDS = (
+    "section", "segment", "metric", "value", "unit", "denominator", "period_start_utc",
+    "period_end_utc", "note", "source_sha256",
+)
+
+
+def utc_iso(timestamp: list[int] | None) -> str | None:
+    if not timestamp:
+        return None
+    seconds, nanos = timestamp
+    return datetime.fromtimestamp(seconds + nanos / 1_000_000_000, timezone.utc).isoformat()
+
+
+def parse_review(item: list, language: str, app_id: str, collected_at: str) -> dict:
+    if not isinstance(item, list) or len(item) < 11:
+        raise ValueError("unexpected review payload")
+    reply = item[7] if isinstance(item[7], list) else None
+    review = {
+        "reviewId": item[0],
+        "content": item[4] or "",
+        "score": item[2],
+        "thumbsUpCount": item[6] or 0,
+        "reviewCreatedVersion": item[10],
+        "reviewedAt": utc_iso(item[5]),
+        "hasDeveloperReply": bool(reply),
+        "repliedAt": utc_iso(reply[2]) if reply and len(reply) > 2 else None,
+        "languageStreams": [language],
+        "collectedAtUtc": collected_at,
+        "sourceUrl": f"https://play.google.com/store/apps/details?id={app_id}",
+        "appId": app_id,
+        "sort": "NEWEST",
+    }
+    if not isinstance(review["reviewId"], str) or review["score"] not in range(1, 6):
+        raise ValueError("invalid review id or rating")
+    return review
+
+
+def parse_rpc_response(text: str) -> tuple[list[list], str | None]:
+    if text.startswith(")]}'"):
+        text = text.split("\n", 1)[1].lstrip()
+    envelope = json.loads(text)
+    row = next(
+        (value for value in envelope if isinstance(value, list) and len(value) > 2 and value[:2] == ["wrb.fr", RPC_ID]),
+        None,
+    )
+    if not row or not row[2]:
+        raise ValueError("Google Play returned no review payload")
+    payload = json.loads(row[2])
+    if not isinstance(payload, list) or not payload or not isinstance(payload[0], list):
+        raise ValueError("unexpected Google Play response")
+    token = payload[1][1] if len(payload) > 1 and payload[1] and len(payload[1]) > 1 else None
+    return payload[0], token
+
+
+def fetch_page(app_id: str, language: str, token: str | None, page_size: int, timeout: int, retries: int) -> tuple[list[list], str | None]:
+    argument = [None, None, [2, 2, [page_size, None, token], None, []], [app_id, 7]]
+    envelope = [[[RPC_ID, json.dumps(argument, separators=(",", ":")), None, "generic"]]]
+    query = urlencode({"rpcids": RPC_ID, "hl": language, "gl": "US"})
+    request = Request(
+        f"{ENDPOINT}?{query}",
+        data=urlencode({"f.req": json.dumps(envelope, separators=(",", ":"))}).encode(),
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+            "User-Agent": "Mozilla/5.0",
+        },
+    )
+    error: Exception | None = None
+    for attempt in range(retries):
+        try:
+            with urlopen(request, timeout=timeout) as response:
+                return parse_rpc_response(response.read().decode())
+        except Exception as exc:  # Network and private-RPC failures share the same bounded retry path.
+            error = exc
+            if attempt + 1 < retries:
+                time.sleep(2**attempt)
+    raise RuntimeError(f"review request failed for {language}: {type(error).__name__}") from error
+
+
+def spreadsheet_safe(value: object) -> str:
+    text = "" if value is None else str(value)
+    return "'" + text if text.lstrip().startswith(("=", "+", "-", "@", "\t", "\r")) else text
+
+
+def write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def write_review_files(jsonl_path: Path, csv_path: Path, rows: list[dict]) -> None:
+    jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = jsonl_path.with_name(f".{jsonl_path.name}.tmp")
+    with temporary.open("w", encoding="utf-8") as file:
+        for row in rows:
+            file.write(json.dumps(row, ensure_ascii=False, separators=(",", ":")) + "\n")
+    temporary.replace(jsonl_path)
+
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = csv_path.with_name(f".{csv_path.name}.tmp")
+    with temporary.open("w", encoding="utf-8-sig", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=("리뷰내용", "별점"), lineterminator="\n")
+        writer.writeheader()
+        writer.writerows({"리뷰내용": spreadsheet_safe(row["content"]), "별점": row["score"]} for row in rows)
+    temporary.replace(csv_path)
+
+
+def crawl(args: argparse.Namespace) -> None:
+    if not 1 <= args.page_size <= 4500:
+        raise SystemExit("--page-size must be between 1 and 4500")
+    collected_at = datetime.now(timezone.utc).isoformat()
+    reviews: dict[str, dict] = {}
+    stream_stats: dict[str, dict] = {}
+    raw_assignments = 0
+    manifest = {
+        "schemaVersion": 1,
+        "appId": args.app_id,
+        "rpcId": RPC_ID,
+        "sort": "NEWEST",
+        "collectedAtUtc": collected_at,
+        "pageSize": args.page_size,
+        "languageStreamsAttempted": args.languages,
+        "streams": stream_stats,
+        "failures": [],
+    }
+    try:
+        for language in args.languages:
+            token = None
+            seen_tokens: set[str] = set()
+            pages = returned = 0
+            while True:
+                batch, next_token = fetch_page(
+                    args.app_id, language, token, args.page_size, args.timeout, args.retries
+                )
+                pages += 1
+                returned += len(batch)
+                raw_assignments += len(batch)
+                for item in batch:
+                    review = parse_review(item, language, args.app_id, collected_at)
+                    existing = reviews.get(review["reviewId"])
+                    if existing:
+                        if language not in existing["languageStreams"]:
+                            existing["languageStreams"].append(language)
+                    else:
+                        reviews[review["reviewId"]] = review
+                if not next_token:
+                    stream_stats[language] = {"pages": pages, "returned": returned, "terminated": True}
+                    break
+                if next_token in seen_tokens:
+                    raise RuntimeError(f"repeated continuation token for {language}")
+                seen_tokens.add(next_token)
+                token = next_token
+                if args.delay:
+                    time.sleep(args.delay)
+    except Exception as exc:
+        manifest["failures"].append({"language": language, "error": type(exc).__name__})
+        write_json(args.manifest_output, manifest)
+        raise
+
+    rows = sorted(reviews.values(), key=lambda row: (row["reviewedAt"] or "", row["reviewId"]), reverse=True)
+    manifest.update(
+        {
+            "rawReviewAssignments": raw_assignments,
+            "uniqueReviewCount": len(rows),
+            "duplicateAssignments": raw_assignments - len(rows),
+            "jsonlOutput": str(args.jsonl_output),
+            "csvOutput": str(args.csv_output),
+        }
+    )
+    write_review_files(args.jsonl_output, args.csv_output, rows)
+    write_json(args.manifest_output, manifest)
+    print(json.dumps({"uniqueReviewCount": len(rows), "rawReviewAssignments": raw_assignments}, ensure_ascii=False))
+
+
+def parse_iso(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("review timestamp has no timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def segment_summary(rows: list[dict]) -> dict[str, float | int]:
+    count = len(rows)
+    low = sum(row["score"] <= 2 for row in rows)
+    positive = sum(row["score"] >= 4 for row in rows)
+    return {
+        "review_count": count,
+        "mean_rating": round(sum(row["score"] for row in rows) / count, 4) if count else 0,
+        "low_review_count": low,
+        "low_review_share": round(low * 100 / count, 4) if count else 0,
+        "positive_review_count": positive,
+        "positive_review_share": round(positive * 100 / count, 4) if count else 0,
+    }
+
+
+def aggregate(rows: list[dict], source_sha256: str, as_of: date, min_segment_size: int) -> list[dict]:
+    if len(rows) != len({row.get("reviewId") for row in rows}):
+        raise ValueError("reviewId values must be unique")
+    for row in rows:
+        if row.get("score") not in range(1, 6) or not isinstance(row.get("thumbsUpCount", 0), int) or row.get("thumbsUpCount", 0) < 0:
+            raise ValueError("invalid rating or thumbs-up count")
+        parse_iso(row["reviewedAt"])
+
+    result: list[dict] = []
+
+    def add(section: str, segment: str, metric: str, value: object, unit: str, denominator: object = "", start: str = "", end: str = "", note: str = "") -> None:
+        result.append(dict(zip(AGGREGATE_FIELDS, (section, segment, metric, value, unit, denominator, start, end, note, source_sha256))))
+
+    timestamps = [parse_iso(row["reviewedAt"]) for row in rows]
+    add("scope", "snapshot", "review_count", len(rows), "count")
+    add("scope", "snapshot", "substantive_text_count", sum(bool((row.get("content") or "").strip()) for row in rows), "count", len(rows))
+    add("scope", "snapshot", "reviewed_at_start", min(timestamps).isoformat(), "timestamp")
+    add("scope", "snapshot", "reviewed_at_end", max(timestamps).isoformat(), "timestamp")
+    add("scope", "snapshot", "nonempty_language_stream_count", len({language for row in rows for language in row.get("languageStreams", [])}), "count")
+    assignments = sum(len(row.get("languageStreams", [])) for row in rows)
+    add("scope", "snapshot", "language_stream_assignments", assignments, "count")
+    add("scope", "snapshot", "duplicate_stream_assignments", assignments - len(rows), "count")
+    replies = sum(bool(row.get("hasDeveloperReply") or row.get("replyContent")) for row in rows)
+    add("engagement", "all", "developer_reply_count", replies, "count", len(rows))
+    add("engagement", "all", "developer_reply_share", round(replies * 100 / len(rows), 4), "percent", len(rows))
+    thumbs = [row.get("thumbsUpCount", 0) for row in rows]
+    add("engagement", "all", "thumbs_up_total", sum(thumbs), "count")
+    add("engagement", "all", "reviews_with_thumbs_up", sum(value > 0 for value in thumbs), "count", len(rows))
+
+    overall = segment_summary(rows)
+    for metric, value in overall.items():
+        add("overall", "all", metric, value, "percent" if metric.endswith("share") else "stars" if metric == "mean_rating" else "count", len(rows) if metric.endswith("share") else "")
+
+    ratings = Counter(row["score"] for row in rows)
+    for score in range(1, 6):
+        add("rating", str(score), "review_count", ratings[score], "count", len(rows))
+        add("rating", str(score), "review_share", round(ratings[score] * 100 / len(rows), 4), "percent", len(rows))
+
+    as_of_utc = datetime.combine(as_of, datetime_time.min, timezone.utc)
+    periods = {
+        "recent_90_days": (as_of_utc - timedelta(days=90), as_of_utc),
+        "previous_90_days": (as_of_utc - timedelta(days=180), as_of_utc - timedelta(days=90)),
+    }
+    for name, (start, end) in periods.items():
+        subset = [row for row in rows if start <= parse_iso(row["reviewedAt"]) < end]
+        for metric, value in segment_summary(subset).items():
+            add("period", name, metric, value, "percent" if metric.endswith("share") else "stars" if metric == "mean_rating" else "count", len(subset) if metric.endswith("share") else "", start.isoformat(), end.isoformat())
+
+    by_language: dict[str, list[dict]] = {}
+    for row in rows:
+        for language in row.get("languageStreams", []):
+            if not isinstance(language, str) or not re.fullmatch(r"[A-Za-z]{2,3}(?:-[A-Za-z]{2})?", language):
+                raise ValueError("invalid language stream")
+            by_language.setdefault(language, []).append(row)
+    suppressed = [language for language, subset in by_language.items() if len(subset) < min_segment_size]
+    for language, subset in sorted(by_language.items(), key=lambda item: (-len(item[1]), item[0])):
+        if len(subset) < min_segment_size:
+            continue
+        for metric, value in segment_summary(subset).items():
+            add("language_stream", language, metric, value, "percent" if metric.endswith("share") else "stars" if metric == "mean_rating" else "count", len(subset) if metric.endswith("share") else "", note="queried locale; not detected review language")
+    add("language_stream", "suppressed", "stream_count", len(suppressed), "count", note=f"streams with fewer than {min_segment_size} reviews")
+
+    low_english = [row for row in rows if row["score"] <= 2 and "en" in row.get("languageStreams", [])]
+    add("low_review_theme", "english_stream", "denominator", len(low_english), "count", note="1-2 stars; multi-label keyword matching")
+    for name, pattern in THEMES.items():
+        matched = sum(bool(pattern.search(row.get("content") or "")) for row in low_english)
+        add("low_review_theme", name, "matched_count", matched, "count", len(low_english), note="English stream; multi-label keyword matching")
+        add("low_review_theme", name, "matched_share", round(matched * 100 / len(low_english), 4) if low_english else 0, "percent", len(low_english), note="English stream; multi-label keyword matching")
+    return result
+
+
+def summarize(args: argparse.Namespace) -> None:
+    raw = args.input.read_bytes()
+    rows = [json.loads(line) for line in raw.decode().splitlines() if line]
+    output = aggregate(rows, hashlib.sha256(raw).hexdigest(), date.fromisoformat(args.as_of), args.min_segment_size)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = args.output.with_name(f".{args.output.name}.tmp")
+    with temporary.open("w", encoding="utf-8-sig", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=AGGREGATE_FIELDS, lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(output)
+    temporary.replace(args.output)
+    print(json.dumps({"aggregateRows": len(output), "sourceReviews": len(rows)}, ensure_ascii=False))
+
+
+def self_test(_: argparse.Namespace) -> None:
+    raw_review = [
+        "review-id", ["ignored user", [None, 2, None, [None, None, "ignored image"]]], 1, None,
+        "slow login", [1_700_000_000, 0], 2, ["developer", "ignored reply", [1_700_000_100, 0]],
+        None, [], "1.0", None, None, None, None, None, 1,
+    ]
+    parsed = parse_review(raw_review, "en", "example.app", "2026-08-11T00:00:00+00:00")
+    assert "userName" not in parsed and "replyContent" not in parsed and parsed["score"] == 1
+    assert spreadsheet_safe("=formula") == "'=formula"
+    rows = [parsed, {**parsed, "reviewId": "review-id-2", "content": "works", "score": 5}]
+    result = aggregate(rows, "0" * 64, date(2026, 8, 11), 1)
+    assert any(row["section"] == "low_review_theme" and row["segment"] == "reliability_performance" and row["metric"] == "matched_count" and row["value"] == 1 for row in result)
+    assert not ({"reviewId", "userName", "userImage", "content", "replyContent"} & set(AGGREGATE_FIELDS))
+    with TemporaryDirectory() as directory:
+        write_review_files(Path(directory) / "reviews.jsonl", Path(directory) / "reviews.csv", rows)
+        with (Path(directory) / "reviews.csv").open(encoding="utf-8-sig") as file:
+            assert next(csv.reader(file)) == ["리뷰내용", "별점"]
+    print("self-test: ok")
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=__doc__)
+    commands = root.add_subparsers(dest="command", required=True)
+    crawl_parser = commands.add_parser("crawl", help="crawl public review streams into ignored local data files")
+    crawl_parser.add_argument("--app-id", default="com.salesforce.chatter")
+    crawl_parser.add_argument("--languages", nargs="+", default=list(LANGUAGE_STREAMS))
+    crawl_parser.add_argument("--page-size", type=int, default=4500)
+    crawl_parser.add_argument("--delay", type=float, default=0.25)
+    crawl_parser.add_argument("--timeout", type=int, default=30)
+    crawl_parser.add_argument("--retries", type=int, default=3)
+    crawl_parser.add_argument("--jsonl-output", type=Path, default=Path("data/raw/salesforce_chatter_google_play_reviews.jsonl"))
+    crawl_parser.add_argument("--csv-output", type=Path, default=Path("data/processed/salesforce_reviews_content_rating.csv"))
+    crawl_parser.add_argument("--manifest-output", type=Path, default=Path("data/processed/salesforce_reviews_manifest.json"))
+    crawl_parser.set_defaults(run=crawl)
+
+    summary_parser = commands.add_parser("summarize", help="write a privacy-safe aggregate CSV")
+    summary_parser.add_argument("input", type=Path)
+    summary_parser.add_argument("--output", type=Path, required=True)
+    summary_parser.add_argument("--as-of", default=datetime.now(timezone.utc).date().isoformat())
+    summary_parser.add_argument("--min-segment-size", type=int, default=10)
+    summary_parser.set_defaults(run=summarize)
+
+    test_parser = commands.add_parser("self-test", help="run deterministic parser and aggregation checks")
+    test_parser.set_defaults(run=self_test)
+    return root
+
+
+if __name__ == "__main__":
+    arguments = parser().parse_args()
+    arguments.run(arguments)


### PR DESCRIPTION
## 변경 요약

- Google Play 공개 리뷰를 77개 언어 스트림에서 수집하고 continuation token 종료까지 순회하는 표준 라이브러리 스크립트를 추가했습니다.
- 원본은 Git에서 제외된 `data/`에만 저장하고, 작성자·프로필 이미지·개발자 답변 원문은 수집하지 않습니다.
- 2026-08-11 스냅샷 18,474건에서 생성한 평점·기간·언어 스트림·영어 저평점 주제별 비식별 집계 CSV와 방법론 문서를 추가했습니다.

## 검증

- `python3 -m py_compile scripts/google_play_reviews.py`
- `python3 scripts/google_play_reviews.py self-test`
- 한국어 공개 스트림 실수집: 120건, JSONL/2열 CSV 일치, 직접 식별 필드 미수집 확인
- 집계 CSV 재생성 byte 비교: 일치
- 원본 SHA-256·18,474건·평점 합·본문 존재·언어 배정·답변·공감 골든 수치 검증
- 집계 CSV에 리뷰 본문·작성자·답변 원문 값이 없음을 검사
- `git diff --cached --check`

## 영향 및 주의 사항

- 제품 런타임 의존성 변경은 없습니다.
- 개별 리뷰 본문 CSV와 원본 JSONL은 저장소 정책에 따라 커밋하지 않았습니다.
- Google Play의 문서화되지 않은 공개 웹 UI RPC를 사용하므로 응답 형식이 바뀌면 수집기가 실패하도록 구성했습니다.