### PR TITLE
SalesLuv 멀티에이전트 워크플로우 문서 추가

### DIFF
--- a/docs/technical/SalesLuv_멀티에이전트_운영_플로우.html
+++ b/docs/technical/SalesLuv_멀티에이전트_운영_플로우.html
@@ -1,0 +1,516 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="SalesLuv가 정말 멀티에이전트가 필요한 이유와 세션 기반 map-reduce 구조">
+  <title>SalesLuv 멀티에이전트 워크플로우 v2</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --paper: #fbfbf9;
+      --surface: #ffffff;
+      --ink: #191f26;
+      --text: #3c454e;
+      --muted: #79828c;
+      --line: #e5e8ec;
+      --line-strong: #cfd5db;
+      --accent: #1f6feb;
+      --accent-soft: #eef4fe;
+      --amber: #a05f0a;
+      --amber-soft: #fdf5e7;
+      --green: #0f7b5f;
+      --green-soft: #eaf6f1;
+      --red: #b3403a;
+      --red-soft: #fbeeed;
+    }
+
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      background: var(--paper);
+      color: var(--text);
+      font-family: Pretendard, "Apple SD Gothic Neo", "Noto Sans KR", system-ui, sans-serif;
+      font-size: 16px;
+      line-height: 1.7;
+      word-break: keep-all;
+      -webkit-font-smoothing: antialiased;
+    }
+    .wrap { width: min(920px, calc(100% - 48px)); margin: 0 auto; }
+    .mono {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 11px;
+      letter-spacing: .14em;
+      text-transform: uppercase;
+    }
+
+    /* ---------- header ---------- */
+    header { padding: 64px 0 0; }
+    .meta {
+      display: flex; justify-content: space-between; gap: 16px;
+      padding-bottom: 20px; margin-bottom: 48px;
+      border-bottom: 1px solid var(--line-strong);
+      color: var(--muted);
+    }
+    .meta b { color: var(--ink); font-weight: 700; }
+    h1 {
+      margin: 0 0 20px;
+      color: var(--ink);
+      font-size: clamp(30px, 5vw, 44px);
+      font-weight: 800;
+      letter-spacing: -.045em;
+      line-height: 1.25;
+    }
+    h1 .accent { color: var(--accent); }
+    .stance {
+      max-width: 780px;
+      margin: 0;
+      font-size: 17.5px;
+      color: var(--text);
+    }
+    .stance b { color: var(--ink); }
+    /* ---------- sections ---------- */
+    section { padding: 72px 0 0; }
+    .sec-head { display: flex; align-items: baseline; gap: 14px; margin-bottom: 8px; }
+    .sec-head .no { color: var(--accent); font-weight: 700; }
+    h2 {
+      margin: 0;
+      color: var(--ink);
+      font-size: clamp(22px, 3vw, 28px);
+      font-weight: 800;
+      letter-spacing: -.035em;
+    }
+    .sec-lead { max-width: 800px; margin: 10px 0 32px; color: var(--muted); font-size: 15.5px; }
+    .sec-lead b { color: var(--ink); font-weight: 700; }
+
+    /* ---------- reasons ---------- */
+    .reasons { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    .reason {
+      padding: 22px 24px;
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-left: 3px solid var(--accent);
+      border-radius: 10px;
+    }
+    .reason .tag { color: var(--accent); font-weight: 700; }
+    .reason h3 { margin: 6px 0 8px; color: var(--ink); font-size: 18px; letter-spacing: -.02em; }
+    .reason p { margin: 0; font-size: 14.5px; }
+    .reason .vs {
+      display: block;
+      margin-top: 14px; padding-top: 12px;
+      border-top: 1px dashed var(--line);
+      color: var(--muted); font-size: 13px;
+    }
+    .reason .vs b { color: var(--red); font-weight: 700; }
+
+    .callout {
+      margin-top: 16px;
+      padding: 20px 24px;
+      border: 1px solid #ecdcbb;
+      border-left: 3px solid var(--amber);
+      border-radius: 10px;
+      background: var(--amber-soft);
+      font-size: 14.5px;
+      color: #6b4a10;
+    }
+    .callout b { color: var(--amber); }
+
+    .mini-head { margin: 34px 0 14px; color: var(--ink); font-size: 16px; font-weight: 800; letter-spacing: -.02em; }
+
+    /* ---------- agent roster ---------- */
+    .roster { display: flex; flex-wrap: wrap; gap: 10px; margin-bottom: 18px; padding-bottom: 16px; border-bottom: 1px solid var(--line); }
+    .roster span {
+      display: inline-flex; align-items: baseline; gap: 8px;
+      padding: 8px 14px;
+      border: 1px solid rgba(31,111,235,.4);
+      border-radius: 999px;
+      background: var(--accent-soft);
+      font-size: 12.5px; font-weight: 700; color: var(--ink);
+    }
+    .roster span i { font-style: normal; font-family: ui-monospace, Menlo, monospace; font-size: 9px; font-weight: 800; letter-spacing: .1em; color: var(--accent); }
+    .roster span small { color: var(--muted); font-size: 10.5px; font-weight: 500; }
+    .roster .rest { border-style: dashed; border-color: var(--line-strong); background: var(--surface); color: var(--muted); font-weight: 600; }
+
+    /* ---------- components table ---------- */
+    .table-wrap { overflow-x: auto; border: 1px solid var(--line); border-radius: 12px; background: var(--surface); }
+    table { width: 100%; border-collapse: collapse; font-size: 13.5px; min-width: 640px; }
+    th, td { padding: 12px 16px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }
+    th { color: var(--muted); font-size: 10.5px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; background: var(--paper); }
+    tr:last-child td { border-bottom: none; }
+    td b { color: var(--ink); }
+
+    /* ---------- user workflow steps ---------- */
+    .steps { display: grid; gap: 10px; }
+    .step {
+      display: flex; align-items: center; gap: 14px;
+      padding: 14px 18px;
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 10px;
+    }
+    .step .n {
+      flex: 0 0 26px; height: 26px;
+      display: grid; place-items: center;
+      border-radius: 50%;
+      background: var(--accent); color: #fff;
+      font-size: 12px; font-weight: 800;
+    }
+    .step .body { min-width: 0; }
+    .step .body b { display: block; color: var(--ink); font-size: 14.5px; letter-spacing: -.01em; }
+    .step .body span { display: block; color: var(--muted); font-size: 13px; }
+    .who {
+      margin-left: auto; align-self: center;
+      white-space: nowrap;
+      padding: 3px 10px; border-radius: 999px;
+      font-size: 10.5px; font-weight: 800;
+    }
+    .who.agent { background: var(--accent-soft); color: var(--accent); }
+    .who.reduce { background: var(--amber-soft); color: var(--amber); }
+    .who.fn { background: #f0f2f5; color: var(--muted); }
+    .who.gate { background: var(--green-soft); color: var(--green); }
+
+    /* ---------- diagram ---------- */
+    .diagram {
+      position: relative;
+      padding: 28px clamp(16px, 4vw, 34px) 24px;
+      background:
+        radial-gradient(circle at 1px 1px, rgba(31, 111, 235, .08) 1px, transparent 0) 0 0 / 22px 22px,
+        var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      box-shadow: 0 18px 54px rgba(25, 31, 38, .06);
+      overflow-x: auto;
+    }
+    .legend {
+      display: flex; flex-wrap: wrap; gap: 16px;
+      margin-top: 22px; padding-top: 15px;
+      border-top: 1px solid var(--line);
+      color: var(--muted); font-size: 11.5px;
+    }
+    .legend i {
+      display: inline-block; width: 11px; height: 11px;
+      margin-right: 6px; border-radius: 3px; vertical-align: -1px;
+      border: 1px solid var(--line-strong); background: var(--paper);
+    }
+    .legend .l-agent i { border-color: var(--accent); background: var(--accent-soft); }
+    .legend .l-reduce i { border-color: #d9a75c; background: var(--amber-soft); }
+    .legend .l-func i { border-style: dashed; background: var(--surface); }
+    .legend .l-gate i { border-color: var(--green); background: var(--green-soft); }
+
+    /* ---------- workflow graph ---------- */
+    .wf-svg { display: block; width: 100%; height: auto; }
+    .wf-svg text { font-family: inherit; }
+
+    /* ---------- footer ---------- */
+    .keyline {
+      margin-top: 84px;
+      padding: 36px 0 40px;
+      border-top: 1px solid var(--line-strong);
+    }
+    .keyline p {
+      max-width: 840px;
+      margin: 10px 0 0;
+      color: var(--ink);
+      font-size: 17.5px;
+      font-weight: 600;
+      letter-spacing: -.02em;
+      line-height: 1.65;
+    }
+    .keyline em { font-style: normal; color: var(--accent); }
+    .foot { padding: 8px 0 48px; color: var(--muted); font-size: 12.5px; }
+
+    .swipe-hint { display: none; margin: 0 0 10px; color: var(--muted); font-size: 11.5px; }
+
+    @media (max-width: 680px) {
+      .reasons { grid-template-columns: 1fr; }
+      .meta { flex-direction: column; gap: 2px; }
+      header { padding-top: 40px; }
+      section { padding-top: 54px; }
+      .wrap { width: calc(100% - 32px); }
+      .wf-svg { min-width: 840px; }
+      .swipe-hint { display: block; }
+      .step { flex-wrap: wrap; }
+      .step .who { margin-left: 40px; }
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <div class="wrap">
+    <div class="meta mono">
+      <span><b>SalesLuv</b> · 멀티에이전트 워크플로우</span>
+      <span>v2 · 2026-08 · docs/technical</span>
+    </div>
+    <h1>에이전트는 판단이 필요한 곳에만.<br><span class="accent">나머지는 함수와 서비스로.</span></h1>
+    <p class="stance">
+      SalesLuv는 서로 다른 책임과 판단 범위를 가진 Assistant Agent, Deal Agent, Portfolio Agent가 협업하는 멀티에이전트 CRM이다.
+      Deal Agent는 딜별 독립 인스턴스로 실행되며, Portfolio Agent와 제약 및 판단 결과를 주고받아 전체 영업 우선순위와 일정을 완성한다.
+    </p>
+  </div>
+</header>
+
+<main class="wrap">
+
+  <!-- 01 -->
+  <section id="why">
+    <div class="sec-head"><span class="no mono">01</span><h2>왜 멀티에이전트이고, 왜 LLM인가</h2></div>
+    <p class="sec-lead">
+      멀티에이전트가 성립하는 상황은 하나다 — <b>한 영업사원이 서로 다른 상태의 여러 딜을 동시에 관리하며, 한정된 시간을 그 사이에 배분해야 한다.</b>
+      활성 딜이 1~2개면 단일 에이전트가 낫다. 이 구조는 딜이 늘어나 하나의 문맥에 다 넣을 수 없을 때 성립한다.
+    </p>
+
+    <p class="mini-head">1-1 · 왜 멀티에이전트인가 — 결정적 이유는 하나다</p>
+    <div class="core-reason">
+      <h3>목적 함수의 분리, 그리고 그 사이의 협상</h3>
+      <p>
+        개별 딜의 최선("이번 주 미팅을 잡아야 한다")과 전체 시간 배분("모든 딜이 그렇게 말한다")은
+        서로 <b>충돌하는 다른 목적 함수</b>다. 한 판단 주체에 두 목표를 함께 주면
+        대변인과 심판을 한 사람이 맡는 꼴이 되어 판단이 서로를 오염시키고,
+        충돌이 생겼을 때 제약을 주고받으며 재판단할 <b>상대가 없다</b>.
+      </p>
+      <p>
+        그래서 목적별로 판단 주체를 분리한다 — Deal은 딜 내부의 최선만(국소), Portfolio는 전체 배분만(전역).
+        충돌하면 Portfolio가 제약을 되돌려 보내고, 해당 딜이 자기 문맥에서 다시 판단한다(양방향 재판단).
+        <b>이 분리와 협상이 멀티에이전트의 유일한 결정적 근거다.</b>
+      </p>
+    </div>
+    <div class="side-benefits">
+      <b>따라오는 운영상 이점 — 멀티의 증명은 아니다.</b>
+      문맥 격리(딜 간 정보 간섭 없음) · 부분 재실행(바뀐 딜만 재계산) · 실패 격리(재시도 단위 축소)는
+      단일 에이전트 + 세션 구조로도 얻을 수 있다. 이 구조를 택하면 기본으로 따라온다.
+    </div>
+
+    <p class="mini-head">1-2 · 왜 룰 기반이 아니라 LLM인가</p>
+    <div class="callout">
+      <b>LLM이 필요한 지점은 둘이다.</b>
+      ① <b>비정형 데이터 해석</b> — 딜 입력의 원천부터가 STT 전사·OCR·사용자 자유 입력이다. 룰이 돌아갈 구조화 필드(단계·위험·약속)는 <b>LLM이 그 원문에서 추출해 만든 2차 산물</b>이라, LLM 없이는 요약·정리·판단의 대상 자체가 만들어지지 않는다. "예산은 확보됐지만 결재권자가 바뀌었다"에서 위험을 뽑는 룰은 만들 수 없다.
+      ② <b>에이전트 간 소통과 우선순위 판단</b> — 에이전트끼리 주고받는 Deal State의 위험·근거·제약은 숫자가 아니라 의미다. 정성 신호(관계 위험 · 이의 · 경쟁 맥락)를 비교해 트레이드오프를 정하고, 재분석 요청의 제약을 해석하고, 그 이유를 승인 화면에 문장으로 설명하는 일은 가중치 공식으로 되지 않는다.
+      결정적 조건(기한 D-day · 미접촉 · 정체 감지)은 여전히 룰이 하고, Deal Agent를 깨우는 것도 룰이다 — <b>룰은 트리거와 계산, LLM은 해석과 판단.</b>
+    </div>
+  </section>
+
+  <!-- 02 -->
+  <section id="workflow">
+    <div class="sec-head"><span class="no mono">02</span><h2>멀티에이전트 구조도 — 한 사이클</h2></div>
+    <p class="sec-lead">
+      Deal Agent 역할을 <b>딜 수만큼 독립 인스턴스로 병렬 실행</b>하고(map), 구조화된 Deal State만 위로 올린다.
+      <b>Portfolio Agent가 우선순위를 판별하고, 충돌한 딜에는 제약을 붙여 재분석을 요청</b>하며(양방향), 팀장 단위는 Team Reduce 1회 호출로 종합한다.
+      승인된 변경은 CRM에 반영되어 <b>다음 사이클의 입력</b>이 된다.
+      파란 대형 노드가 에이전트다 — 나머지는 에이전트에게 데이터를 나르고, 결과를 받아 적는 조연이다.
+    </p>
+
+    <div class="diagram">
+      <div class="roster">
+        <span><i>AGENT 01</i> Assistant <small>대화 · chat_session_id</small></span>
+        <span><i>AGENT 02</i> Deal ×N 세션 <small>딜 분석 · deal_id</small></span>
+        <span><i>AGENT 03</i> Portfolio <small>전역 조정 · owner_user_id</small></span>
+        <span class="rest">그 외는 전부 함수 · 서비스 · 승인 게이트</span>
+      </div>
+      <p class="swipe-hint">📱 다이어그램은 옆으로 밀어서 볼 수 있어요 →</p>
+      <svg class="wf-svg" viewBox="0 0 920 510" role="img"
+           aria-label="에이전트 워크플로우: 트리거 이벤트가 Orchestrator를 거쳐 Deal Agent 세션들을 병렬 실행하고, Deal State가 Portfolio Agent와 Team Reduce를 거쳐 승인 게이트에서 확정되어 CRM에 반영된 뒤 다음 사이클로 돌아온다. Assistant Agent는 사용자 대화로 CRM 조회와 세션 실행을 담당한다.">
+        <defs>
+          <linearGradient id="gradAgent" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0" stop-color="#2e7dff"/>
+            <stop offset="1" stop-color="#1a55c8"/>
+          </linearGradient>
+          <filter id="fGlow" x="-30%" y="-30%" width="160%" height="160%">
+            <feDropShadow dx="0" dy="6" stdDeviation="7" flood-color="#1f6feb" flood-opacity="0.28"/>
+          </filter>
+          <marker id="mDark" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse">
+            <path d="M0,0 L10,5 L0,10 z" fill="#3c454e"/>
+          </marker>
+          <marker id="mBlue" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse">
+            <path d="M0,0 L10,5 L0,10 z" fill="#1f6feb"/>
+          </marker>
+          <marker id="mAmber" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse">
+            <path d="M0,0 L10,5 L0,10 z" fill="#a05f0a"/>
+          </marker>
+          <marker id="mGreen" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse">
+            <path d="M0,0 L10,5 L0,10 z" fill="#0f7b5f"/>
+          </marker>
+        </defs>
+
+        <!-- feedback: DB → 다음 사이클 -->
+        <path d="M486,462 L15,462 L15,74 L24,74" fill="none" stroke="#a05f0a" stroke-width="1.6" stroke-dasharray="5 4" marker-end="url(#mAmber)"/>
+        <text x="250" y="450" text-anchor="middle" font-size="10.5" font-weight="700" fill="#a05f0a">변경된 딜만 dirty → 다음 사이클 부분 재실행</text>
+
+        <!-- main pipeline edges -->
+        <line x1="190" y1="74" x2="244" y2="74" stroke="#3c454e" stroke-width="1.6" marker-end="url(#mDark)"/>
+        <path d="M430,74 C462,74 466,100 486,104" fill="none" stroke="#1f6feb" stroke-width="1.6" marker-end="url(#mBlue)"/>
+        <path d="M430,74 C468,74 460,150 486,158" fill="none" stroke="#1f6feb" stroke-width="1.6" marker-end="url(#mBlue)"/>
+        <path d="M430,74 C472,74 456,202 486,212" fill="none" stroke="#1f6feb" stroke-width="1.6" marker-end="url(#mBlue)"/>
+        <text x="340" y="132" text-anchor="middle" font-size="10" fill="#79828c">필요한 세션만 병렬 실행 (map)</text>
+        <path d="M300,108 C282,126 232,150 196,162" fill="none" stroke="#3c454e" stroke-width="1.4" marker-end="url(#mDark)"/>
+        <text x="243" y="147" text-anchor="middle" font-size="9" fill="#79828c">보고서 초안 호출</text>
+        <line x1="720" y1="118" x2="750" y2="118" stroke="#1f6feb" stroke-width="2.2" marker-end="url(#mBlue)"/>
+        <line x1="755" y1="150" x2="724" y2="150" stroke="#a05f0a" stroke-width="2.2" marker-end="url(#mAmber)"/>
+        <line x1="835" y1="180" x2="835" y2="326" stroke="#3c454e" stroke-width="1.6" marker-end="url(#mDark)"/>
+        <text x="827" y="225" text-anchor="end" font-size="9.5" fill="#79828c">일정·업무 제안 — 전부 초안</text>
+        <line x1="595" y1="426" x2="595" y2="390" stroke="#3c454e" stroke-width="1.4" marker-end="url(#mDark)"/>
+        <text x="606" y="412" text-anchor="start" font-size="9" fill="#79828c">확정 보고서·매출 집계</text>
+        <line x1="687" y1="353" x2="754" y2="361" stroke="#a05f0a" stroke-width="1.6" marker-end="url(#mAmber)"/>
+        <text x="716" y="341" text-anchor="middle" font-size="9" font-weight="700" fill="#a05f0a">팀 브리핑·제안</text>
+        <path d="M905,332 C919,296 919,215 905,184" fill="none" stroke="#a05f0a" stroke-width="1.6" stroke-dasharray="5 4" marker-end="url(#mAmber)"/>
+        <path d="M835,400 L835,462 L728,462" fill="none" stroke="#0f7b5f" stroke-width="1.6" marker-end="url(#mGreen)"/>
+        <text x="780" y="452" text-anchor="middle" font-size="9.5" font-weight="700" fill="#0f7b5f">승인된 값만</text>
+
+        <!-- assistant edges -->
+        <line x1="112" y1="310" x2="156" y2="310" stroke="#3c454e" stroke-width="1.6" marker-end="url(#mDark)"/>
+        <path d="M265,246 C265,200 420,228 486,228" fill="none" stroke="#1f6feb" stroke-width="1.6" stroke-dasharray="4 3" marker-end="url(#mBlue)"/>
+        <text x="345" y="207" text-anchor="middle" font-size="9.5" font-weight="700" fill="#1f6feb">판단 필요 시 세션 실행</text>
+        <path d="M370,340 C430,350 450,430 486,450" fill="none" stroke="#1f6feb" stroke-width="1.6" stroke-dasharray="4 3" marker-end="url(#mBlue)"/>
+        <text x="415" y="392" text-anchor="middle" font-size="9.5" font-weight="700" fill="#1f6feb">사실 조회</text>
+
+        <!-- service / data nodes -->
+        <rect x="30" y="40" width="160" height="68" rx="10" fill="#ffffff" stroke="#cfd5db" stroke-width="1.2"/>
+        <text x="110" y="66" text-anchor="middle" font-size="12.5" font-weight="700" fill="#191f26">트리거 이벤트</text>
+        <text x="110" y="84" text-anchor="middle" font-size="10" fill="#79828c">일정 임박 · 딜 변경 · 기록 확정</text>
+
+        <rect x="250" y="40" width="180" height="68" rx="10" fill="#191f26"/>
+        <text x="340" y="66" text-anchor="middle" font-size="12.5" font-weight="700" fill="#ffffff">Orchestrator Service</text>
+        <text x="340" y="84" text-anchor="middle" font-size="10" fill="#aeb7c1">호출 · 전달 · 저장 · 완료 처리</text>
+
+        <rect x="755" y="78" width="160" height="98" rx="12" fill="url(#gradAgent)" filter="url(#fGlow)"/>
+        <text x="835" y="97" text-anchor="middle" font-size="8.5" font-weight="800" letter-spacing="1.2" fill="#cfe0ff">AGENT 03 · PORTFOLIO</text>
+        <text x="835" y="117" text-anchor="middle" font-size="13.5" font-weight="800" fill="#ffffff">Portfolio Agent ⟳</text>
+        <text x="835" y="136" text-anchor="middle" font-size="9.5" fill="rgba(255,255,255,.88)">Deal State 비교 · 우선순위 판별</text>
+        <text x="835" y="152" text-anchor="middle" font-size="9" fill="rgba(255,255,255,.88)">캘린더 조회 → 일정 배치 → 조정 ⟳</text>
+        <text x="835" y="169" text-anchor="middle" font-size="8.5" fill="rgba(255,255,255,.68)">상태 · owner_user_id</text>
+
+        <rect x="505" y="322" width="180" height="62" rx="10" fill="#fdf5e7" stroke="#d9a75c" stroke-width="1.2"/>
+        <text x="595" y="342" text-anchor="middle" font-size="12" font-weight="700" fill="#191f26">Team Reduce</text>
+        <text x="595" y="358" text-anchor="middle" font-size="9" fill="#a05f0a">팀장 · 1회 종합 — 보조 경로</text>
+        <text x="595" y="373" text-anchor="middle" font-size="9" fill="#79828c">리스크 · 코칭 · 목표 갭</text>
+
+        <rect x="760" y="330" width="150" height="70" rx="10" fill="#eaf6f1" stroke="#0f7b5f" stroke-width="1.2"/>
+        <text x="835" y="353" text-anchor="middle" font-size="12.5" font-weight="700" fill="#191f26">사용자 승인 게이트</text>
+        <text x="835" y="370" text-anchor="middle" font-size="9.5" fill="#0f7b5f">모든 제안은 초안</text>
+        <text x="835" y="385" text-anchor="middle" font-size="9.5" fill="#79828c">선택 · 수정 · 결재</text>
+
+        <rect x="490" y="430" width="230" height="64" rx="10" fill="#f4f6f8" stroke="#cfd5db" stroke-width="1.2"/>
+        <text x="605" y="456" text-anchor="middle" font-size="12.5" font-weight="700" fill="#191f26">CRM 기준 상태 · DB</text>
+        <text x="605" y="474" text-anchor="middle" font-size="10" fill="#79828c">승인된 값만 반영 · 다음 실행의 입력</text>
+
+        <rect x="30" y="150" width="160" height="76" rx="10" fill="rgba(255,255,255,.85)" stroke="#b9c2cb" stroke-width="1.2" stroke-dasharray="5 4"/>
+        <text x="110" y="170" text-anchor="middle" font-size="8.5" font-weight="800" letter-spacing="1.2" fill="#79828c">LLM FN ×1 · 단발</text>
+        <text x="110" y="189" text-anchor="middle" font-size="10.5" font-weight="700" fill="#191f26">미팅 보고서 작성</text>
+        <text x="110" y="207" text-anchor="middle" font-size="9" fill="#79828c">STT · OCR · 직접 입력 → 초안</text>
+
+        <rect x="20" y="282" width="90" height="56" rx="9" fill="#ffffff" stroke="#cfd5db" stroke-width="1.2"/>
+        <text x="65" y="306" text-anchor="middle" font-size="12" font-weight="700" fill="#191f26">사용자</text>
+        <text x="65" y="322" text-anchor="middle" font-size="10" fill="#79828c">질문 · 승인</text>
+
+        <!-- AGENT: Deal panel -->
+        <rect x="490" y="20" width="230" height="260" rx="16" fill="url(#gradAgent)" filter="url(#fGlow)"/>
+        <text x="605" y="44" text-anchor="middle" font-size="9" font-weight="800" letter-spacing="1.5" fill="#cfe0ff">AGENT 02 · PARALLEL MAP</text>
+        <text x="605" y="67" text-anchor="middle" font-size="17" font-weight="800" fill="#ffffff">Deal Agent ⟳</text>
+        <rect x="506" y="82" width="198" height="46" rx="9" fill="rgba(255,255,255,.13)" stroke="rgba(255,255,255,.4)"/>
+        <text x="605" y="100" text-anchor="middle" font-size="11.5" font-weight="700" fill="#ffffff">Session A · deal_id=A</text>
+        <text x="605" y="115" text-anchor="middle" font-size="9.5" fill="rgba(255,255,255,.78)">도구 선택 → 조회 → 판단 ⟳</text>
+        <rect x="506" y="136" width="198" height="46" rx="9" fill="rgba(255,255,255,.13)" stroke="rgba(255,255,255,.4)"/>
+        <text x="605" y="154" text-anchor="middle" font-size="11.5" font-weight="700" fill="#ffffff">Session B · deal_id=B</text>
+        <text x="605" y="169" text-anchor="middle" font-size="9.5" fill="rgba(255,255,255,.78)">도구 선택 → 조회 → 판단 ⟳</text>
+        <rect x="506" y="190" width="198" height="46" rx="9" fill="rgba(255,255,255,.13)" stroke="rgba(255,255,255,.4)"/>
+        <text x="605" y="208" text-anchor="middle" font-size="11.5" font-weight="700" fill="#ffffff">Session C · deal_id=C</text>
+        <text x="605" y="223" text-anchor="middle" font-size="9.5" fill="rgba(255,255,255,.78)">도구 선택 → 조회 → 판단 ⟳</text>
+        <text x="605" y="254" text-anchor="middle" font-size="10" fill="rgba(255,255,255,.85)">딜 판단 · 미팅 브리핑 생성</text>
+        <text x="605" y="268" text-anchor="middle" font-size="9" fill="rgba(255,255,255,.68)">독립 상태·이력 · 병렬 실행</text>
+
+        <!-- AGENT: Assistant -->
+        <rect x="160" y="250" width="210" height="120" rx="14" fill="url(#gradAgent)" filter="url(#fGlow)"/>
+        <text x="265" y="272" text-anchor="middle" font-size="9" font-weight="800" letter-spacing="1.5" fill="#cfe0ff">AGENT 01 · CHAT</text>
+        <text x="265" y="294" text-anchor="middle" font-size="16" font-weight="800" fill="#ffffff">Assistant Agent ⟳</text>
+        <text x="265" y="316" text-anchor="middle" font-size="10.5" fill="rgba(255,255,255,.88)">범위 해석 → 도구 조회 → 답변</text>
+        <text x="265" y="332" text-anchor="middle" font-size="10.5" fill="rgba(255,255,255,.88)">근거가 부족하면 반복 ⟳</text>
+        <text x="265" y="356" text-anchor="middle" font-size="9.5" fill="rgba(255,255,255,.68)">상태 · chat_session_id</text>
+
+        <!-- 에이전트 간 통신 라벨 (halo, 최상단) -->
+        <text x="736" y="106" text-anchor="middle" font-size="9.5" font-weight="800" fill="#1f6feb" stroke="#ffffff" stroke-width="3" paint-order="stroke">Deal State →</text>
+        <text x="736" y="167" text-anchor="middle" font-size="9" font-weight="800" fill="#a05f0a" stroke="#ffffff" stroke-width="3" paint-order="stroke">← 제약·재분석</text>
+        <text x="893" y="252" text-anchor="end" font-size="8.5" font-weight="800" fill="#a05f0a" stroke="#ffffff" stroke-width="3" paint-order="stroke">팀 목표 변경 승인</text>
+        <text x="893" y="266" text-anchor="end" font-size="8.5" font-weight="800" fill="#a05f0a" stroke="#ffffff" stroke-width="3" paint-order="stroke">→ Portfolio 재계획</text>
+      </svg>
+
+      <div class="legend">
+        <span class="l-agent"><i></i>파란 노드 — 에이전트 ×3 (⟳ 판단 루프)</span>
+        <span class="l-reduce"><i></i>Team Reduce — 보조 경로 · 1회 종합</span>
+        <span class="l-func"><i></i>LLM 함수 — 단발</span>
+        <span class="l-gate"><i></i>승인 게이트</span>
+        <span><span style="color:#a05f0a;font-weight:800;">—</span> Portfolio의 제약·재분석 요청</span>
+        <span><span style="color:#1f6feb;font-weight:800;">┄</span> Assistant의 조회·실행</span>
+        <span><span style="color:#a05f0a;font-weight:800;">┄</span> 승인 후 다음 사이클 재실행</span>
+      </div>
+    </div>
+
+  </section>
+
+  <!-- 03 -->
+  <section id="components">
+    <div class="sec-head"><span class="no mono">03</span><h2>각 구성요소 설명</h2></div>
+    <p class="sec-lead">
+      역할 경계의 한 줄 규칙 — <b>Deal은 딜 내부(무엇·왜), Portfolio는 딜 사이(언제·순서), 팀 층위는 팀장 승인을 거친 보조 경로.</b>
+      이 경계는 프롬프트 규율이 아니라 스키마 계약(위로는 Deal State만, 아래로는 ReanalysisRequest만)으로 강제된다.
+    </p>
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th style="width:24%">구성요소</th><th style="width:18%">유형</th><th>하는 일</th></tr></thead>
+        <tbody>
+          <tr><td><b>Assistant Agent</b></td><td><span class="who agent">에이전트 ⟳</span></td><td>챗봇 진입점. 질문 범위를 해석하고 권한 안에서 조회하며, 판단이 필요하면 세션을 실행해 근거와 함께 답한다</td></tr>
+          <tr><td><b>Deal Agent ×N</b></td><td><span class="who agent">에이전트 ⟳</span></td><td>딜 하나의 위험·가치·다음 행동을 판단하고, 확정된 미팅에는 목표·질문·위험·준비물로 구성된 브리핑을 생성. <b>딜 내부만 본다</b> — 다른 딜의 존재를 모름</td></tr>
+          <tr><td><b>Portfolio Agent</b></td><td><span class="who agent">에이전트 ⟳</span></td><td>전체 딜을 비교해 우선순위 판별, 캘린더를 조회하며 일정 배치(언제·순서). <b>딜 사이만 본다</b> — 원문 기록엔 접근 없음, 충돌 딜에는 재분석 요청</td></tr>
+          <tr><td><b>Team Reduce</b></td><td><span class="who reduce">판단 호출 ×1</span></td><td>팀원별 결과·보고서·매출 집계를 한 번에 종합해 팀 리스크·코칭 포인트 제안. 팀장 승인 → 팀 목표 변경 이벤트 → Portfolio 재계획의 <b>보조 피드백 경로</b></td></tr>
+          <tr><td><b>미팅 보고서 작성 함수</b></td><td><span class="who fn">LLM 함수</span></td><td>미팅 후 STT·OCR·직접 입력을 해석해 같은 카드 안에 보고서 초안과 고객·딜 변경안을 생성</td></tr>
+          <tr><td><b>Orchestrator</b></td><td><span class="who fn">일반 서비스</span></td><td>이벤트에 맞는 Agent·함수를 호출하고 데이터를 전달하며, 승인 후 저장·미팅 완료·재분석 요청을 처리. 콘텐츠를 직접 판단하거나 작성하지 않음</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- 04 -->
+  <section id="scenarios">
+    <div class="sec-head"><span class="no mono">04</span><h2>사용 시나리오 — 팀원과 팀장</h2></div>
+    <p class="sec-lead">
+      두 화면의 원칙은 같다 — <b>LLM은 분석·준비·초안·제안까지, 확정은 사람의 선택과 결재로.</b>
+      팀원은 에이전트를 직접 부르지 않는다. 추천을 받고, 선택하고, 승인하는 것이 사용자의 일이다.
+    </p>
+
+    <p class="mini-head">팀원(영업사원)의 하루</p>
+    <div class="steps">
+      <div class="step"><span class="n">1</span><div class="body"><b>하루 시작 — 오늘의 우선순위 확인</b><span>전체 딜 비교 결과와 추천 일정을 보고, 선택한 항목만 캘린더에 등록</span></div><span class="who agent">Portfolio Agent</span></div>
+      <div class="step"><span class="n">2</span><div class="body"><b>미팅 전 — 카드에서 브리핑 확인</b><span>오늘의 미팅 카드를 열어 고객 히스토리, 딜 상태, 확인할 질문과 준비물을 확인</span></div><span class="who agent">Deal Agent</span></div>
+      <div class="step"><span class="n">3</span><div class="body"><b>미팅 후 — 같은 카드에서 보고서 작성</b><span>STT·OCR·직접 입력 → LLM이 미팅 보고서와 고객·딜 변경안 초안 생성</span></div><span class="who fn">미팅 보고서 작성 함수</span></div>
+      <div class="step"><span class="n">4</span><div class="body"><b>보고서 확정 — 미팅 완료</b><span>사용자가 초안을 수정·확정하면 보고서가 제출되고 해당 일정이 완료 상태로 전환</span></div><span class="who gate">사용자 확정</span></div>
+      <div class="step"><span class="n">5</span><div class="body"><b>정보 반영 — 다음 판단 시작</b><span>승인된 변경만 CRM에 반영되고, 해당 Deal과 전체 Portfolio가 새로운 정보로 재계산</span></div><span class="who agent">Deal → Portfolio</span></div>
+      <div class="step"><span class="n">6</span><div class="body"><b>수시 — 챗봇 질문</b><span>"이번 달 성사 가능성 높은 딜은?" — 권한 범위에서 근거와 함께 답변</span></div><span class="who agent">Assistant Agent</span></div>
+    </div>
+
+    <p class="mini-head">팀장의 하루 — 숫자(매출 집계·달성률)는 LLM이 아니라 서비스가 계산한다</p>
+    <div class="steps">
+      <div class="step"><span class="n">1</span><div class="body"><b>아침 — 팀 브리핑</b><span>팀원별 파이프라인 요약, 관계·지연 리스크, 코칭 포인트, 목표 갭 해석 확인</span></div><span class="who reduce">Team Reduce</span></div>
+      <div class="step"><span class="n">2</span><div class="body"><b>보고 현황 확인</b><span>완료된 미팅별 보고서와 아직 보고서가 확정되지 않은 일정을 한 화면에서 확인</span></div><span class="who fn">일반 서비스</span></div>
+      <div class="step"><span class="n">3</span><div class="body"><b>보고서 검토</b><span>팀원이 미팅 카드에서 확정한 보고서와 주요 이슈를 확인</span></div><span class="who fn">조회</span></div>
+      <div class="step"><span class="n">4</span><div class="body"><b>매출 관리</b><span>매출 자료(xlsx) 업로드 → 추출 초안 확인·확정 → 목표 달성률 자동 집계</span></div><span class="who fn">서비스 계산 → 확정</span></div>
+      <div class="step"><span class="n">5</span><div class="body"><b>팀 목표 조정</b><span>집중 상품·기간 목표 변경을 결재하면, 팀원 전원의 우선순위가 자동 재계산</span></div><span class="who agent">이벤트 → Portfolio</span></div>
+      <div class="step"><span class="n">6</span><div class="body"><b>수시 — 팀 범위 질문</b><span>"이번 분기 리스크 큰 고객사는?" — 팀 권한 범위에서 조회·답변</span></div><span class="who agent">Assistant Agent</span></div>
+    </div>
+  </section>
+
+  <!-- key sentence -->
+  <div class="keyline">
+    <span class="mono" style="color: var(--accent);">Key Sentence</span>
+    <p>
+      SalesLuv는 서로 다른 목표와 판단 범위를 가진 Assistant·Deal·Portfolio Agent가 협업하고,
+      딜별 Deal Agent와 Portfolio Agent가 제약과 판단 결과를 주고받는 <em>양방향 재판단</em>으로 전체 우선순위와 일정을 완성하는 멀티에이전트 CRM이다.
+      팀장 단위는 Team Reduce 1회 호출로 종합한다<em>(reduce)</em>.
+      에이전트는 판단 루프가 필요한 곳에만 둔다.
+    </p>
+  </div>
+  <div class="foot">SalesLuv · 멀티에이전트 워크플로우</div>
+
+</main>
+
+</body>
+</html>


### PR DESCRIPTION
## 변경 요약

- SalesLuv의 Assistant·Deal·Portfolio Agent 역할과 협업 구조를 문서화했습니다.
- Deal Agent와 Portfolio Agent 간 양방향 재판단 흐름을 구조도로 정리했습니다.
- 미팅 브리핑은 Deal Agent가 판단하고, 미팅 보고서는 단발 LLM 함수가 작성하도록 책임을 구분했습니다.
- 보고서 확정 후 미팅 완료, CRM 반영, Deal·Portfolio 재계산으로 이어지는 사용자 흐름을 반영했습니다.
- Team Reduce와 사용자 승인 게이트를 보조 경로로 명확히 구분했습니다.

## 검증

- 데스크톱·모바일 브라우저 렌더링 확인
- JavaScript 페이지 오류 및 전체 페이지 가로 넘침 없음 확인
- `git diff --check` 통과
- 비밀값·개인정보 포함 여부 확인

## 영향 및 주의 사항

- 문서 HTML 한 파일만 추가하며 애플리케이션 코드에는 영향이 없습니다.