### PR TITLE
feat(auth): 로그인 세션 흐름 연결

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -21,6 +21,11 @@ defaults:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      APP_ENV: test
+      DEBUG: 'false'
+      CORS_ORIGINS: http://testserver
+      SESSION_SECRET: test-only-session-signing-key-at-least-32-characters
     steps:
       - uses: actions/checkout@v4
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,6 +8,18 @@ DEBUG=true
 # CORS (프론트 개발 서버 주소)
 CORS_ORIGINS=http://localhost:5173
 
+# 인증
+# SESSION_SECRET은 `openssl rand -hex 32` 등으로 생성한 32자 이상의 임의값을 사용한다.
+SESSION_SECRET=
+SESSION_TTL_SECONDS=28800
+LOGIN_MAX_ATTEMPTS=5
+LOGIN_WINDOW_SECONDS=60
+
+# 공유 개발 DB에 합성 로그인 계정을 넣을 때만 사용한다.
+DEMO_MANAGER_LOGIN_ID=
+DEMO_MEMBER_LOGIN_ID=
+DEMO_PASSWORD=
+
 # DB (Supabase)
 #
 # Supabase 대시보드 > Project Settings > Database > Connection string 에서 복사.

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
-from app.api import health
+from app.api import auth, health
 
 api_router = APIRouter()
 api_router.include_router(health.router)
+api_router.include_router(auth.router)

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,0 +1,145 @@
+import asyncio
+import math
+import time
+
+from fastapi import APIRouter, HTTPException, Request, Response, status
+from sqlalchemy import select
+
+from app.api.deps import CurrentMember, DbSession
+from app.core.config import settings
+from app.core.security import (
+    create_session_token,
+    dummy_password_hash,
+    verify_password,
+)
+from app.models.workspace import Member
+from app.schemas.auth import LoginRequest, SessionRead
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+# ponytail: 단일 프로세스용 고정 구간 제한기. 다중 worker 배포 시 공유 저장소로 교체한다.
+_login_attempts: dict[tuple[str, str], tuple[int, float]] = {}
+_max_login_buckets = 10_000
+# ponytail: scrypt 메모리를 프로세스당 약 64MiB로 제한한다. 부하가 커지면 인증 worker를 분리한다.
+_scrypt_slots = asyncio.Semaphore(2)
+_dummy_password_hash = dummy_password_hash()
+
+
+def _reserve_login_attempt(client_host: str, login_id: str) -> int | None:
+    now = time.monotonic()
+    expired_keys = [
+        key
+        for key, (_, started_at) in _login_attempts.items()
+        if now - started_at >= settings.login_window_seconds
+    ]
+    for key in expired_keys:
+        _login_attempts.pop(key, None)
+
+    keys = ((client_host, ""), (client_host, login_id))
+    retry_after = 0
+    for key in keys:
+        count, started_at = _login_attempts.get(key, (0, now))
+        if count >= settings.login_max_attempts:
+            retry_after = max(
+                retry_after,
+                math.ceil(settings.login_window_seconds - (now - started_at)),
+            )
+
+    if retry_after:
+        return max(1, retry_after)
+    new_bucket_count = sum(key not in _login_attempts for key in keys)
+    if len(_login_attempts) + new_bucket_count > _max_login_buckets:
+        return settings.login_window_seconds
+    for key in keys:
+        count, started_at = _login_attempts.get(key, (0, now))
+        _login_attempts[key] = (count + 1, started_at)
+    return None
+
+
+def _release_login_attempt(client_host: str, login_id: str) -> None:
+    for key in ((client_host, ""), (client_host, login_id)):
+        attempt = _login_attempts.get(key)
+        if attempt is None:
+            continue
+        count, started_at = attempt
+        if count == 1:
+            _login_attempts.pop(key)
+        else:
+            _login_attempts[key] = (count - 1, started_at)
+
+
+@router.post("/login", response_model=SessionRead)
+async def login(
+    payload: LoginRequest,
+    request: Request,
+    response: Response,
+    db: DbSession,
+) -> Member:
+    client_host = request.client.host if request.client else "unknown"
+    retry_after = _reserve_login_attempt(client_host, payload.login_id)
+    if retry_after is not None:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="login_rate_limited",
+            headers={"Retry-After": str(retry_after)},
+        )
+
+    try:
+        result = await db.execute(select(Member).where(Member.login_id == payload.login_id))
+        member = result.scalar_one_or_none()
+        password_hash = member.password_hash if member is not None else _dummy_password_hash
+        async with _scrypt_slots:
+            password_matches = await asyncio.to_thread(
+                verify_password,
+                payload.password,
+                password_hash,
+            )
+    except BaseException:
+        _release_login_attempt(client_host, payload.login_id)
+        raise
+
+    if (
+        member is None
+        or not password_matches
+        or not member.active
+        or member.role_code not in {"member", "manager"}
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid_credentials",
+        )
+
+    _release_login_attempt(client_host, payload.login_id)
+    token = create_session_token(
+        member.id,
+        settings.session_secret.get_secret_value(),
+        settings.session_ttl_seconds,
+    )
+    response.set_cookie(
+        key="salesluv_session",
+        value=token,
+        max_age=settings.session_ttl_seconds,
+        path="/api",
+        secure=settings.session_cookie_secure,
+        httponly=True,
+        samesite="lax",
+    )
+    response.headers["Cache-Control"] = "no-store"
+    return member
+
+
+@router.get("/me", response_model=SessionRead)
+async def me(member: CurrentMember, response: Response) -> Member:
+    response.headers["Cache-Control"] = "no-store"
+    return member
+
+
+@router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
+async def logout(response: Response) -> None:
+    response.delete_cookie(
+        key="salesluv_session",
+        path="/api",
+        secure=settings.session_cookie_secure,
+        httponly=True,
+        samesite="lax",
+    )

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -6,9 +6,46 @@ Depends() 를 인자 기본값에 직접 쓰지 않게 되어 린터(B008)와도
 
 from typing import Annotated
 
-from fastapi import Depends
+from fastapi import Depends, HTTPException, Request, status
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
+from app.core.security import read_session_token
 from app.db.session import get_db
+from app.models.workspace import Member, Team
 
 type DbSession = Annotated[AsyncSession, Depends(get_db)]
+
+
+async def get_current_member(request: Request, db: DbSession) -> Member:
+    token = request.cookies.get("salesluv_session", "")
+    member_id = read_session_token(
+        token,
+        settings.session_secret.get_secret_value(),
+    )
+    if member_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="not_authenticated",
+        )
+
+    result = await db.execute(
+        select(Member)
+        .join(Team, Member.team_id == Team.id)
+        .where(
+            Member.id == member_id,
+            Member.active.is_(True),
+            Member.role_code.in_(("member", "manager")),
+        )
+    )
+    member = result.scalar_one_or_none()
+    if member is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="not_authenticated",
+        )
+    return member
+
+
+type CurrentMember = Annotated[Member, Depends(get_current_member)]

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -4,8 +4,10 @@
 코드 다른 곳에서 os.getenv 를 직접 호출하지 마세요.
 """
 
+from typing import Literal, Self
 from urllib.parse import urlsplit, urlunsplit
 
+from pydantic import Field, SecretStr, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -16,7 +18,7 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
-    app_env: str = "local"
+    app_env: Literal["local", "test", "production"]
     debug: bool = True
 
     # 프론트 개발 서버 주소. 쉼표로 여러 개 지정 가능.
@@ -26,9 +28,45 @@ class Settings(BaseSettings):
     # 드라이버 접두사(+asyncpg)는 아래에서 자동으로 붙입니다.
     database_url: str = ""
 
+    session_secret: SecretStr = Field(min_length=32)
+    session_ttl_seconds: int = Field(default=28_800, ge=300, le=86_400)
+    login_max_attempts: int = Field(default=5, ge=1, le=20)
+    login_window_seconds: int = Field(default=60, ge=10, le=3_600)
+
+    # 공유 개발 DB에 합성 계정을 넣는 일회성 seed 전용 값입니다.
+    demo_manager_login_id: str = ""
+    demo_member_login_id: str = ""
+    demo_password: SecretStr = SecretStr("")
+
     @property
     def cors_origin_list(self) -> list[str]:
         return [origin.strip() for origin in self.cors_origins.split(",") if origin.strip()]
+
+    @property
+    def session_cookie_secure(self) -> bool:
+        return self.app_env == "production"
+
+    @model_validator(mode="after")
+    def validate_production_security(self) -> Self:
+        if self.app_env != "production":
+            return self
+        if self.debug:
+            raise ValueError("production에서는 DEBUG=false여야 합니다.")
+        if not self.cors_origin_list:
+            raise ValueError("production CORS origin이 비어 있습니다.")
+        for origin in self.cors_origin_list:
+            parts = urlsplit(origin)
+            if (
+                parts.scheme != "https"
+                or not parts.hostname
+                or parts.username is not None
+                or parts.password is not None
+                or parts.path
+                or parts.query
+                or parts.fragment
+            ):
+                raise ValueError("production CORS origin은 경로 없는 HTTPS origin이어야 합니다.")
+        return self
 
     @property
     def async_database_url(self) -> str:

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,0 +1,201 @@
+"""Password hashing and signed session tokens."""
+
+import base64
+import binascii
+import hashlib
+import hmac
+import json
+import secrets
+import time
+from functools import cache
+from uuid import UUID
+
+_MAX_PASSWORD_LENGTH = 256
+_MAX_PASSWORD_HASH_LENGTH = 256
+_SCRYPT_N = 2**15
+_SCRYPT_R = 8
+_SCRYPT_P = 3
+_SCRYPT_MAXMEM = 64 * 1024 * 1024
+_SCRYPT_SALT_BYTES = 16
+_SCRYPT_KEY_BYTES = 32
+_PASSWORD_SCHEME = "scrypt"
+_PASSWORD_VERSION = "v1"
+
+_SESSION_VERSION = 1
+_SESSION_SIGNATURE_BYTES = 32
+_MAX_SESSION_TOKEN_LENGTH = 512
+_MAX_SESSION_PAYLOAD_BYTES = 256
+_SESSION_SIGNING_CONTEXT = b"salesluv-session-v1."
+_MIN_SESSION_SECRET_BYTES = 32
+
+
+def hash_password(password: str) -> str:
+    """Hash a password without normalizing or trimming it."""
+    password_bytes = _password_bytes(password)
+    salt = secrets.token_bytes(_SCRYPT_SALT_BYTES)
+    digest = _derive_password_key(password_bytes, salt)
+    return "$".join(
+        (
+            _PASSWORD_SCHEME,
+            _PASSWORD_VERSION,
+            _encode_base64url(salt),
+            _encode_base64url(digest),
+        )
+    )
+
+
+def verify_password(password: str, encoded: str) -> bool:
+    """Return whether a password matches a supported encoded hash."""
+    if not isinstance(encoded, str) or len(encoded) > _MAX_PASSWORD_HASH_LENGTH:
+        return False
+
+    try:
+        password_bytes = _password_bytes(password)
+        scheme, version, salt_text, digest_text = encoded.split("$")
+        if scheme != _PASSWORD_SCHEME or version != _PASSWORD_VERSION:
+            return False
+
+        salt = _decode_base64url(salt_text)
+        expected = _decode_base64url(digest_text)
+        if len(salt) != _SCRYPT_SALT_BYTES or len(expected) != _SCRYPT_KEY_BYTES:
+            return False
+
+        actual = _derive_password_key(password_bytes, salt)
+    except (TypeError, ValueError, UnicodeError):
+        return False
+
+    return secrets.compare_digest(actual, expected)
+
+
+@cache
+def dummy_password_hash() -> str:
+    """Return one lazily-created hash for account-enumeration-safe verification."""
+    return hash_password(secrets.token_urlsafe(32))
+
+
+def create_session_token(
+    member_id: UUID,
+    secret: str | bytes,
+    ttl_seconds: int,
+    now: int | None = None,
+) -> str:
+    """Create a compact HMAC-SHA256 signed session token."""
+    member_uuid = member_id if isinstance(member_id, UUID) else UUID(str(member_id))
+    secret_bytes = _session_secret_bytes(secret)
+    current_time = _timestamp(now)
+    if isinstance(ttl_seconds, bool) or not isinstance(ttl_seconds, int) or ttl_seconds <= 0:
+        raise ValueError("ttl_seconds must be a positive integer")
+
+    payload = json.dumps(
+        {"v": _SESSION_VERSION, "sub": str(member_uuid), "exp": current_time + ttl_seconds},
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    payload_text = _encode_base64url(payload)
+    signature = _sign_session_payload(payload_text, secret_bytes)
+    return f"{payload_text}.{_encode_base64url(signature)}"
+
+
+def read_session_token(
+    token: str,
+    secret: str | bytes,
+    now: int | None = None,
+) -> UUID | None:
+    """Validate a session token and return its member UUID, or None."""
+    if not isinstance(token, str) or not 0 < len(token) <= _MAX_SESSION_TOKEN_LENGTH:
+        return None
+
+    try:
+        secret_bytes = _session_secret_bytes(secret)
+        current_time = _timestamp(now)
+        payload_text, signature_text = token.split(".")
+        signature = _decode_base64url(signature_text)
+        if len(signature) != _SESSION_SIGNATURE_BYTES:
+            return None
+
+        expected_signature = _sign_session_payload(payload_text, secret_bytes)
+        if not hmac.compare_digest(signature, expected_signature):
+            return None
+
+        payload_bytes = _decode_base64url(payload_text)
+        if len(payload_bytes) > _MAX_SESSION_PAYLOAD_BYTES:
+            return None
+        payload = json.loads(payload_bytes)
+        if not isinstance(payload, dict) or set(payload) != {"v", "sub", "exp"}:
+            return None
+        if type(payload["v"]) is not int or payload["v"] != _SESSION_VERSION:
+            return None
+        if type(payload["sub"]) is not str or type(payload["exp"]) is not int:
+            return None
+        if payload["exp"] <= current_time:
+            return None
+
+        member_id = UUID(payload["sub"])
+        if str(member_id) != payload["sub"]:
+            return None
+    except (TypeError, ValueError, UnicodeError, json.JSONDecodeError):
+        return None
+
+    return member_id
+
+
+def _password_bytes(password: str) -> bytes:
+    if not isinstance(password, str):
+        raise TypeError("password must be a string")
+    if len(password) > _MAX_PASSWORD_LENGTH:
+        raise ValueError(f"password must be at most {_MAX_PASSWORD_LENGTH} characters")
+    return password.encode("utf-8")
+
+
+def _derive_password_key(password: bytes, salt: bytes) -> bytes:
+    return hashlib.scrypt(
+        password,
+        salt=salt,
+        n=_SCRYPT_N,
+        r=_SCRYPT_R,
+        p=_SCRYPT_P,
+        maxmem=_SCRYPT_MAXMEM,
+        dklen=_SCRYPT_KEY_BYTES,
+    )
+
+
+def _sign_session_payload(payload_text: str, secret: bytes) -> bytes:
+    message = _SESSION_SIGNING_CONTEXT + payload_text.encode("ascii")
+    return hmac.digest(secret, message, "sha256")
+
+
+def _session_secret_bytes(secret: str | bytes) -> bytes:
+    if isinstance(secret, str):
+        value = secret.encode("utf-8")
+    elif isinstance(secret, bytes):
+        value = secret
+    else:
+        raise TypeError("secret must be a string or bytes")
+    if len(value) < _MIN_SESSION_SECRET_BYTES:
+        raise ValueError(f"secret must be at least {_MIN_SESSION_SECRET_BYTES} bytes")
+    return value
+
+
+def _timestamp(now: int | None) -> int:
+    if now is None:
+        return int(time.time())
+    if isinstance(now, bool) or not isinstance(now, int):
+        raise TypeError("now must be an integer Unix timestamp")
+    return now
+
+
+def _encode_base64url(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).rstrip(b"=").decode("ascii")
+
+
+def _decode_base64url(value: str) -> bytes:
+    if not value or "=" in value:
+        raise ValueError("invalid base64url value")
+    padding = "=" * (-len(value) % 4)
+    try:
+        decoded = base64.b64decode(value + padding, altchars=b"-_", validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("invalid base64url value") from exc
+    if _encode_base64url(decoded) != value:
+        raise ValueError("non-canonical base64url value")
+    return decoded

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,8 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 from app.api import api_router
 from app.core.config import settings
@@ -17,5 +20,30 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_error_without_submitted_values(
+    _request: Request,
+    exc: RequestValidationError,
+) -> JSONResponse:
+    errors = []
+    for error in exc.errors():
+        safe_error = error.copy()
+        safe_error.pop("input", None)
+        errors.append(safe_error)
+    return JSONResponse(status_code=422, content=jsonable_encoder({"detail": errors}))
+
+
+@app.middleware("http")
+async def require_allowed_origin(request: Request, call_next):
+    if (
+        request.url.path.startswith("/api/")
+        and request.method in {"POST", "PUT", "PATCH", "DELETE"}
+        and request.headers.get("origin") not in settings.cors_origin_list
+    ):
+        return JSONResponse(status_code=403, content={"detail": "origin_not_allowed"})
+    return await call_next(request)
+
 
 app.include_router(api_router, prefix="/api")

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,0 +1,3 @@
+from app.schemas.auth import LoginRequest, SessionRead
+
+__all__ = ["LoginRequest", "SessionRead"]

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,0 +1,32 @@
+from typing import Annotated, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, StringConstraints
+
+LoginId = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=True,
+        to_lower=True,
+        strict=True,
+        min_length=1,
+        max_length=254,
+    ),
+]
+Password = Annotated[str, StringConstraints(strict=True, min_length=1, max_length=256)]
+
+
+class LoginRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    login_id: LoginId
+    password: Password
+
+
+class SessionRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    display_name: str
+    role_code: Literal["member", "manager"]
+    job_title: str | None

--- a/backend/scripts/seed_demo_auth.py
+++ b/backend/scripts/seed_demo_auth.py
@@ -1,0 +1,98 @@
+"""공유 개발 DB에 합성 로그인 계정 두 개를 반복 가능하게 넣는다."""
+
+import asyncio
+from uuid import UUID
+
+from sqlalchemy import or_, select
+from sqlalchemy.dialects.postgresql import insert
+
+from app.core.config import settings
+from app.core.security import hash_password
+from app.db.session import get_sessionmaker
+from app.models.workspace import Member, Team
+
+TEAM_ID = UUID("6d0f1b76-6b1a-4b72-9ba3-1df477a62d78")
+MANAGER_ID = UUID("a6a7a7f6-7141-4b94-9355-bde585f44d1a")
+MEMBER_ID = UUID("86d40aa1-0a5b-4a23-912f-e039c392c60a")
+
+
+async def seed_demo_auth() -> None:
+    manager_login_id = settings.demo_manager_login_id.strip().lower()
+    member_login_id = settings.demo_member_login_id.strip().lower()
+    password = settings.demo_password.get_secret_value()
+
+    if not manager_login_id or not member_login_id or not password:
+        raise SystemExit("backend/.env의 DEMO_* 인증 값을 먼저 채워주세요.")
+    if manager_login_id == member_login_id:
+        raise SystemExit("두 데모 계정의 로그인 ID는 달라야 합니다.")
+    if len(password) > 256:
+        raise SystemExit("DEMO_PASSWORD는 256자 이하여야 합니다.")
+
+    manager_hash = await asyncio.to_thread(hash_password, password)
+    member_hash = await asyncio.to_thread(hash_password, password)
+
+    async with get_sessionmaker()() as session, session.begin():
+        team_insert = insert(Team).values(id=TEAM_ID, name="SalesLuv 데모팀")
+        await session.execute(
+            team_insert.on_conflict_do_update(
+                index_elements=[Team.id],
+                set_={"name": team_insert.excluded.name},
+            )
+        )
+
+        accounts = (
+            {
+                "id": MANAGER_ID,
+                "login_id": manager_login_id,
+                "password_hash": manager_hash,
+                "display_name": "김서현",
+                "role_code": "manager",
+                "job_title": "영업팀장",
+            },
+            {
+                "id": MEMBER_ID,
+                "login_id": member_login_id,
+                "password_hash": member_hash,
+                "display_name": "김지훈",
+                "role_code": "member",
+                "job_title": "영업 담당자",
+            },
+        )
+        expected_by_id = {account["id"]: account["login_id"] for account in accounts}
+        expected_by_login = {login_id: member_id for member_id, login_id in expected_by_id.items()}
+        existing = await session.execute(
+            select(Member.id, Member.login_id).where(
+                or_(
+                    Member.id.in_(expected_by_id),
+                    Member.login_id.in_(expected_by_login),
+                )
+            )
+        )
+        for member_id, login_id in existing:
+            if (
+                expected_by_id.get(member_id) != login_id
+                or expected_by_login.get(login_id) != member_id
+            ):
+                raise SystemExit("기존 회원과 데모 계정 ID 또는 로그인 ID가 충돌합니다.")
+
+        for account in accounts:
+            member_insert = insert(Member).values(team_id=TEAM_ID, active=True, **account)
+            await session.execute(
+                member_insert.on_conflict_do_update(
+                    index_elements=[Member.id],
+                    set_={
+                        "team_id": member_insert.excluded.team_id,
+                        "password_hash": member_insert.excluded.password_hash,
+                        "display_name": member_insert.excluded.display_name,
+                        "role_code": member_insert.excluded.role_code,
+                        "job_title": member_insert.excluded.job_title,
+                        "active": member_insert.excluded.active,
+                    },
+                )
+            )
+
+    print("개발 DB의 합성 로그인 계정 2개를 준비했습니다.")
+
+
+if __name__ == "__main__":
+    asyncio.run(seed_demo_auth())

--- a/backend/sql/README.md
+++ b/backend/sql/README.md
@@ -34,3 +34,16 @@
 | 2026-08-17 | 개발 Supabase `public` | `20260817_0001_core_schema.sql` | Session Pooler | 성공 |
 | 2026-08-17 | 개발 Supabase `public` | `20260817_0002_remaining_schema.sql` | Session Pooler | 성공 |
 | 2026-08-17 | 개발 Supabase `public` | `20260817_0003_singular_table_names.sql` | Session Pooler | 성공 |
+| 2026-08-17 | 개발 Supabase `public` | `scripts/seed_demo_auth.py` | Session Pooler | 성공 |
+
+## 개발 로그인 계정
+
+`backend/.env`의 `DEMO_MANAGER_LOGIN_ID`, `DEMO_MEMBER_LOGIN_ID`, `DEMO_PASSWORD`를 채운 뒤
+아래 명령을 실행합니다. 평문 비밀번호는 파일이나 로그에 남기지 않고 실행 시 scrypt로 해시합니다.
+
+```bash
+cd backend
+DEBUG=false uv run python -m scripts.seed_demo_auth
+```
+
+고정된 합성 팀과 팀장·팀원 계정을 upsert하므로 같은 개발 DB에 다시 실행할 수 있습니다.

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,251 @@
+import secrets
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from app.api.auth import (
+    _login_attempts,
+    _reserve_login_attempt,
+)
+from app.core.config import Settings, settings
+from app.core.security import (
+    create_session_token,
+    hash_password,
+    read_session_token,
+    verify_password,
+)
+from app.db.session import get_db
+from app.main import app
+from app.models.workspace import Member
+
+ORIGIN = settings.cors_origin_list[0]
+
+
+class _Result:
+    def __init__(self, member: Member | None):
+        self.member = member
+
+    def scalar_one_or_none(self) -> Member | None:
+        return self.member
+
+
+class _Db:
+    def __init__(self, member: Member | None):
+        self.member = member
+
+    async def execute(self, _statement):
+        return _Result(self.member)
+
+
+@pytest.fixture(autouse=True)
+def reset_auth_state():
+    _login_attempts.clear()
+    app.dependency_overrides.clear()
+    yield
+    _login_attempts.clear()
+    app.dependency_overrides.clear()
+
+
+def _member(password_hash: str, *, active: bool = True) -> Member:
+    return Member(
+        id=uuid4(),
+        team_id=uuid4(),
+        login_id="manager@salesluv.demo",
+        password_hash=password_hash,
+        display_name="합성 팀장",
+        role_code="manager",
+        job_title="영업팀장",
+        active=active,
+    )
+
+
+def _client(member: Member | None) -> TestClient:
+    async def override_db():
+        yield _Db(member)
+
+    app.dependency_overrides[get_db] = override_db
+    return TestClient(app)
+
+
+def test_password_hash_and_session_token_round_trip():
+    password = secrets.token_urlsafe(24)
+    first_hash = hash_password(password)
+    second_hash = hash_password(password)
+
+    assert first_hash != second_hash
+    assert verify_password(password, first_hash)
+    assert not verify_password(f"{password}x", first_hash)
+
+    member_id = uuid4()
+    secret = secrets.token_urlsafe(32)
+    token = create_session_token(member_id, secret, 60, now=1_000)
+
+    assert read_session_token(token, secret, now=1_059) == member_id
+    assert read_session_token(token, secret, now=1_060) is None
+    assert read_session_token(f"{token}x", secret, now=1_001) is None
+
+
+def test_login_me_and_logout_use_signed_cookie():
+    password = secrets.token_urlsafe(24)
+    member = _member(hash_password(password))
+
+    with _client(member) as client:
+        login = client.post(
+            "/api/auth/login",
+            headers={"Origin": ORIGIN},
+            json={"login_id": member.login_id.upper(), "password": password},
+        )
+
+        assert login.status_code == 200
+        assert login.json() == {
+            "id": str(member.id),
+            "display_name": "합성 팀장",
+            "role_code": "manager",
+            "job_title": "영업팀장",
+        }
+        cookie = login.headers["set-cookie"].lower()
+        assert "salesluv_session=" in cookie
+        assert "httponly" in cookie
+        assert "samesite=lax" in cookie
+        assert "path=/api" in cookie
+        assert f"max-age={settings.session_ttl_seconds}" in cookie
+        assert login.headers["cache-control"] == "no-store"
+        assert not _login_attempts
+
+        me = client.get("/api/auth/me")
+        assert me.status_code == 200
+        assert me.json()["id"] == str(member.id)
+
+        logout = client.post("/api/auth/logout", headers={"Origin": ORIGIN})
+        assert logout.status_code == 204
+        assert logout.content == b""
+        assert "max-age=0" in logout.headers["set-cookie"].lower()
+        assert client.get("/api/auth/me").status_code == 401
+
+
+@pytest.mark.parametrize("member_state", ["missing", "wrong_password", "inactive"])
+def test_invalid_login_does_not_reveal_account_state(member_state: str):
+    password = secrets.token_urlsafe(24)
+    member = None if member_state == "missing" else _member(hash_password(password))
+    if member_state == "inactive" and member is not None:
+        member.active = False
+    submitted_password = f"{password}x" if member_state == "wrong_password" else password
+
+    with _client(member) as client:
+        response = client.post(
+            "/api/auth/login",
+            headers={"Origin": ORIGIN},
+            json={"login_id": "manager@salesluv.demo", "password": submitted_password},
+        )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "invalid_credentials"}
+
+
+def test_mutation_requires_exact_allowed_origin():
+    password = secrets.token_urlsafe(24)
+    with _client(None) as client:
+        missing = client.post(
+            "/api/auth/login",
+            json={"login_id": "nobody", "password": password},
+        )
+        suffix = client.post(
+            "/api/auth/login",
+            headers={"Origin": f"{ORIGIN}.evil.test"},
+            json={"login_id": "nobody", "password": password},
+        )
+        preflight = client.options(
+            "/api/auth/login",
+            headers={
+                "Origin": ORIGIN,
+                "Access-Control-Request-Method": "POST",
+            },
+        )
+
+    assert missing.status_code == 403
+    assert suffix.status_code == 403
+    assert preflight.status_code == 200
+
+
+def test_login_attempts_are_rate_limited():
+    password = secrets.token_urlsafe(24)
+    member = _member(hash_password(password))
+
+    with _client(member) as client:
+        for _ in range(settings.login_max_attempts):
+            response = client.post(
+                "/api/auth/login",
+                headers={"Origin": ORIGIN},
+                json={"login_id": member.login_id, "password": f"{password}x"},
+            )
+            assert response.status_code == 401
+
+        limited = client.post(
+            "/api/auth/login",
+            headers={"Origin": ORIGIN},
+            json={"login_id": member.login_id, "password": password},
+        )
+
+    assert limited.status_code == 429
+    assert limited.json() == {"detail": "login_rate_limited"}
+    assert int(limited.headers["retry-after"]) > 0
+
+
+def test_changing_login_id_does_not_bypass_ip_rate_limit():
+    for _ in range(settings.login_max_attempts):
+        login_id = f"target-{_}"
+        assert _reserve_login_attempt("same-ip", login_id) is None
+
+    assert _reserve_login_attempt("same-ip", "new-account") is not None
+
+
+def test_validation_error_does_not_echo_password():
+    submitted_password = secrets.token_urlsafe(257)
+
+    with _client(None) as client:
+        response = client.post(
+            "/api/auth/login",
+            headers={"Origin": ORIGIN},
+            json={"login_id": "nobody", "password": submitted_password},
+        )
+
+    assert response.status_code == 422
+    assert submitted_password not in response.text
+    assert all("input" not in error for error in response.json()["detail"])
+
+
+def test_production_auth_settings_fail_closed(monkeypatch):
+    secret = secrets.token_urlsafe(32)
+
+    monkeypatch.delenv("APP_ENV", raising=False)
+    with pytest.raises(ValidationError):
+        Settings(_env_file=None, session_secret=secret)
+    with pytest.raises(ValidationError):
+        Settings(_env_file=None, app_env="staging", session_secret=secret)
+    with pytest.raises(ValidationError):
+        Settings(
+            _env_file=None,
+            app_env="production",
+            debug=True,
+            cors_origins="https://salesluv.example",
+            session_secret=secret,
+        )
+    with pytest.raises(ValidationError):
+        Settings(
+            _env_file=None,
+            app_env="production",
+            debug=False,
+            cors_origins="http://salesluv.example",
+            session_secret=secret,
+        )
+
+    production = Settings(
+        _env_file=None,
+        app_env="production",
+        debug=False,
+        cors_origins="https://salesluv.example",
+        session_secret=secret,
+    )
+    assert production.session_cookie_secure

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -5,5 +5,5 @@ import { env } from '@/config/env'
 export const client = axios.create({
   baseURL: `${env.apiBaseUrl}/api`,
   timeout: 10_000,
-  headers: { 'Content-Type': 'application/json' },
+  withCredentials: true,
 })

--- a/frontend/src/auth/SessionProvider.tsx
+++ b/frontend/src/auth/SessionProvider.tsx
@@ -1,41 +1,117 @@
-import { type ReactNode, useCallback, useMemo, useState } from 'react'
+import { type ReactNode, useCallback, useEffect, useState } from 'react'
+import { isAxiosError } from 'axios'
 
-import { ROUTES } from '@/constants/routes'
-import { clearProfileId, readProfileId, writeProfileId } from '@/mocks'
-import { findProfile } from '@/mocks/profiles'
+import { client } from '@/api/client'
+import { clearProfileId, profile as mockProfile, readProfileId, writeProfileId } from '@/mocks'
 import { clearScope } from '@/scope/scopeStorage'
 
 import { type Session, SessionContext } from './sessionContext'
 
-// 세션은 고른 데모 프로필 자체입니다. 탭을 닫으면 사라지도록 sessionStorage 에 두며,
-// 읽고 쓰는 자리는 mocks/ 한 곳입니다 — 시드를 고르는 것과 같은 값이라야 하기 때문입니다.
-function readSession(): Session | null {
-  const id = readProfileId()
-  if (id === null) return null
-  const { role, name, title } = findProfile(id)
-  return { role, profile: { name, title } }
+interface AuthUser {
+  id: string
+  display_name: string
+  role_code: Session['role']
+  job_title: string | null
+}
+
+const PROFILE_ID_BY_ROLE: Record<Session['role'], string> = {
+  manager: 'sample-manager',
+  member: 'sample-member',
+}
+
+const toSession = ({ display_name, role_code, job_title }: AuthUser): Session => ({
+  role: role_code,
+  profile: { name: display_name, title: job_title ?? '' },
+})
+
+/** 인증과 무관한 합성 데이터 선택값만 실제 역할에 맞춥니다. */
+function syncMockProfile(role: Session['role']): 'ready' | 'reload' | 'failed' {
+  const expectedId = PROFILE_ID_BY_ROLE[role]
+  if (readProfileId() !== expectedId) writeProfileId(expectedId)
+
+  if (mockProfile.id === expectedId) return 'ready'
+  return readProfileId() === expectedId ? 'reload' : 'failed'
 }
 
 export default function SessionProvider({ children }: { children: ReactNode }) {
-  // 초기화 함수는 첫 페인트 전에 실행되므로 새로고침해도 로그인 화면이 스쳐 지나가지 않습니다.
-  const [session, setSession] = useState<Session | null>(readSession)
+  // undefined 는 서버 세션 복원 중입니다. 이때 라우트를 렌더하면 로그인 화면으로 잘못 튕깁니다.
+  const [session, setSession] = useState<Session | null>()
+  const [restoreFailed, setRestoreFailed] = useState(false)
 
-  const login = useCallback((profileId: string) => {
-    writeProfileId(profileId)
-    // 앞사람이 보던 범위가 다음 로그인에 남지 않도록 지웁니다.
-    clearScope()
-    // 목업 시드는 모듈이 로드될 때 프로필에 맞춰 확정됩니다. setState 로는 이미 만들어진
-    // 데이터셋이 바뀌지 않으므로 프로필을 저장한 뒤 통째로 새로고침합니다.
-    window.location.assign(ROUTES.DASHBOARD)
+  useEffect(() => {
+    let active = true
+
+    client
+      .get<AuthUser>('/auth/me')
+      .then(({ data }) => {
+        if (!active) return
+        const next = toSession(data)
+        const mockSync = syncMockProfile(next.role)
+        if (mockSync === 'reload') {
+          window.location.reload()
+          return
+        }
+        if (mockSync === 'failed') {
+          setRestoreFailed(true)
+          return
+        }
+        setSession(next)
+      })
+      .catch((error: unknown) => {
+        if (!active) return
+        if (isAxiosError(error) && error.response?.status === 401) {
+          setSession(null)
+          return
+        }
+        setRestoreFailed(true)
+      })
+
+    return () => {
+      active = false
+    }
   }, [])
 
-  const logout = useCallback(() => {
+  const login = useCallback(async (loginId: string, password: string) => {
+    const { data } = await client.post<AuthUser>('/auth/login', {
+      login_id: loginId,
+      password,
+    })
+    const next = toSession(data)
+    clearScope()
+    const mockSync = syncMockProfile(next.role)
+    if (mockSync === 'reload') {
+      window.location.reload()
+      return
+    }
+    if (mockSync === 'failed') {
+      await client.post('/auth/logout')
+      throw new Error('mock profile storage unavailable')
+    }
+    setSession(next)
+  }, [])
+
+  const logout = useCallback(async () => {
+    try {
+      await client.post('/auth/logout')
+    } catch {
+      return
+    }
     clearProfileId()
     clearScope()
     setSession(null)
   }, [])
 
-  const value = useMemo(() => ({ session, login, logout }), [session, login, logout])
+  if (restoreFailed) {
+    return (
+      <main role="alert">
+        서버에 연결할 수 없습니다.{' '}
+        <button type="button" onClick={() => window.location.reload()}>
+          다시 시도
+        </button>
+      </main>
+    )
+  }
+  if (session === undefined) return null
 
-  return <SessionContext value={value}>{children}</SessionContext>
+  return <SessionContext value={{ session, login, logout }}>{children}</SessionContext>
 }

--- a/frontend/src/auth/sessionContext.ts
+++ b/frontend/src/auth/sessionContext.ts
@@ -1,5 +1,3 @@
-// 실제 인증이 붙기 전까지 세션은 로그인 화면의 데모 프로필 버튼으로만 만들어집니다.
-// 백엔드 인증이 들어오면 SessionProvider 의 login 이 API 를 호출하도록 바꾸면 됩니다.
 import { createContext, useContext } from 'react'
 
 import type { Role } from '@/types'
@@ -16,9 +14,8 @@ export interface Session {
 
 export interface SessionContextValue {
   session: Session | null
-  /** mocks/profiles.ts 의 MockProfile.id */
-  login: (profileId: string) => void
-  logout: () => void
+  login: (loginId: string, password: string) => Promise<void>
+  logout: () => Promise<void>
 }
 
 export const SessionContext = createContext<SessionContextValue | null>(null)

--- a/frontend/src/pages/Login/Login.module.scss
+++ b/frontend/src/pages/Login/Login.module.scss
@@ -226,59 +226,11 @@
   margin-top: 4px;
 }
 
-.or {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  margin: 24px 0;
-  color: var(--muted);
-  font-size: 11px;
-
-  &::before,
-  &::after {
-    content: '';
-    flex: 1;
-    height: 1px;
-    background: var(--line);
-  }
-}
-
-.demoRoles {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 10px;
-
-  @include sm {
-    grid-template-columns: 1fr;
-  }
-}
-
-.demoRole {
-  padding: 14px;
-  text-align: left;
-  cursor: pointer;
-  background: var(--surface);
-  border: 1px solid var(--line-2);
-  border-radius: 13px;
-  transition:
-    background var(--t-fast),
-    border-color var(--t-fast);
-
-  &:hover {
-    border-color: rgba(0, 122, 255, 0.36);
-    background: #f4f8ff;
-  }
-
-  strong {
-    display: block;
-    margin-bottom: 4px;
-    font-size: 13px;
-  }
-
-  span {
-    font-size: 11px;
-    color: var(--muted);
-  }
+.error {
+  margin-top: -4px;
+  color: var(--red);
+  font-size: 12px;
+  line-height: 1.5;
 }
 
 .footnote {

--- a/frontend/src/pages/Login/Login.tsx
+++ b/frontend/src/pages/Login/Login.tsx
@@ -1,18 +1,29 @@
 import { type FormEvent, useState } from 'react'
+import { isAxiosError } from 'axios'
 import { Navigate } from 'react-router'
 
 import { useSession } from '@/auth/sessionContext'
 import Button from '@/components/Button'
 import { ROUTES } from '@/constants/routes'
-import { DEFAULT_PROFILE_ID, MOCK_PROFILES } from '@/mocks/profiles'
 
 import styles from './Login.module.scss'
+
+function loginErrorMessage(error: unknown): string {
+  if (isAxiosError(error)) {
+    if (error.response?.status === 401) return '로그인 아이디 또는 비밀번호를 확인해 주세요.'
+    if (error.response?.status === 429)
+      return '로그인 시도가 너무 많습니다. 잠시 후 다시 시도해 주세요.'
+  }
+  return '로그인할 수 없습니다. 잠시 후 다시 시도해 주세요.'
+}
 
 export default function Login() {
   const { session, login } = useSession()
 
-  const [email, setEmail] = useState('manager@salesluv.demo')
-  const [password, setPassword] = useState('salesluv')
+  const [loginId, setLoginId] = useState('')
+  const [password, setPassword] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   // 로그인 직후에도, 이미 로그인한 채로 /login 에 들어와도 이 한 줄이 목적지를 정합니다.
   // login() 뒤에 navigate() 를 따로 부르면 이 리다이렉트와 경합해 목적지를 잃습니다.
@@ -21,10 +32,17 @@ export default function Login() {
   // 대시보드뿐이라 나머지로 되돌아가 봐야 404 를 만나기 때문입니다.
   if (session) return <Navigate to={ROUTES.DASHBOARD} replace />
 
-  const onSubmit = (event: FormEvent) => {
+  const onSubmit = async (event: FormEvent) => {
     event.preventDefault()
-    // 아직 인증 API 가 없어 입력값을 검증하지 않습니다. 아래 각주가 이를 밝힙니다.
-    login(DEFAULT_PROFILE_ID)
+    setSubmitting(true)
+    setError(null)
+    try {
+      await login(loginId.trim(), password)
+    } catch (cause) {
+      setError(loginErrorMessage(cause))
+    } finally {
+      setSubmitting(false)
+    }
   }
 
   return (
@@ -70,13 +88,17 @@ export default function Login() {
 
         <form onSubmit={onSubmit}>
           <div className={styles.field}>
-            <label htmlFor="email">이메일</label>
+            <label htmlFor="login-id">로그인 아이디</label>
             <input
               className={styles.input}
-              id="email"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
+              id="login-id"
+              type="text"
+              autoComplete="username"
+              value={loginId}
+              onChange={(e) => setLoginId(e.target.value)}
+              disabled={submitting}
+              aria-invalid={error !== null}
+              aria-describedby={error ? 'login-error' : undefined}
               required
             />
           </div>
@@ -86,26 +108,24 @@ export default function Login() {
               className={styles.input}
               id="password"
               type="password"
+              autoComplete="current-password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
+              disabled={submitting}
+              aria-invalid={error !== null}
+              aria-describedby={error ? 'login-error' : undefined}
               required
             />
           </div>
-          <Button className={styles.mainBtn} type="submit">
-            팀장 데모로 로그인 <span aria-hidden="true">→</span>
+          {error && (
+            <p id="login-error" className={styles.error} role="alert">
+              {error}
+            </p>
+          )}
+          <Button className={styles.mainBtn} type="submit" disabled={submitting}>
+            {submitting ? '로그인 중…' : '로그인'} <span aria-hidden="true">→</span>
           </Button>
         </form>
-
-        <div className={styles.or}>데모 프로필로 바로 보기</div>
-
-        <div className={styles.demoRoles}>
-          {MOCK_PROFILES.map(({ id, label, note }) => (
-            <button key={id} className={styles.demoRole} type="button" onClick={() => login(id)}>
-              <strong>{label}</strong>
-              <span>{note}</span>
-            </button>
-          ))}
-        </div>
 
         <p className={styles.footnote}>
           시연용 합성 데이터입니다. 실제 개인정보는 포함되어 있지 않습니다.


### PR DESCRIPTION
## 변경 요약

- FastAPI에 로그인, 세션 복원, 로그아웃 API를 추가했습니다.
- scrypt 비밀번호 해시, HMAC 서명 쿠키, Origin 검사, 로그인 시도 제한을 적용했습니다.
- React 로그인 화면과 세션 공급자를 실제 API에 연결했습니다.
- 개발 Supabase용 합성 팀장·팀원 계정 seed와 실행 문서를 추가했습니다.

## 검증

- 백엔드: Ruff 및 포맷 검사 통과, pytest 14개 통과
- CI 무DB 환경: pytest 12개 통과, DB 검사 2개 정상 skip
- 프론트엔드: 타입 검사, lint, 포맷 검사, production build, mock 정합성 검사 통과
- 개발 Supabase: 팀장·팀원 login → me → logout 흐름 확인
- 별도 보안 검토: P0/P1 잔여 문제 없음

## 영향 및 주의 사항

- `APP_ENV`와 32자 이상의 `SESSION_SECRET`을 반드시 설정해야 합니다.
- 로그인 제한기는 단일 프로세스 MVP 기준이며 다중 worker 배포 시 공유 저장소로 교체해야 합니다.
- 기존 업무 화면 데이터는 아직 mock을 사용하고, 인증만 실제 DB/API로 전환됩니다.