### PR TITLE
docs: 미팅 분석 중심 멀티에이전트 흐름 수정

### DIFF
--- a/demo/multi_agent_flow.html
+++ b/demo/multi_agent_flow.html
@@ -389,8 +389,8 @@
 
     .capture { left: 70px; top: 60px; width: 235px; min-height: 170px; }
     .customer { left: 390px; top: 60px; }
-    .cs { left: 720px; top: 38px; width: 260px; min-height: 88px; }
-    .sentiment { left: 720px; top: 145px; width: 260px; min-height: 100px; }
+    .cs { left: 720px; top: 28px; width: 260px; min-height: 110px; }
+    .deal-score { left: 720px; top: 165px; width: 260px; min-height: 100px; }
     .report { left: 390px; top: 270px; }
     .draft { left: 710px; top: 289px; width: 220px; min-height: 112px; }
     .approval { left: 1000px; top: 306px; width: 150px; min-height: 80px; }
@@ -507,7 +507,7 @@
         <p class="eyebrow">SalesLuv · System Map</p>
         <h1>Multi-Agent Flow</h1>
       </div>
-      <p class="summary">고객 접점 데이터를 수집하고, 보고서와 추천을 거쳐 다음 영업 일정을 만드는 전체 흐름입니다.</p>
+      <p class="summary">미팅 자료를 분석해 C/S와 딜 점수를 만들고, 원문과 분석 결과로 보고서를 작성하는 흐름입니다.</p>
     </header>
 
     <nav class="editor-bar" aria-label="그래프 편집 도구">
@@ -534,37 +534,38 @@
 
         <article class="node card source capture" id="node-capture">
           <span class="kind" aria-label="Input">I</span>
-          <h2>고객 접점 정보</h2>
+          <h2>미팅 자료</h2>
           <ul>
-            <li>명함 정보</li>
-            <li>STT · OCR</li>
+            <li>녹음 파일 · STT</li>
+            <li>미팅 내용 메모</li>
             <li>직접 입력</li>
           </ul>
         </article>
 
-        <article class="node agent customer" id="node-customer" data-letter="C">
-          <div><b>고객관리</b><span>AGENT</span></div>
+        <article class="node agent customer" id="node-customer" data-letter="A">
+          <div><b>미팅 분석</b><span>AGENT</span></div>
         </article>
 
         <article class="node card result cs" id="node-cs">
           <span class="kind" aria-label="Output">O</span>
-          <h3>C/S 사항 정리</h3>
+          <h3>C/S 사항</h3>
+          <ul><li>보고서 · C/S 관리 페이지 공통 사용</li></ul>
         </article>
 
-        <article class="node card result sentiment" id="node-sentiment">
-          <span class="kind" aria-label="Output">O</span>
-          <h3>감정 분석</h3>
-          <ul><li>분노 · 호감 · 만족도</li></ul>
+        <article class="node card result deal-score" id="node-deal-score">
+          <span class="kind" aria-label="Model">M</span>
+          <h3>딜 승산 점수</h3>
+          <ul><li>0–100점 · 승인 없이 화면 표시만</li></ul>
         </article>
 
         <article class="node agent report" id="node-report" data-letter="R">
-          <div><b>보고서</b><span>AGENT</span></div>
+          <div><b>보고서 작성</b><span>AGENT</span></div>
         </article>
 
         <article class="node card result draft" id="node-draft">
           <span class="kind" aria-label="Output">O</span>
           <h3>보고서 초안</h3>
-          <ul><li>핵심 내용 자동 정리</li></ul>
+          <ul><li>원문 + 분석 결과 기반 · C/S 포함</li></ul>
         </article>
 
         <article class="node card gate approval" id="node-approval">
@@ -639,18 +640,17 @@
           </defs>
 
           <path class="wire blue" d="M305 145 H390" data-edge data-from="node-capture" data-to="node-customer" data-from-side="right" data-to-side="left"/>
-          <path class="wire" d="M305 180 H340 V345 H390" data-edge data-from="node-capture" data-to="node-report" data-from-side="right" data-to-side="left" data-from-shift="35"/>
+          <path class="wire dashed" d="M305 180 H340 V375 H390" data-edge data-from="node-capture" data-to="node-report" data-from-side="right" data-to-side="left" data-from-shift="35"/>
           <path class="wire blue" d="M580 132 H655 V82 H720" data-edge data-from="node-customer" data-to="node-cs" data-from-side="right" data-to-side="left" data-from-shift="-3"/>
-          <path class="wire blue" d="M580 158 H670 V195 H720" data-edge data-from="node-customer" data-to="node-sentiment" data-from-side="right" data-to-side="left" data-from-shift="23"/>
+          <path class="wire blue" d="M580 158 H670 V195 H720" data-edge data-from="node-customer" data-to="node-deal-score" data-from-side="right" data-to-side="left" data-from-shift="23"/>
+          <path class="wire blue" d="M485 210 V300" data-edge data-from="node-customer" data-to="node-report" data-from-side="bottom" data-to-side="top"/>
           <path class="wire" d="M580 345 H710" data-edge data-from="node-report" data-to="node-draft" data-from-side="right" data-to-side="left"/>
           <path class="wire green" d="M930 345 H1000" data-edge data-from="node-draft" data-to="node-approval" data-from-side="right" data-to-side="left"/>
           <path class="wire green" d="M1150 345 H1210" data-edge data-from="node-approval" data-to="node-complete" data-from-side="right" data-to-side="left"/>
 
-          <path class="wire green dashed no-arrow" id="feedback-sentiment" d="M980 195 H1380 V480"/>
           <path class="wire green dashed no-arrow" id="feedback-report" d="M1288 386 V480 H1380"/>
           <path class="wire green dashed" id="feedback-merged" d="M1380 480 V570 H580"/>
           <circle id="feedback-junction" cx="1380" cy="480" r="4" fill="#0f7b5f"/>
-          <text class="wire-label" id="label-sentiment" x="1160" y="186">감정 분석</text>
           <text class="wire-label" id="label-report" x="1298" y="440">보고서 완성</text>
           <text class="wire-label" id="label-contract-input" x="1090" y="560">계약관리 입력</text>
 
@@ -670,17 +670,18 @@
       <div class="legend" aria-label="범례">
         <span><b class="legend-io">I</b>인풋</span>
         <span><b class="legend-io output">O</b>아웃풋</span>
+        <span><b class="legend-io output">M</b>ML 모델</span>
         <span><i class="l-agent"></i>에이전트</span>
         <span><i class="l-human"></i>사용자 승인</span>
         <span>↑↓ 에이전트 간 쌍방 교류</span>
-        <span>점선은 다음 판단에 반영되는 피드백</span>
+        <span>점선은 원문 참조 또는 다음 판단 피드백</span>
       </div>
     </section>
   </main>
 
   <script>
     (() => {
-      const STORAGE_KEY = "salesluv-flow-editor:v1";
+      const STORAGE_KEY = "salesluv-flow-editor:v2";
       const canvas = document.querySelector(".flow-canvas");
       const wires = document.querySelector(".wires");
       const userEdgeLayer = document.querySelector("#user-edge-layer");
@@ -764,22 +765,16 @@
       }
 
       function updateFeedback() {
-        const sentiment = box(nodeById.get("node-sentiment"));
         const report = box(nodeById.get("node-complete"));
         const contract = box(nodeById.get("node-contract"));
         const busX = canvas.clientWidth - 20;
         const joinY = clamp(Math.max(report.bottom + 60, contract.top + 10), 40, canvas.clientHeight - 40);
         const targetY = clamp(contract.top + contract.height * 2 / 3, contract.top + 18, contract.bottom - 18);
 
-        document.querySelector("#feedback-sentiment").setAttribute("d", `M${sentiment.right} ${sentiment.cy} H${busX} V${joinY}`);
         document.querySelector("#feedback-report").setAttribute("d", `M${report.cx} ${report.bottom} V${joinY} H${busX}`);
         document.querySelector("#feedback-merged").setAttribute("d", `M${busX} ${joinY} V${targetY} H${contract.right}`);
         document.querySelector("#feedback-junction").setAttribute("cx", busX);
         document.querySelector("#feedback-junction").setAttribute("cy", joinY);
-
-        const sentimentLabel = document.querySelector("#label-sentiment");
-        sentimentLabel.setAttribute("x", sentiment.right + (busX - sentiment.right) * .45);
-        sentimentLabel.setAttribute("y", sentiment.cy - 9);
 
         const reportLabel = document.querySelector("#label-report");
         reportLabel.setAttribute("x", report.cx + 10);
@@ -850,7 +845,7 @@
 
       function snapshot() {
         return {
-          version: 1,
+          version: 2,
           nodes: Object.fromEntries(nodes.map((node) => [node.id, {
             x: node.offsetLeft,
             y: node.offsetTop,
@@ -881,7 +876,7 @@
         } catch {
           return;
         }
-        if (!saved || saved.version !== 1) return;
+        if (!saved || saved.version !== 2) return;
 
         Object.entries(saved.nodes || {}).forEach(([id, value]) => {
           const node = nodeById.get(id);

--- a/docs/technical/SalesLuv_ERD.md
+++ b/docs/technical/SalesLuv_ERD.md
@@ -340,7 +340,7 @@ LLM이 만든 초안과 사람이 수정·검토·승인한 최종 보고서를 
 - `started_at?` — 대기 상태가 끝나고 실행을 시작한 시각
 - `finished_at?` — 완료 또는 실패한 시각
 
-`parent_run_id`로 Agent 간 교류를 표현한다. 고객관리 Agent의 감정분석 결과가 계약관리 Agent 실행을 호출하면 두 실행을 부모·자식으로 연결한다.
+`parent_run_id`로 Agent 간 교류를 표현한다. 보고서 Agent의 승인된 최종 결과가 계약관리 Agent 실행을 호출하면 두 실행을 부모·자식으로 연결한다. 딜 승산 점수는 화면 표시용 ML 결과이며 다른 Agent 실행을 호출하지 않는다.
 
 사용자가 시작한 실행은 `requested_by_member_id`, `idempotency_key` 조합을 중복 불가로 둔다. Agent 내부 호출은 `idempotency_key`를 사용하지 않는다.
 

--- a/docs/technical/SalesLuv_멀티에이전트_운영_플로우.html
+++ b/docs/technical/SalesLuv_멀티에이전트_운영_플로우.html
@@ -15,7 +15,7 @@
     --wire:#aab2be;
     --chip:#ffffff;
 
-    --c1:#2563eb; --c1-bg:#eaf0ff;   /* 고객관리 */
+    --c1:#2563eb; --c1-bg:#eaf0ff;   /* 미팅분석 */
     --c2:#d97706; --c2-bg:#fdf1e0;   /* 보고서 */
     --c3:#7c3aed; --c3-bg:#f2ecff;   /* 계약관리 */
     --c4:#0d9488; --c4-bg:#e0f5f1;   /* 일정관리 */
@@ -66,6 +66,7 @@
   }
   .badge.in{ color:var(--muted); }
   .badge.out{ color:var(--muted); }
+  .badge.model{ color:var(--c3); }
 
   /* ---------- board ---------- */
   .board{
@@ -135,7 +136,7 @@
 
   /* ---------- outputs ---------- */
   .outs{ display:flex; flex-direction:column; gap:14px; align-items:flex-start; }
-  .outs.row{ flex-direction:row; align-items:center; flex-wrap:wrap; gap:12px 46px; }
+  .outs.row{ flex-direction:row; align-items:center; flex-wrap:wrap; gap:12px 24px; }
 
   .chip{
     display:inline-flex; align-items:center; gap:9px;
@@ -169,6 +170,7 @@
     <div class="legend">
       <span><i class="badge in">I</i> Input — 에이전트로 들어오는 값</span>
       <span><i class="badge out">O</i> Output — 에이전트가 내보내는 값</span>
+      <span><i class="badge model">M</i> Model — ML 분류 모델</span>
       <span><i class="badge" style="color:var(--wire)">↕</i> 에이전트 간 교류</span>
     </div>
   </header>
@@ -182,27 +184,28 @@
     <div class="in" id="in1" style="grid-area:in1">
       <h3>미팅 자료</h3>
       <ul>
-        <li>STT</li>
-        <li>OCR</li>
-        <li>직접입력</li>
+        <li>녹음 파일 (STT)</li>
+        <li>미팅 내용 메모</li>
+        <li>직접 입력</li>
       </ul>
     </div>
 
     <div class="agent a1" id="ag-customer" style="grid-area:ag1">
-      <div class="nm">고객관리</div>
+      <div class="nm">미팅 분석</div>
       <div class="tag">AGENT</div>
     </div>
     <div class="outs" id="ou1" style="grid-area:ou1">
-      <div class="chip" id="o-cs"><i class="badge out">O</i> C/S 사항</div>
-      <div class="chip" id="o-emo"><i class="badge out">O</i> 감정 분석 <em>(현재 감정, 변화된 감정 )</em></div>
+      <div class="chip" id="o-cs"><i class="badge out">O</i> C/S 사항 <em>(보고서 · C/S 관리 페이지 공통 사용)</em></div>
+      <div class="chip" id="o-deal-features"><i class="badge out">O</i> 딜 특성 구조화 <em>(승인권자 · 예산 · 경쟁사 · 니즈)</em></div>
+      <div class="chip" id="o-win-score"><i class="badge model">M</i> 딜 승산 점수 <em>(0–100점 · 승인 없이 화면 표시만)</em></div>
     </div>
 
     <div class="agent a2" id="ag-report" style="grid-area:ag2">
-      <div class="nm">보고서</div>
+      <div class="nm">보고서 작성</div>
       <div class="tag">AGENT</div>
     </div>
     <div class="outs row" id="ou2" style="grid-area:ou2">
-      <div class="chip" id="o-draft"><i class="badge out">O</i> 보고서 초안</div>
+      <div class="chip" id="o-draft"><i class="badge out">O</i> 보고서 초안 · C/S 포함</div>
       <div class="human" id="o-human"><span class="k">HUMAN</span> 수정 · 승인</div>
       <div class="chip solid" id="o-final">보고서 완성</div>
     </div>
@@ -279,9 +282,11 @@
   // A→B 연결 정의. type: line(가로) / rail(우측 레일 경유) / drop(아래로) / duplex(양방향)
   const LINKS = [
     ['in1',          'ag-customer', 'line'],
-    ['in1',          'ag-report',   'line'],
+    ['in1',          'ag-report',   'line', {label:'원문 참조', dashed:true}],
+    ['ag-customer',  'ag-report',   'drop', {label:'분석 결과', gutter:18}],
     ['ag-customer',  'o-cs',        'line'],
-    ['ag-customer',  'o-emo',       'line'],
+    ['ag-customer',  'o-deal-features', 'line'],
+    ['o-deal-features', 'o-win-score',  'drop', {gutter:9}],
     ['ag-report',    'o-draft',     'line'],
     ['o-draft',      'o-human',     'line', {thin:true}],
     ['o-human',      'o-final',     'line', {thin:true}],
@@ -297,7 +302,6 @@
     ['ag-doc',       'o-docsum',    'line'],
 
     // 에이전트 간 연결
-    ['o-emo',        'ag-contract', 'rail',   {label:'I', enter:-22, gutter:38}],
     ['o-final',      'ag-contract', 'drop',   {label:'I', enter: 22, gutter:18}],
     ['o-nextmeet',   'ag-schedule', 'drop',   {label:'I', enter: 26, gutter:20}],
     ['ag-contract',  'ag-schedule', 'duplex', {label:'교류', offset:-34}],
@@ -405,6 +409,7 @@
         'stroke-linecap':'round',
         'marker-end':'url(#ah)'
       });
+      if(opt.dashed) path.setAttribute('stroke-dasharray', '6 5');
 
       if(type === 'line'){
         const x1 = a.r + 4, y1 = a.cy;
@@ -412,6 +417,7 @@
         const dx = Math.max(24, (x2 - x1) * .5);
         path.setAttribute('d',
           `M ${px(x1)} ${px(y1)} C ${px(x1+dx)} ${px(y1)}, ${px(x2-dx)} ${px(y2)}, ${px(x2)} ${px(y2)}`);
+        if(opt.label) labelAt(labels, (x1+x2)/2, (y1+y2)/2, opt.label);
       }
 
       else if(type === 'rail'){


### PR DESCRIPTION
## 변경 요약

- 감정 분석 흐름을 제거하고 미팅 분석 Agent 중심으로 재구성했습니다.
- 미팅 원문과 분석 결과를 보고서 작성 Agent가 함께 참조하도록 연결했습니다.
- C/S 사항을 보고서와 C/S 관리 페이지에서 공통 사용하도록 명시했습니다.
- 구조화된 딜 특성으로 ML 승산 점수를 계산하되 승인 없이 표시만 하고 다른 Agent는 호출하지 않도록 했습니다.
- 편집용 데모와 ERD 설명을 운영 플로우에 맞춰 동기화했습니다.

## 검증

- `git diff --check` 통과
- 두 HTML 파일의 인라인 JavaScript 구문 검사 통과
- Codex 인앱 브라우저 전체 렌더링 확인
- 브라우저 콘솔 경고·오류 0건 확인

## 영향 및 주의 사항

- 문서와 데모 HTML만 변경하며 백엔드·프런트엔드 실행 로직에는 영향이 없습니다.
- ML 점수는 화면 표시 전용이며 후속 Agent 실행 조건으로 사용하지 않습니다.