### PR TITLE
feat: 일정 API와 캘린더 실제 데이터 흐름 연결

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter
 
-from app.api import auth, customers, health
+from app.api import activities, auth, customers, health
 
 api_router = APIRouter()
 api_router.include_router(health.router)
 api_router.include_router(auth.router)
 api_router.include_router(customers.router)
+api_router.include_router(activities.router)

--- a/backend/app/api/activities.py
+++ b/backend/app/api/activities.py
@@ -1,0 +1,398 @@
+from datetime import UTC, datetime, time, timedelta
+from typing import Annotated
+from uuid import UUID, uuid4
+from zoneinfo import ZoneInfo
+
+from fastapi import APIRouter, HTTPException, Query, Response, status
+from sqlalchemy import and_, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from app.api.deps import CurrentMember, DbSession
+from app.models.crm import Activity, CustomerCompany, CustomerContact
+from app.models.sales import Product
+from app.models.workspace import Member
+from app.schemas.activities import (
+    ActivityCreate,
+    ActivityPage,
+    ActivityPageParams,
+    ActivityPatch,
+    ActivityRead,
+)
+
+router = APIRouter(tags=["activities"])
+
+_SEOUL = ZoneInfo("Asia/Seoul")
+_owner = aliased(Member)
+_contact = aliased(CustomerContact)
+_contact_owner = aliased(Member)
+_company = aliased(CustomerCompany)
+_product = aliased(Product)
+
+
+def _joined_select(*entities):
+    return (
+        select(*entities)
+        .select_from(Activity)
+        .join(_owner, Activity.owner_member_id == _owner.id)
+        .outerjoin(_contact, Activity.customer_contact_id == _contact.id)
+        .outerjoin(_contact_owner, _contact.owner_member_id == _contact_owner.id)
+        .outerjoin(_company, _contact.company_id == _company.id)
+        .outerjoin(_product, Activity.product_id == _product.id)
+    )
+
+
+def _scope(member: Member, owner_ids: tuple[UUID, ...] | None = None):
+    conditions = [
+        Activity.team_id == member.team_id,
+        Activity.deleted_at.is_(None),
+        _owner.team_id == member.team_id,
+        _owner.active.is_(True),
+        _owner.role_code.in_(("member", "manager")),
+        or_(
+            Activity.customer_contact_id.is_(None),
+            and_(
+                _company.team_id == member.team_id,
+                _contact_owner.team_id == member.team_id,
+                _contact_owner.active.is_(True),
+                _contact_owner.role_code.in_(("member", "manager")),
+            ),
+        ),
+        or_(Activity.product_id.is_(None), _product.team_id == member.team_id),
+    ]
+    if member.role_code == "member":
+        conditions.extend(
+            (
+                Activity.owner_member_id == member.id,
+                or_(
+                    Activity.customer_contact_id.is_(None),
+                    _contact.owner_member_id == member.id,
+                ),
+            )
+        )
+    elif owner_ids is not None:
+        conditions.append(Activity.owner_member_id.in_(owner_ids))
+    return conditions
+
+
+def _seoul(value: datetime | None) -> datetime | None:
+    return None if value is None else value.astimezone(_SEOUL)
+
+
+def _activity_read(
+    activity: Activity,
+    owner_display_name: str,
+    contact: CustomerContact | None,
+    company_id: UUID | None,
+    company_name: str | None,
+    product_name: str | None,
+) -> ActivityRead:
+    return ActivityRead(
+        id=activity.id,
+        owner_member_id=activity.owner_member_id,
+        owner_display_name=owner_display_name,
+        customer_contact_id=activity.customer_contact_id,
+        customer_contact_name=None if contact is None else contact.name,
+        customer_contact_department=None if contact is None else contact.department,
+        customer_contact_job_title=None if contact is None else contact.job_title,
+        customer_company_id=company_id,
+        customer_company_name=company_name,
+        product_id=activity.product_id,
+        product_name=product_name,
+        activity_type=activity.activity_type,
+        category_code=activity.category_code,
+        title=activity.title,
+        starts_at=_seoul(activity.starts_at),
+        ends_at=_seoul(activity.ends_at),
+        all_day=activity.all_day,
+        location=activity.location,
+        action_tag=activity.action_tag,
+        completed_at=_seoul(activity.completed_at),
+        note=activity.note,
+        created_at=_seoul(activity.created_at),
+        updated_at=_seoul(activity.updated_at),
+    )
+
+
+async def _owner_filter(
+    db: AsyncSession,
+    member: Member,
+    requested: list[UUID] | None,
+) -> tuple[UUID, ...] | None:
+    if requested is None:
+        return None
+    if member.role_code != "manager":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="scope_not_allowed",
+        )
+    owner_ids = tuple(dict.fromkeys(requested))
+    result = await db.execute(
+        select(Member.id).where(
+            Member.id.in_(owner_ids),
+            Member.team_id == member.team_id,
+            Member.active.is_(True),
+            Member.role_code.in_(("member", "manager")),
+        )
+    )
+    if set(result.scalars().all()) != set(owner_ids):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="scope_not_allowed",
+        )
+    return owner_ids
+
+
+async def _activity_row(
+    db: AsyncSession,
+    member: Member,
+    activity_id: UUID,
+):
+    result = await db.execute(
+        _joined_select(
+            Activity,
+            _owner.display_name,
+            _contact,
+            _company.id,
+            _company.name,
+            _product.name,
+        ).where(Activity.id == activity_id, *_scope(member))
+    )
+    row = result.one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="activity_not_found",
+        )
+    return row
+
+
+async def _locked_activity(
+    db: AsyncSession,
+    member: Member,
+    activity_id: UUID,
+) -> Activity:
+    conditions = [
+        Activity.id == activity_id,
+        Activity.team_id == member.team_id,
+        Activity.deleted_at.is_(None),
+        Member.team_id == member.team_id,
+        Member.active.is_(True),
+        Member.role_code.in_(("member", "manager")),
+    ]
+    if member.role_code == "member":
+        conditions.append(Activity.owner_member_id == member.id)
+    result = await db.execute(
+        select(Activity)
+        .join(Member, Activity.owner_member_id == Member.id)
+        .where(*conditions)
+        .with_for_update(of=Activity)
+    )
+    activity = result.scalar_one_or_none()
+    if activity is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="activity_not_found",
+        )
+    return activity
+
+
+async def _contact_info(
+    db: AsyncSession,
+    member: Member,
+    contact_id: UUID,
+) -> tuple[CustomerContact, UUID, str]:
+    conditions = [
+        CustomerContact.id == contact_id,
+        CustomerCompany.team_id == member.team_id,
+        Member.team_id == member.team_id,
+        Member.active.is_(True),
+        Member.role_code.in_(("member", "manager")),
+    ]
+    if member.role_code == "member":
+        conditions.append(CustomerContact.owner_member_id == member.id)
+    result = await db.execute(
+        select(CustomerContact, CustomerCompany.id, CustomerCompany.name)
+        .join(CustomerCompany, CustomerContact.company_id == CustomerCompany.id)
+        .join(Member, CustomerContact.owner_member_id == Member.id)
+        .where(*conditions)
+    )
+    row = result.one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="customer_contact_not_found",
+        )
+    return row
+
+
+async def _team_product(db: AsyncSession, member: Member, product_id: UUID) -> Product:
+    result = await db.execute(
+        select(Product).where(
+            Product.id == product_id,
+            Product.team_id == member.team_id,
+            Product.active.is_(True),
+        )
+    )
+    product = result.scalar_one_or_none()
+    if product is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="product_not_found",
+        )
+    return product
+
+
+def _validate_range(starts_at: datetime, ends_at: datetime | None) -> None:
+    if ends_at is not None and ends_at <= starts_at:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="invalid_activity_range",
+        )
+
+
+@router.get("/activities", response_model=ActivityPage)
+async def list_activities(
+    page: Annotated[ActivityPageParams, Query()],
+    member: CurrentMember,
+    db: DbSession,
+) -> ActivityPage:
+    owner_ids = await _owner_filter(db, member, page.owner_member_id)
+    start_at = datetime.combine(page.start_date, time.min, _SEOUL)
+    end_at = datetime.combine(page.end_date or page.start_date, time.min, _SEOUL) + timedelta(
+        days=1
+    )
+    scope = [
+        *_scope(member, owner_ids),
+        Activity.starts_at >= start_at,
+        Activity.starts_at < end_at,
+    ]
+    total_result = await db.execute(_joined_select(func.count(Activity.id)).where(*scope))
+    total = total_result.scalar_one()
+    rows_result = await db.execute(
+        _joined_select(
+            Activity,
+            _owner.display_name,
+            _contact,
+            _company.id,
+            _company.name,
+            _product.name,
+        )
+        .where(*scope)
+        .order_by(Activity.starts_at, Activity.id)
+        .offset(page.skip)
+        .limit(page.limit)
+    )
+    items = [_activity_read(*row) for row in rows_result.all()]
+    has_more = page.skip + len(items) < total
+    return ActivityPage(
+        items=items,
+        skip=page.skip,
+        limit=page.limit,
+        total=total,
+        has_more=has_more,
+        next_skip=page.skip + len(items) if has_more else None,
+    )
+
+
+@router.get("/activities/{activity_id}", response_model=ActivityRead)
+async def get_activity(
+    activity_id: UUID,
+    member: CurrentMember,
+    db: DbSession,
+) -> ActivityRead:
+    return _activity_read(*await _activity_row(db, member, activity_id))
+
+
+@router.post(
+    "/activities",
+    response_model=ActivityRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_activity(
+    payload: ActivityCreate,
+    response: Response,
+    member: CurrentMember,
+    db: DbSession,
+) -> ActivityRead:
+    try:
+        contact_info = (
+            None
+            if payload.customer_contact_id is None
+            else await _contact_info(db, member, payload.customer_contact_id)
+        )
+        product = (
+            None
+            if payload.product_id is None
+            else await _team_product(db, member, payload.product_id)
+        )
+        activity = Activity(
+            id=uuid4(),
+            team_id=member.team_id,
+            owner_member_id=member.id,
+            **payload.model_dump(),
+        )
+        db.add(activity)
+        await db.flush()
+        read = _activity_read(
+            activity,
+            member.display_name,
+            None if contact_info is None else contact_info[0],
+            None if contact_info is None else contact_info[1],
+            None if contact_info is None else contact_info[2],
+            None if product is None else product.name,
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    response.headers["Location"] = f"/api/activities/{activity.id}"
+    return read
+
+
+@router.patch("/activities/{activity_id}", response_model=ActivityRead)
+async def update_activity(
+    activity_id: UUID,
+    payload: ActivityPatch,
+    member: CurrentMember,
+    db: DbSession,
+) -> ActivityRead:
+    try:
+        activity = await _locked_activity(db, member, activity_id)
+        values = payload.model_dump(exclude_unset=True)
+        if values.get("customer_contact_id") is not None:
+            await _contact_info(db, member, values["customer_contact_id"])
+        if values.get("product_id") is not None:
+            await _team_product(db, member, values["product_id"])
+        _validate_range(
+            values.get("starts_at", activity.starts_at),
+            values.get("ends_at", activity.ends_at),
+        )
+        for field_name, value in values.items():
+            setattr(activity, field_name, value)
+        activity.updated_at = datetime.now(UTC)
+        await db.flush()
+        read = _activity_read(*await _activity_row(db, member, activity_id))
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return read
+
+
+@router.delete("/activities/{activity_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_activity(
+    activity_id: UUID,
+    member: CurrentMember,
+    db: DbSession,
+) -> None:
+    try:
+        activity = await _locked_activity(db, member, activity_id)
+        now = datetime.now(UTC)
+        activity.deleted_at = now
+        activity.updated_at = now
+        await db.flush()
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise

--- a/backend/app/schemas/activities.py
+++ b/backend/app/schemas/activities.py
@@ -1,0 +1,180 @@
+from datetime import UTC, date, datetime, timedelta
+from typing import Annotated, Literal, Self
+from uuid import UUID
+
+from pydantic import (
+    AfterValidator,
+    AwareDatetime,
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictBool,
+    StringConstraints,
+    model_validator,
+)
+
+
+def _seoul_offset(value: datetime) -> datetime:
+    if value.utcoffset() != timedelta(hours=9):
+        raise ValueError("datetime offset must be +09:00")
+    return value
+
+
+ActivityType = Literal["meeting", "task"]
+ActivityCategory = Literal[
+    "visit",
+    "demo",
+    "education",
+    "call",
+    "delivery",
+    "conference",
+    "internal",
+]
+ActionTag = Literal[
+    "first_call",
+    "meeting",
+    "demo_requested",
+    "demo_in_progress",
+    "demo_completed",
+    "quote_completed",
+    "contract_completed",
+    "product_training",
+    "delivery_completed",
+    "internal_meeting",
+    "weekly_review",
+    "monthly_review",
+    "quarterly_review",
+    "conference",
+    "ojt",
+]
+SafeDateTime = Annotated[
+    AwareDatetime,
+    Field(
+        ge=datetime.min.replace(tzinfo=UTC),
+        le=datetime.max.replace(hour=14, tzinfo=UTC),
+    ),
+    AfterValidator(_seoul_offset),
+]
+CalendarDate = Annotated[date, Field(le=date.max - timedelta(days=1))]
+Title = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=254),
+]
+ShortText = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=500),
+]
+Note = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=5_000),
+]
+
+
+class _WriteModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class ActivityCreate(_WriteModel):
+    customer_contact_id: UUID | None = None
+    product_id: UUID | None = None
+    activity_type: ActivityType
+    category_code: ActivityCategory
+    title: Title
+    starts_at: SafeDateTime
+    ends_at: SafeDateTime | None = None
+    all_day: StrictBool = False
+    location: ShortText | None = None
+    action_tag: ActionTag | None = None
+    note: Note | None = None
+
+    @model_validator(mode="after")
+    def ends_after_start(self) -> Self:
+        if self.ends_at is not None and self.ends_at <= self.starts_at:
+            raise ValueError("ends_at must be after starts_at")
+        return self
+
+
+class ActivityPatch(_WriteModel):
+    customer_contact_id: UUID | None = None
+    product_id: UUID | None = None
+    activity_type: ActivityType | None = None
+    category_code: ActivityCategory | None = None
+    title: Title | None = None
+    starts_at: SafeDateTime | None = None
+    ends_at: SafeDateTime | None = None
+    all_day: StrictBool | None = None
+    location: ShortText | None = None
+    action_tag: ActionTag | None = None
+    note: Note | None = None
+
+    @model_validator(mode="after")
+    def validate_patch(self) -> Self:
+        for field_name in (
+            "activity_type",
+            "category_code",
+            "title",
+            "starts_at",
+            "all_day",
+        ):
+            if field_name in self.model_fields_set and getattr(self, field_name) is None:
+                raise ValueError(f"{field_name} cannot be null")
+        if (
+            "starts_at" in self.model_fields_set
+            and "ends_at" in self.model_fields_set
+            and self.ends_at is not None
+            and self.starts_at is not None
+            and self.ends_at <= self.starts_at
+        ):
+            raise ValueError("ends_at must be after starts_at")
+        return self
+
+
+class ActivityRead(BaseModel):
+    id: UUID
+    owner_member_id: UUID
+    owner_display_name: str
+    customer_contact_id: UUID | None
+    customer_contact_name: str | None
+    customer_contact_department: str | None
+    customer_contact_job_title: str | None
+    customer_company_id: UUID | None
+    customer_company_name: str | None
+    product_id: UUID | None
+    product_name: str | None
+    activity_type: ActivityType
+    category_code: ActivityCategory
+    title: str
+    starts_at: datetime
+    ends_at: datetime | None
+    all_day: bool
+    location: str | None
+    action_tag: ActionTag | None
+    completed_at: datetime | None
+    note: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class ActivityPage(BaseModel):
+    items: list[ActivityRead]
+    skip: int
+    limit: int
+    total: int
+    has_more: bool
+    next_skip: int | None
+
+
+class ActivityPageParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    start_date: CalendarDate
+    end_date: CalendarDate | None = None
+    owner_member_id: list[UUID] | None = None
+    skip: int = Field(default=0, ge=0, le=9_223_372_036_854_775_807)
+    limit: int = Field(default=30, ge=1, le=100)
+
+    @model_validator(mode="after")
+    def dates_in_order(self) -> Self:
+        if self.end_date is not None and self.end_date < self.start_date:
+            raise ValueError("end_date must not be before start_date")
+        return self

--- a/backend/scripts/seed_demo_activities.py
+++ b/backend/scripts/seed_demo_activities.py
@@ -1,0 +1,499 @@
+"""filled 데모팀에만 고정 합성 상품과 일정 12건을 반복 가능하게 넣는다."""
+
+import asyncio
+from datetime import date, datetime, time, timedelta
+from typing import NamedTuple
+from uuid import UUID, uuid5
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import and_, or_, select
+from sqlalchemy.dialects.postgresql import insert
+
+from app.db.session import get_sessionmaker
+from app.models.crm import Activity, CustomerCompany, CustomerContact
+from app.models.sales import Product
+from app.models.workspace import Member, Team
+from scripts.seed_demo_auth import FILLED_MANAGER_ID, FILLED_TEAM_ID
+from scripts.seed_demo_customers import (
+    FILLED_TEAM_NAME,
+    OWNER_IDS,
+    company_id,
+    contact_id,
+)
+
+REFERENCE_DATE = date(2026, 8, 17)
+SEOUL = ZoneInfo("Asia/Seoul")
+
+CATEGORY_CODES = {
+    "visit": "visit",
+    "demo": "demo",
+    "edu": "education",
+    "call": "call",
+    "delivery": "delivery",
+    "booth": "conference",
+    "internal": "internal",
+}
+
+ACTION_TAG_CODES = {
+    "첫 전화": "first_call",
+    "미팅": "meeting",
+    "데모 요청": "demo_requested",
+    "데모 진행": "demo_in_progress",
+    "데모 완료": "demo_completed",
+    "견적완료": "quote_completed",
+    "계약완료": "contract_completed",
+    "제품교육": "product_training",
+    "납품완료": "delivery_completed",
+    "내부회의": "internal_meeting",
+    "주간점검": "weekly_review",
+    "월간점검": "monthly_review",
+    "분기점검": "quarterly_review",
+    "컨퍼런스": "conference",
+    "OJT": "ojt",
+}
+
+PRODUCT_NAMES = ("CardioView X7", "SonoFlex Pro", "OrthoScan Mini")
+ACTIVITY_OWNER_IDS = {**OWNER_IDS, "김서현": FILLED_MANAGER_ID}
+
+
+class ActivitySeed(NamedTuple):
+    mock_id: str
+    day_offset: int
+    start_time: time
+    duration_minutes: int | None
+    kind: str
+    owner_name: str
+    customer_contact_id: UUID | None
+    product_name: str | None
+    stage: str | None
+    location: str
+    title: str
+    note: str
+    completed: bool
+    all_day: bool = False
+
+
+ACTIVITY_SEEDS = (
+    ActivitySeed(
+        "a1",
+        0,
+        time(9, 30),
+        40,
+        "visit",
+        "김지훈",
+        contact_id("FM-CU-2026-0001"),
+        "CardioView X7",
+        "견적완료",
+        "본관 3층 회의실",
+        "CardioView X7 도입 후속 미팅",
+        (
+            "지난 방문에서 제기된 3년 유지보수 비용 이슈에 대응합니다. "
+            "TCO 비교표와 경쟁사 대비 납기 자료를 지참하고, 4분기 예산 집행 가능 여부와 "
+            "최종 승인권자를 확인하는 것이 이번 미팅의 목표입니다."
+        ),
+        True,
+    ),
+    ActivitySeed(
+        "a2",
+        0,
+        time(11),
+        30,
+        "call",
+        "이수민",
+        contact_id("FM-CU-2026-0003"),
+        "SonoFlex Pro",
+        "견적완료",
+        "전화",
+        "견적 회신 지연 건 후속 통화",
+        (
+            "견적 전달 후 14일째 회신이 없습니다. 예산 보류 사유를 확인하고 "
+            "데모 재일정을 제안합니다. 리스 옵션 안내 자료를 미리 준비하세요."
+        ),
+        False,
+    ),
+    ActivitySeed(
+        "a3",
+        0,
+        time(14),
+        60,
+        "demo",
+        "김지훈",
+        contact_id("FM-CU-2026-0002"),
+        "OrthoScan Mini",
+        "데모 진행",
+        "교육실",
+        "프로브 3종 비교 시연",
+        (
+            "실사용 간호 인력 5명이 참관합니다. 소독 프로토콜과 프로브 교체 주기 질문이 "
+            "예상됩니다. 데모 장비 반출 확인이 오전 중에 끝나야 합니다."
+        ),
+        False,
+    ),
+    ActivitySeed(
+        "a4",
+        0,
+        time(16, 30),
+        30,
+        "internal",
+        "김서현",
+        None,
+        None,
+        "주간점검",
+        "본사 회의실 B",
+        "주간 파이프라인 점검",
+        "8월 확정 매출 진척과 리스크 딜 2건을 공유합니다. 일일보고서 미작성 3건을 마감합니다.",
+        False,
+    ),
+    ActivitySeed(
+        "a5",
+        -2,
+        time(10),
+        None,
+        "booth",
+        "김지훈",
+        None,
+        "CardioView X7",
+        "컨퍼런스",
+        "코엑스 C홀",
+        "학술대회 부스 운영 1일차",
+        "CardioView X7 실물 전시와 상담을 진행합니다. 리드 카드는 당일 저녁에 CRM으로 옮깁니다.",
+        True,
+        True,
+    ),
+    ActivitySeed(
+        "a6",
+        -2,
+        time(16),
+        50,
+        "visit",
+        "박도윤",
+        contact_id("FM-CU-2026-0005"),
+        "OrthoScan Mini",
+        "미팅",
+        "학회장 미팅룸",
+        "학회 현장 구매 담당자 면담",
+        (
+            "학회 참석 중인 구매 담당자와 짧게 면담합니다. "
+            "기존 시스템 연동 범위와 도입 승인 절차를 확인합니다."
+        ),
+        True,
+    ),
+    ActivitySeed(
+        "a7",
+        1,
+        time(9),
+        90,
+        "delivery",
+        "이수민",
+        contact_id("FM-CU-2026-0003"),
+        "SonoFlex Pro",
+        "계약완료",
+        "1층 처치실",
+        "SonoFlex Pro 납품 입회",
+        (
+            "발주 FM-PO-2026-0021 건의 예상 입고일입니다. 설치 공간은 사전 확인을 "
+            "마쳤습니다. 입회 후 초기 셋업과 사용 교육 일정을 함께 잡으세요."
+        ),
+        False,
+    ),
+    ActivitySeed(
+        "a8",
+        2,
+        time(13, 30),
+        60,
+        "edu",
+        "김지훈",
+        contact_id("FM-CU-2026-0002"),
+        "OrthoScan Mini",
+        "제품교육",
+        "교육실",
+        "OrthoScan Mini 사용 교육 1회차",
+        (
+            "데모에서 나온 소독 프로토콜 질문을 교육 자료에 반영해 진행합니다. "
+            "참석자 명단은 전날까지 확정합니다."
+        ),
+        False,
+    ),
+    ActivitySeed(
+        "a9",
+        6,
+        time(11),
+        45,
+        "visit",
+        "김지훈",
+        None,
+        "CardioView X7",
+        "계약완료",
+        "본관 2층",
+        "CardioView X7 계약 조건 협의",
+        "발주 FM-PO-2026-0020의 분할 납품 2차 일정과 계약 조건을 함께 정리합니다.",
+        False,
+    ),
+    ActivitySeed(
+        "a10",
+        -6,
+        time(14),
+        40,
+        "visit",
+        "김지훈",
+        contact_id("FM-CU-2026-0001"),
+        "CardioView X7",
+        "데모 완료",
+        "본관 3층",
+        "CardioView X7 제품 테스트",
+        (
+            "실사용 테스트를 진행했습니다. 화면 가독성은 긍정적이었고 "
+            "유지보수 비용 설명 요청을 받았습니다."
+        ),
+        True,
+    ),
+    ActivitySeed(
+        "a11",
+        8,
+        time(10, 30),
+        40,
+        "visit",
+        "박도윤",
+        contact_id("FM-CU-2026-0005"),
+        "OrthoScan Mini",
+        "데모 요청",
+        "회의실",
+        "OrthoScan Mini 본원 데모",
+        (
+            "학회 면담 후속으로 본원에서 데모를 진행합니다. "
+            "보안 요구사항과 데이터 접근 권한을 확인하세요."
+        ),
+        False,
+    ),
+    ActivitySeed(
+        "a12",
+        0,
+        time(17),
+        40,
+        "internal",
+        "김지훈",
+        None,
+        None,
+        None,
+        "본사 회의실 B",
+        "담당 고객 진척 공유",
+        (
+            "한빛대학교병원 견적 회신 일정과 서림메디컬센터 데모 결과를 팀장에게 "
+            "공유합니다. 다음 주 방문 계획을 확정합니다."
+        ),
+        False,
+    ),
+)
+
+
+def product_id(name: str) -> UUID:
+    return uuid5(FILLED_TEAM_ID, f"product:{name}")
+
+
+def activity_id(mock_id: str) -> UUID:
+    return uuid5(FILLED_TEAM_ID, f"activity:{mock_id}")
+
+
+def activity_row(seed: ActivitySeed) -> dict:
+    starts_at = datetime.combine(
+        REFERENCE_DATE + timedelta(days=seed.day_offset),
+        seed.start_time,
+        tzinfo=SEOUL,
+    )
+    ends_at = (
+        starts_at + timedelta(minutes=seed.duration_minutes)
+        if seed.duration_minutes is not None
+        else None
+    )
+    return {
+        "id": activity_id(seed.mock_id),
+        "team_id": FILLED_TEAM_ID,
+        "owner_member_id": ACTIVITY_OWNER_IDS[seed.owner_name],
+        "customer_contact_id": seed.customer_contact_id,
+        "end_user_contact_id": None,
+        "activity_type": "task" if seed.kind == "internal" else "meeting",
+        "category_code": CATEGORY_CODES[seed.kind],
+        "title": seed.title,
+        "starts_at": starts_at,
+        "ends_at": ends_at,
+        "all_day": seed.all_day,
+        "due_at": None,
+        "location": seed.location,
+        "action_tag": ACTION_TAG_CODES[seed.stage] if seed.stage else None,
+        "completed_at": (ends_at or starts_at) if seed.completed else None,
+        "note": seed.note,
+        "deleted_at": None,
+        "product_id": product_id(seed.product_name) if seed.product_name else None,
+        "contract_id": None,
+        "order_id": None,
+    }
+
+
+async def seed_demo_activities() -> None:
+    products = {product_id(name): name for name in PRODUCT_NAMES}
+    activities = tuple(activity_row(seed) for seed in ACTIVITY_SEEDS)
+    expected_activity_ids = {row["id"] for row in activities}
+    expected_members = {
+        ACTIVITY_OWNER_IDS[seed.owner_name]: (
+            seed.owner_name,
+            "manager" if seed.owner_name == "김서현" else "member",
+        )
+        for seed in ACTIVITY_SEEDS
+    }
+    expected_contacts = {
+        contact_id("FM-CU-2026-0001"): (
+            company_id("한빛대학교병원"),
+            OWNER_IDS["김지훈"],
+        ),
+        contact_id("FM-CU-2026-0002"): (
+            company_id("서림메디컬센터"),
+            OWNER_IDS["김지훈"],
+        ),
+        contact_id("FM-CU-2026-0003"): (
+            company_id("새봄정형외과"),
+            OWNER_IDS["이수민"],
+        ),
+        contact_id("FM-CU-2026-0005"): (
+            company_id("정우병원"),
+            OWNER_IDS["박도윤"],
+        ),
+    }
+
+    async with get_sessionmaker()() as session, session.begin():
+        filled_team_name = (
+            await session.execute(
+                select(Team.name).where(Team.id == FILLED_TEAM_ID).with_for_update()
+            )
+        ).scalar_one_or_none()
+        if filled_team_name != FILLED_TEAM_NAME:
+            raise SystemExit("filled 인증 seed를 먼저 실행하세요.")
+
+        existing_members = (
+            await session.execute(
+                select(
+                    Member.id,
+                    Member.team_id,
+                    Member.display_name,
+                    Member.role_code,
+                    Member.active,
+                )
+                .where(Member.id.in_(expected_members))
+                .with_for_update()
+            )
+        ).all()
+        if {row.id for row in existing_members} != set(expected_members):
+            raise SystemExit("인증과 고객 seed를 먼저 실행해 일정 담당자를 준비하세요.")
+        for row in existing_members:
+            display_name, role_code = expected_members[row.id]
+            if (
+                row.team_id != FILLED_TEAM_ID
+                or row.display_name != display_name
+                or row.role_code != role_code
+                or not row.active
+            ):
+                raise SystemExit("합성 일정 담당자 ID, 팀, 이름 또는 역할이 충돌합니다.")
+
+        existing_contacts = (
+            await session.execute(
+                select(
+                    CustomerContact.id,
+                    CustomerContact.company_id,
+                    CustomerContact.owner_member_id,
+                    CustomerCompany.team_id,
+                )
+                .join(CustomerCompany, CustomerContact.company_id == CustomerCompany.id)
+                .where(CustomerContact.id.in_(expected_contacts))
+                .with_for_update()
+            )
+        ).all()
+        if {row.id for row in existing_contacts} != set(expected_contacts):
+            raise SystemExit("고객 seed를 먼저 실행해 일정 고객 담당자를 준비하세요.")
+        for row in existing_contacts:
+            company_id_, owner_id = expected_contacts[row.id]
+            if (
+                row.team_id != FILLED_TEAM_ID
+                or row.company_id != company_id_
+                or row.owner_member_id != owner_id
+            ):
+                raise SystemExit("합성 일정 고객 담당자 ID, 고객사, owner 또는 팀이 충돌합니다.")
+
+        existing_products = (
+            await session.execute(
+                select(Product.id, Product.team_id, Product.name)
+                .where(
+                    or_(
+                        Product.id.in_(products),
+                        and_(
+                            Product.team_id == FILLED_TEAM_ID,
+                            Product.name.in_(PRODUCT_NAMES),
+                        ),
+                    )
+                )
+                .with_for_update()
+            )
+        ).all()
+        expected_product_ids = {name: id_ for id_, name in products.items()}
+        for row in existing_products:
+            if (
+                products.get(row.id) != row.name
+                or expected_product_ids.get(row.name) != row.id
+                or row.team_id != FILLED_TEAM_ID
+            ):
+                raise SystemExit("합성 상품 ID, 이름 또는 팀이 충돌합니다.")
+
+        existing_activities = (
+            await session.execute(
+                select(Activity.id, Activity.team_id)
+                .where(Activity.id.in_(expected_activity_ids))
+                .with_for_update()
+            )
+        ).all()
+        if any(row.team_id != FILLED_TEAM_ID for row in existing_activities):
+            raise SystemExit("합성 일정 ID 또는 팀이 충돌합니다.")
+
+        for id_, name in products.items():
+            product_insert = insert(Product).values(
+                id=id_,
+                team_id=FILLED_TEAM_ID,
+                name=name,
+                active=True,
+            )
+            upserted_id = (
+                await session.execute(
+                    product_insert.on_conflict_do_update(
+                        index_elements=[Product.id],
+                        set_={"active": product_insert.excluded.active},
+                        where=and_(
+                            Product.team_id == FILLED_TEAM_ID,
+                            Product.name == name,
+                        ),
+                    ).returning(Product.id)
+                )
+            ).scalar_one_or_none()
+            if upserted_id is None:
+                raise SystemExit("합성 상품 ID, 이름 또는 팀이 충돌합니다.")
+
+        for row in activities:
+            activity_insert = insert(Activity).values(**row)
+            update_fields = {
+                key: getattr(activity_insert.excluded, key)
+                for key in row
+                if key not in {"id", "team_id"}
+            }
+            upserted_id = (
+                await session.execute(
+                    activity_insert.on_conflict_do_update(
+                        index_elements=[Activity.id],
+                        set_=update_fields,
+                        where=Activity.team_id == FILLED_TEAM_ID,
+                    ).returning(Activity.id)
+                )
+            ).scalar_one_or_none()
+            if upserted_id is None:
+                raise SystemExit("합성 일정 ID 또는 팀이 충돌합니다.")
+
+    print("개발 DB의 filled 합성 팀에 상품 3개와 일정 12건을 준비했습니다.")
+
+
+if __name__ == "__main__":
+    asyncio.run(seed_demo_activities())

--- a/backend/sql/README.md
+++ b/backend/sql/README.md
@@ -40,6 +40,7 @@
 | 2026-08-17 | 개발 Supabase `public` | `scripts/seed_demo_auth.py` 초기 2계정 | Session Pooler | 성공 |
 | 2026-08-17 | 개발 Supabase `public` | `scripts/seed_demo_auth.py` 2팀·4계정 | Session Pooler | 성공 |
 | 2026-08-17 | 개발 Supabase `public` | `scripts/seed_demo_customers.py` 고객사 6개·담당자 32명 | Session Pooler | 성공 |
+| 2026-08-17 | 개발 Supabase `public` | `scripts/seed_demo_activities.py` 상품 3개·일정 12건 | Session Pooler | 성공 |
 
 ## 개발 로그인 계정
 
@@ -61,4 +62,12 @@ upsert하므로 같은 개발 DB에 다시 실행할 수 있습니다.
 ```bash
 cd backend
 DEBUG=false uv run python -m scripts.seed_demo_customers
+```
+
+일정 seed는 인증과 고객 seed를 차례로 실행한 뒤 적용합니다. 데이터가 있는 팀에만 고정
+합성 상품 3개와 일정 12건을 upsert하고 첫 세팅 팀은 건드리지 않습니다.
+
+```bash
+cd backend
+DEBUG=false uv run python -m scripts.seed_demo_activities
 ```

--- a/backend/tests/test_activities.py
+++ b/backend/tests/test_activities.py
@@ -1,0 +1,501 @@
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from app.api.deps import get_current_member
+from app.core.config import settings
+from app.db.session import get_db
+from app.main import app
+from app.models.crm import Activity, CustomerCompany, CustomerContact
+from app.models.sales import Product
+from app.models.workspace import Member
+from app.schemas.activities import ActivityCreate, ActivityPageParams, ActivityPatch
+
+ORIGIN = settings.cors_origin_list[0]
+NOW = datetime(2026, 8, 17, tzinfo=UTC)
+START = datetime(2026, 8, 17, 1, 0, tzinfo=UTC)
+END = datetime(2026, 8, 17, 2, 0, tzinfo=UTC)
+_MISSING = object()
+
+
+class _Scalars:
+    def __init__(self, values):
+        self.values = values
+
+    def all(self):
+        return self.values
+
+
+class _Result:
+    def __init__(self, *, scalar=_MISSING, rows=None, scalar_values=None):
+        self.scalar = scalar
+        self.rows = [] if rows is None else rows
+        self.scalar_values = [] if scalar_values is None else scalar_values
+
+    def scalar_one(self):
+        assert self.scalar is not _MISSING
+        return self.scalar
+
+    def scalar_one_or_none(self):
+        assert self.scalar is not _MISSING
+        return self.scalar
+
+    def one_or_none(self):
+        assert len(self.rows) <= 1
+        return self.rows[0] if self.rows else None
+
+    def all(self):
+        return self.rows
+
+    def scalars(self):
+        return _Scalars(self.scalar_values)
+
+
+class _Db:
+    def __init__(self, *results: _Result, flush_error: Exception | None = None):
+        self.results = list(results)
+        self.flush_error = flush_error
+        self.statements = []
+        self.added = []
+        self.flush_count = 0
+        self.commit_count = 0
+        self.rollback_count = 0
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        assert self.results
+        return self.results.pop(0)
+
+    def add(self, value):
+        self.added.append(value)
+
+    async def flush(self):
+        self.flush_count += 1
+        if self.flush_error is not None:
+            raise self.flush_error
+        for value in self.added:
+            if isinstance(value, Activity):
+                value.created_at = value.created_at or NOW
+                value.updated_at = value.updated_at or NOW
+
+    async def commit(self):
+        self.commit_count += 1
+
+    async def rollback(self):
+        self.rollback_count += 1
+
+
+@pytest.fixture(autouse=True)
+def reset_dependency_overrides():
+    app.dependency_overrides.clear()
+    yield
+    app.dependency_overrides.clear()
+
+
+def _member(*, role: str = "member", team_id: UUID | None = None) -> Member:
+    return Member(
+        id=uuid4(),
+        team_id=team_id or uuid4(),
+        login_id=f"{uuid4()}@salesluv.demo",
+        password_hash="unused",
+        display_name="합성 영업 담당자",
+        role_code=role,
+        job_title="영업 담당자",
+        active=True,
+    )
+
+
+def _company(team_id: UUID) -> CustomerCompany:
+    return CustomerCompany(
+        id=uuid4(),
+        team_id=team_id,
+        name="합성 고객사",
+        region_code="seoul",
+        created_at=NOW,
+    )
+
+
+def _contact(company_id: UUID, owner_id: UUID) -> CustomerContact:
+    return CustomerContact(
+        id=uuid4(),
+        company_id=company_id,
+        owner_member_id=owner_id,
+        name="합성 고객",
+        department="영업부",
+        job_title="팀장",
+        email=None,
+        phone="02-000-0000",
+        status_code=None,
+        source_code=None,
+        memo=None,
+        registered_at=NOW,
+    )
+
+
+def _product(team_id: UUID) -> Product:
+    return Product(id=uuid4(), team_id=team_id, name="합성 상품", active=True)
+
+
+def _activity(member: Member, *, contact_id: UUID | None = None, product_id: UUID | None = None):
+    return Activity(
+        id=uuid4(),
+        team_id=member.team_id,
+        owner_member_id=member.id,
+        customer_contact_id=contact_id,
+        end_user_contact_id=None,
+        activity_type="meeting",
+        category_code="visit",
+        title="합성 미팅",
+        starts_at=START,
+        ends_at=END,
+        all_day=False,
+        due_at=None,
+        location="회의실",
+        action_tag="meeting",
+        completed_at=None,
+        note="합성 메모",
+        deleted_at=None,
+        created_at=NOW,
+        updated_at=NOW,
+        product_id=product_id,
+        contract_id=None,
+        order_id=None,
+    )
+
+
+def _row(
+    activity: Activity,
+    owner: Member,
+    contact: CustomerContact | None = None,
+    company: CustomerCompany | None = None,
+    product: Product | None = None,
+):
+    return (
+        activity,
+        owner.display_name,
+        contact,
+        None if company is None else company.id,
+        None if company is None else company.name,
+        None if product is None else product.name,
+    )
+
+
+def _client(db: _Db, member: Member) -> TestClient:
+    async def override_db():
+        yield db
+
+    async def override_member():
+        return member
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_member] = override_member
+    return TestClient(app)
+
+
+def test_activity_request_contract_rejects_unsafe_values():
+    payload = ActivityCreate(
+        activity_type="meeting",
+        category_code="education",
+        title="  합성 미팅  ",
+        starts_at="2026-08-17T10:00:00+09:00",
+        ends_at="2026-08-17T11:00:00+09:00",
+        action_tag="demo_completed",
+    )
+
+    assert payload.title == "합성 미팅"
+    assert ActivityPatch(note=None).model_dump(exclude_unset=True) == {"note": None}
+    assert ActivityPageParams(start_date="2026-08-17").end_date is None
+
+    invalid_payloads = (
+        {"owner_member_id": str(uuid4())},
+        {"category_code": "edu"},
+        {"action_tag": "데모 완료"},
+        {"starts_at": "2026-08-17T10:00:00"},
+        {"starts_at": "2026-08-17T01:00:00Z"},
+        {"starts_at": "9999-12-31T15:00:00+00:00"},
+        {"ends_at": "2026-08-17T09:00:00+09:00"},
+    )
+    base = {
+        "activity_type": "meeting",
+        "category_code": "visit",
+        "title": "합성 미팅",
+        "starts_at": "2026-08-17T10:00:00+09:00",
+        "ends_at": "2026-08-17T11:00:00+09:00",
+    }
+    for invalid in invalid_payloads:
+        with pytest.raises(ValidationError):
+            ActivityCreate(**(base | invalid))
+    with pytest.raises(ValidationError):
+        ActivityPatch(title=None)
+    with pytest.raises(ValidationError):
+        ActivityPageParams(start_date="2026-08-18", end_date="2026-08-17")
+    with pytest.raises(ValidationError):
+        ActivityPageParams(start_date="9999-12-31")
+    with pytest.raises(ValidationError):
+        ActivityPageParams(start_date="2026-08-17", skip=9_223_372_036_854_775_808)
+
+
+def test_member_cannot_link_another_owners_customer_contact():
+    member = _member()
+    other_owner = _member(team_id=member.team_id)
+    company = _company(member.team_id)
+    contact = _contact(company.id, other_owner.id)
+    db = _Db(_Result(rows=[]))
+
+    with _client(db, member) as client:
+        response = client.post(
+            "/api/activities",
+            headers={"Origin": ORIGIN},
+            json={
+                "customer_contact_id": str(contact.id),
+                "activity_type": "meeting",
+                "category_code": "visit",
+                "title": "다른 담당자의 고객 일정",
+                "starts_at": "2026-08-17T10:00:00+09:00",
+            },
+        )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "customer_contact_not_found"}
+    assert member.id in db.statements[0].compile().params.values()
+    assert not db.added
+
+
+def test_member_list_is_owner_date_and_soft_delete_scoped():
+    member = _member()
+    company = _company(member.team_id)
+    contact = _contact(company.id, member.id)
+    product = _product(member.team_id)
+    activity = _activity(member, contact_id=contact.id, product_id=product.id)
+    db = _Db(_Result(scalar=1), _Result(rows=[_row(activity, member, contact, company, product)]))
+
+    with _client(db, member) as client:
+        response = client.get(
+            "/api/activities",
+            params={"start_date": "2026-08-17", "limit": 30},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["items"][0]["id"] == str(activity.id)
+    assert response.json()["items"][0]["owner_member_id"] == str(member.id)
+    assert response.json()["items"][0]["starts_at"].endswith("+09:00")
+    assert response.json()["items"][0]["customer_company_name"] == company.name
+    assert response.json()["items"][0]["product_name"] == product.name
+    for statement in db.statements:
+        sql = str(statement)
+        assert "activity.deleted_at IS NULL" in sql
+        assert member.id in statement.compile().params.values()
+        assert member.team_id in statement.compile().params.values()
+
+    denied_db = _Db()
+    with _client(denied_db, member) as client:
+        denied = client.get(
+            "/api/activities",
+            params=[("start_date", "2026-08-17"), ("owner_member_id", str(member.id))],
+        )
+        unknown = client.get("/api/activities?start_date=2026-08-17&unknown=true")
+    assert denied.status_code == 403
+    assert denied.json() == {"detail": "scope_not_allowed"}
+    assert unknown.status_code == 422
+    assert not denied_db.statements
+
+
+def test_manager_owner_filter_is_limited_to_active_same_team_members():
+    manager = _member(role="manager")
+    owner = _member(team_id=manager.team_id)
+    activity = _activity(owner)
+    db = _Db(
+        _Result(scalar_values=[owner.id]),
+        _Result(scalar=1),
+        _Result(rows=[_row(activity, owner)]),
+    )
+
+    with _client(db, manager) as client:
+        response = client.get(
+            "/api/activities",
+            params=[
+                ("start_date", "2026-08-17"),
+                ("owner_member_id", str(owner.id)),
+            ],
+        )
+
+    assert response.status_code == 200
+    assert response.json()["items"][0]["owner_member_id"] == str(owner.id)
+    parameter_values = db.statements[1].compile().params.values()
+    assert any(
+        owner.id in value for value in parameter_values if isinstance(value, (list, tuple, set))
+    )
+    assert manager.id not in db.statements[1].compile().params.values()
+
+    invalid_db = _Db(_Result(scalar_values=[]))
+    with _client(invalid_db, manager) as client:
+        invalid = client.get(
+            "/api/activities",
+            params=[
+                ("start_date", "2026-08-17"),
+                ("owner_member_id", str(uuid4())),
+            ],
+        )
+    assert invalid.status_code == 403
+    assert invalid.json() == {"detail": "scope_not_allowed"}
+    assert len(invalid_db.statements) == 1
+
+
+def test_create_uses_authenticated_owner_and_same_team_references():
+    member = _member()
+    company = _company(member.team_id)
+    contact = _contact(company.id, member.id)
+    product = _product(member.team_id)
+    db = _Db(
+        _Result(rows=[(contact, company.id, company.name)]),
+        _Result(scalar=product),
+    )
+
+    with _client(db, member) as client:
+        response = client.post(
+            "/api/activities",
+            headers={"Origin": ORIGIN},
+            json={
+                "customer_contact_id": str(contact.id),
+                "product_id": str(product.id),
+                "activity_type": "meeting",
+                "category_code": "demo",
+                "title": "  합성 데모  ",
+                "starts_at": "2026-08-17T10:00:00+09:00",
+                "ends_at": "2026-08-17T11:00:00+09:00",
+                "action_tag": "demo_in_progress",
+            },
+        )
+
+    assert response.status_code == 201
+    assert response.json()["owner_member_id"] == str(member.id)
+    assert response.json()["owner_display_name"] == member.display_name
+    assert response.json()["customer_contact_name"] == contact.name
+    assert response.json()["product_name"] == product.name
+    assert response.headers["location"] == f"/api/activities/{response.json()['id']}"
+    activity = db.added[0]
+    assert activity.team_id == member.team_id
+    assert activity.owner_member_id == member.id
+    assert activity.title == "합성 데모"
+    assert db.flush_count == db.commit_count == 1
+    assert db.rollback_count == 0
+    assert member.team_id in db.statements[0].compile().params.values()
+    assert member.team_id in db.statements[1].compile().params.values()
+
+    hidden_db = _Db(_Result(rows=[]))
+    with _client(hidden_db, member) as client:
+        hidden = client.post(
+            "/api/activities",
+            headers={"Origin": ORIGIN},
+            json={
+                "customer_contact_id": str(uuid4()),
+                "activity_type": "meeting",
+                "category_code": "visit",
+                "title": "타팀 고객 일정",
+                "starts_at": "2026-08-17T10:00:00+09:00",
+            },
+        )
+    assert hidden.status_code == 404
+    assert hidden.json() == {"detail": "customer_contact_not_found"}
+    assert hidden_db.rollback_count == 1
+    assert not hidden_db.added
+
+
+def test_detail_and_patch_share_scope_and_patch_revalidates_range():
+    member = _member()
+    activity = _activity(member)
+    company = _company(member.team_id)
+    contact = _contact(company.id, member.id)
+    detail_db = _Db(_Result(rows=[_row(activity, member)]))
+    with _client(detail_db, member) as client:
+        detail = client.get(f"/api/activities/{activity.id}")
+    assert detail.status_code == 200
+
+    patch_db = _Db(
+        _Result(scalar=activity),
+        _Result(rows=[(contact, company.id, company.name)]),
+        _Result(rows=[_row(activity, member, contact, company)]),
+    )
+    with _client(patch_db, member) as client:
+        updated = client.patch(
+            f"/api/activities/{activity.id}",
+            headers={"Origin": ORIGIN},
+            json={
+                "customer_contact_id": str(contact.id),
+                "starts_at": "2026-08-17T12:00:00+09:00",
+                "ends_at": None,
+                "note": None,
+            },
+        )
+    assert updated.status_code == 200
+    assert updated.json()["customer_contact_id"] == str(contact.id)
+    assert updated.json()["ends_at"] is None
+    assert updated.json()["note"] is None
+    assert activity.updated_at > NOW
+    assert "FOR UPDATE" in str(patch_db.statements[0])
+    assert patch_db.flush_count == patch_db.commit_count == 1
+
+    invalid_activity = _activity(member)
+    invalid_db = _Db(_Result(scalar=invalid_activity))
+    with _client(invalid_db, member) as client:
+        invalid = client.patch(
+            f"/api/activities/{invalid_activity.id}",
+            headers={"Origin": ORIGIN},
+            json={"starts_at": "2026-08-17T12:00:00+09:00"},
+        )
+    assert invalid.status_code == 422
+    assert invalid.json() == {"detail": "invalid_activity_range"}
+    assert invalid_db.flush_count == invalid_db.commit_count == 0
+    assert invalid_db.rollback_count == 1
+
+
+def test_cross_team_activity_is_hidden_and_delete_is_soft():
+    member = _member()
+    hidden_db = _Db(_Result(rows=[]), _Result(scalar=None))
+    activity_id = uuid4()
+    with _client(hidden_db, member) as client:
+        hidden_detail = client.get(f"/api/activities/{activity_id}")
+        hidden_delete = client.delete(
+            f"/api/activities/{activity_id}",
+            headers={"Origin": ORIGIN},
+        )
+    assert hidden_detail.status_code == hidden_delete.status_code == 404
+    assert hidden_detail.json() == hidden_delete.json() == {"detail": "activity_not_found"}
+    assert hidden_db.rollback_count == 1
+
+    activity = _activity(member)
+    delete_db = _Db(_Result(scalar=activity))
+    with _client(delete_db, member) as client:
+        deleted = client.delete(
+            f"/api/activities/{activity.id}",
+            headers={"Origin": ORIGIN},
+        )
+    assert deleted.status_code == 204
+    assert deleted.content == b""
+    assert activity.deleted_at is not None
+    assert activity.updated_at == activity.deleted_at
+    assert delete_db.flush_count == delete_db.commit_count == 1
+    assert "FOR UPDATE" in str(delete_db.statements[0])
+
+
+def test_write_failure_rolls_back_transaction():
+    member = _member()
+    db = _Db(flush_error=RuntimeError("synthetic failure"))
+
+    with _client(db, member) as client, pytest.raises(RuntimeError, match="synthetic failure"):
+        client.post(
+            "/api/activities",
+            headers={"Origin": ORIGIN},
+            json={
+                "activity_type": "task",
+                "category_code": "internal",
+                "title": "합성 업무",
+                "starts_at": "2026-08-17T10:00:00+09:00",
+            },
+        )
+
+    assert db.commit_count == 0
+    assert db.rollback_count == 1

--- a/backend/tests/test_seed_demo_activities.py
+++ b/backend/tests/test_seed_demo_activities.py
@@ -1,0 +1,111 @@
+from collections import Counter
+from datetime import timedelta
+from uuid import uuid5
+
+from scripts.seed_demo_activities import (
+    ACTION_TAG_CODES,
+    ACTIVITY_SEEDS,
+    CATEGORY_CODES,
+    PRODUCT_NAMES,
+    REFERENCE_DATE,
+    SEOUL,
+    activity_id,
+    activity_row,
+    product_id,
+)
+from scripts.seed_demo_auth import EMPTY_TEAM_ID, FILLED_TEAM_ID
+
+
+def test_demo_activity_seed_shape_is_fixed_and_synthetic():
+    rows = {seed.mock_id: activity_row(seed) for seed in ACTIVITY_SEEDS}
+
+    assert REFERENCE_DATE.isoformat() == "2026-08-17"
+    assert SEOUL.key == "Asia/Seoul"
+    assert len(rows) == len(ACTIVITY_SEEDS) == 12
+    assert set(rows) == {f"a{number}" for number in range(1, 13)}
+    assert len({row["id"] for row in rows.values()}) == 12
+    assert all(row["team_id"] == FILLED_TEAM_ID != EMPTY_TEAM_ID for row in rows.values())
+    assert all(
+        row["id"] == activity_id(mock_id) == uuid5(FILLED_TEAM_ID, f"activity:{mock_id}")
+        for mock_id, row in rows.items()
+    )
+
+    assert set(CATEGORY_CODES.values()) == {
+        "visit",
+        "demo",
+        "education",
+        "call",
+        "delivery",
+        "conference",
+        "internal",
+    }
+    assert set(ACTION_TAG_CODES.values()) == {
+        "first_call",
+        "meeting",
+        "demo_requested",
+        "demo_in_progress",
+        "demo_completed",
+        "quote_completed",
+        "contract_completed",
+        "product_training",
+        "delivery_completed",
+        "internal_meeting",
+        "weekly_review",
+        "monthly_review",
+        "quarterly_review",
+        "conference",
+        "ojt",
+    }
+    assert len(ACTION_TAG_CODES) == len(set(ACTION_TAG_CODES.values())) == 15
+    assert all(
+        code.isascii() and code.replace("_", "").islower() for code in ACTION_TAG_CODES.values()
+    )
+    assert Counter(row["activity_type"] for row in rows.values()) == {
+        "meeting": 10,
+        "task": 2,
+    }
+    assert Counter(seed.owner_name for seed in ACTIVITY_SEEDS) == {
+        "김지훈": 7,
+        "이수민": 2,
+        "박도윤": 2,
+        "김서현": 1,
+    }
+
+    assert {mock_id for mock_id, row in rows.items() if row["customer_contact_id"] is None} == {
+        "a4",
+        "a5",
+        "a9",
+        "a12",
+    }
+    assert sum(row["customer_contact_id"] is not None for row in rows.values()) == 8
+    assert Counter(seed.product_name for seed in ACTIVITY_SEEDS) == {
+        "CardioView X7": 4,
+        "OrthoScan Mini": 4,
+        "SonoFlex Pro": 2,
+        None: 2,
+    }
+    assert set(PRODUCT_NAMES) == {"CardioView X7", "OrthoScan Mini", "SonoFlex Pro"}
+    assert len({product_id(name) for name in PRODUCT_NAMES}) == 3
+    assert all(
+        product_id(name) == uuid5(FILLED_TEAM_ID, f"product:{name}") for name in PRODUCT_NAMES
+    )
+
+    assert {mock_id for mock_id, row in rows.items() if row["completed_at"] is not None} == {
+        "a1",
+        "a5",
+        "a6",
+        "a10",
+    }
+    assert {mock_id for mock_id, row in rows.items() if row["all_day"]} == {"a5"}
+    assert rows["a5"]["ends_at"] is None
+    assert rows["a12"]["action_tag"] is None
+
+    for seed in ACTIVITY_SEEDS:
+        row = rows[seed.mock_id]
+        assert row["starts_at"].date() == REFERENCE_DATE + timedelta(days=seed.day_offset)
+        assert row["starts_at"].timetz().replace(tzinfo=None) == seed.start_time
+        assert row["starts_at"].tzinfo == SEOUL
+        if seed.duration_minutes is None:
+            assert row["ends_at"] is None
+        else:
+            assert row["ends_at"] - row["starts_at"] == timedelta(minutes=seed.duration_minutes)

--- a/frontend/src/components/layout/Topbar/Topbar.tsx
+++ b/frontend/src/components/layout/Topbar/Topbar.tsx
@@ -50,8 +50,8 @@ export default function Topbar() {
 
       <div className={styles.spacer} />
 
-      {/* 고객 API는 이번 슬라이스에서 담당자 범위를 받지 않으므로 고객 화면에만 숨깁니다. */}
-      {isManager && pathname !== ROUTES.CUSTOMERS && (
+      {/* 실제 팀원 UUID 목록이 붙기 전까지 DB 화면에는 목업 담당자 필터를 노출하지 않습니다. */}
+      {isManager && pathname !== ROUTES.CUSTOMERS && pathname !== ROUTES.CALENDAR && (
         <div className={styles.scope}>
           <ScopeSwitcher />
         </div>

--- a/frontend/src/pages/Calendar/Calendar.tsx
+++ b/frontend/src/pages/Calendar/Calendar.tsx
@@ -7,11 +7,11 @@ import {
   type PointerEvent as ReactPointerEvent,
 } from 'react'
 
-import { agendaById } from '@/shared/agenda'
+import Button from '@/components/Button'
+import { readProfileId } from '@/mocks'
 import { aiSuggestions } from '@/shared/suggestions'
 import type { AiSuggestion, CalendarEvent } from '@/types'
 import usePointerDrag from '@/hooks/usePointerDrag'
-import RecordDrawer from '@/pages/Dashboard/components/RecordDrawer'
 import { parseISO, startOfMonth, TODAY, TODAY_ISO } from '@/utils/date'
 
 import EventModal from './components/EventModal'
@@ -22,27 +22,63 @@ import useCalendarEvents, { DEFAULTS } from './useCalendarEvents'
 
 import styles from './Calendar.module.scss'
 
-export default function Calendar() {
-  const { eventsByDate, addEvent, updateEvent, moveEvent, removeEvent } = useCalendarEvents()
+const acceptedStorageKey = () => `salesluv.calendar.accepted:${readProfileId() ?? 'default'}`
 
+function readAccepted(): ReadonlySet<string> {
+  try {
+    const value: unknown = JSON.parse(sessionStorage.getItem(acceptedStorageKey()) ?? '[]')
+    return new Set(
+      Array.isArray(value) ? value.filter((id): id is string => typeof id === 'string') : [],
+    )
+  } catch {
+    return new Set()
+  }
+}
+
+export default function Calendar() {
   const [cursor, setCursor] = useState(() => startOfMonth(TODAY))
+  const {
+    events,
+    eventsByDate,
+    loading,
+    error,
+    reload,
+    addEvent,
+    updateEvent,
+    moveEvent,
+    removeEvent,
+  } = useCalendarEvents(cursor)
   const [selectedISO, setSelectedISO] = useState(TODAY_ISO)
   const [previewId, setPreviewId] = useState<string | null>(null)
   const [dismissed, setDismissed] = useState<ReadonlySet<string>>(new Set())
-  /**
-   * 이미 달력에 넣은 추천. 목록에서 사라지는 것은 닫은 것과 같지만, 다시 받을 때
-   * 되살아나면 안 됩니다. 같은 일정을 두 번 넣게 됩니다.
-   */
-  const [accepted, setAccepted] = useState<ReadonlySet<string>>(new Set())
+  const [accepted, setAccepted] = useState<ReadonlySet<string>>(readAccepted)
   const [refreshing, setRefreshing] = useState(false)
-  /** 상세를 보고 있는 일정. 칩을 누르면 고치기 전에 먼저 이것부터 폅니다. */
-  const [viewingId, setViewingId] = useState<string | null>(null)
   const [editing, setEditing] = useState<CalendarEvent | null>(null)
   /** 새 일정을 만드는 날짜. 등록 모달을 그 날짜로 엽니다. */
   const [creating, setCreating] = useState<string | null>(null)
   const [justAddedId, setJustAddedId] = useState<string | null>(null)
+  const accepting = useRef(new Set<string>())
 
-  const suggestions = useMemo(() => aiSuggestions.filter((s) => !dismissed.has(s.id)), [dismissed])
+  const suggestions = useMemo(() => {
+    if (loading || error) return []
+    // ponytail: activity에 추천 원본 ID가 없어 고정 추천 6개의 고유 제목으로 중복만 막습니다.
+    // 추천이 동적으로 늘면 activity에 source_id를 추가해야 합니다.
+    const existingTitles = new Set(events.map((event) => event.title))
+    return aiSuggestions.filter(
+      (suggestion) =>
+        !accepted.has(suggestion.id) &&
+        !dismissed.has(suggestion.id) &&
+        !existingTitles.has(suggestion.title),
+    )
+  }, [accepted, dismissed, error, events, loading])
+
+  useEffect(() => {
+    try {
+      sessionStorage.setItem(acceptedStorageKey(), JSON.stringify([...accepted]))
+    } catch {
+      // 현재 화면에서는 accepted 상태와 DB 제목 대조가 중복을 막습니다.
+    }
+  }, [accepted])
 
   const dismiss = useCallback((id: string) => {
     setDismissed((prev) => new Set(prev).add(id))
@@ -51,28 +87,36 @@ export default function Calendar() {
 
   /** dateISO 를 주면 추천일 대신 그 날짜로 넣습니다. 끌어다 놓은 경우입니다. */
   const accept = useCallback(
-    (s: AiSuggestion, dateISO?: string) => {
+    async (s: AiSuggestion, dateISO?: string) => {
+      if (loading || error || accepting.current.has(s.id)) return
+      accepting.current.add(s.id)
       const date = dateISO ?? s.date
-      const added = addEvent({
-        date,
-        time: s.time,
-        dur: s.dur,
-        kind: s.kind,
-        title: s.title,
-        hospital: s.hospital,
-        dept: s.dept,
-        contact: s.contact,
-        place: s.place,
-        brief: s.reason,
-      })
-      // 넣은 자리가 화면 밖이면 확인할 수 없으니 그 달로 옮기고 그 날을 고릅니다.
-      setCursor(startOfMonth(parseISO(date)))
-      setSelectedISO(date)
-      setJustAddedId(added.id)
-      setAccepted((prev) => new Set(prev).add(s.id))
-      dismiss(s.id)
+      try {
+        const added = await addEvent({
+          date,
+          time: s.time,
+          dur: s.dur,
+          kind: s.kind,
+          title: s.title,
+          hospital: s.hospital,
+          dept: s.dept,
+          contact: s.contact,
+          place: s.place,
+          brief: s.reason,
+        })
+        // 넣은 자리가 화면 밖이면 확인할 수 없으니 그 달로 옮기고 그 날을 고릅니다.
+        setCursor(startOfMonth(parseISO(date)))
+        setSelectedISO(date)
+        setJustAddedId(added.id)
+        setAccepted((prev) => new Set(prev).add(s.id))
+        dismiss(s.id)
+      } catch {
+        return
+      } finally {
+        accepting.current.delete(s.id)
+      }
     },
-    [addEvent, dismiss],
+    [addEvent, dismiss, error, loading],
   )
 
   // 목업이라 부를 서버가 없습니다. 닫아 둔 추천을 되살리는 것이 다시 받아 온
@@ -84,25 +128,36 @@ export default function Calendar() {
     setRefreshing(true)
     setPreviewId(null)
     refreshTimer.current = setTimeout(() => {
-      // 이미 넣은 것만 빼고 처음 상태로 돌립니다.
       setDismissed(new Set(accepted))
       setRefreshing(false)
     }, 600)
   }, [accepted])
 
+  const move = useCallback(
+    async (id: string, dateISO: string) => {
+      try {
+        const moved = await moveEvent(id, dateISO)
+        if (!moved) return
+        setSelectedISO(dateISO)
+        setJustAddedId(moved.id)
+      } catch {
+        return
+      }
+    },
+    [moveEvent],
+  )
+
   /** 끌던 것을 이 날짜에 놓습니다. */
   const drop = useCallback(
     (dragged: Dragging, dateISO: string) => {
       if (dragged.kind === 'event') {
-        moveEvent(dragged.id, dateISO)
-        setSelectedISO(dateISO)
-        setJustAddedId(dragged.id)
+        void move(dragged.id, dateISO)
         return
       }
       const s = suggestions.find((item) => item.id === dragged.id)
-      if (s) accept(s, dateISO)
+      if (s) void accept(s, dateISO)
     },
-    [suggestions, moveEvent, accept],
+    [suggestions, move, accept],
   )
 
   // 놓인 자리의 표식은 날짜 칸의 ISO 문자열입니다. 이 화면의 어휘로 이름만 바꿔 받습니다.
@@ -135,28 +190,25 @@ export default function Calendar() {
   }, [suggestions, previewId, dragging, dropISO])
 
   const create = useCallback(
-    (event: CalendarEvent) => {
-      // 빈 id 는 addEvent 가 새로 매깁니다.
-      setJustAddedId(addEvent(event).id)
+    async (event: CalendarEvent) => {
+      const added = await addEvent(event)
+      setJustAddedId(added.id)
       setCreating(null)
     },
     [addEvent],
   )
 
-  // 목록이 바뀌면 이 컴포넌트가 다시 그려지므로 여기서 매번 집어 옵니다.
-  const viewed = viewingId ? agendaById(viewingId) : undefined
-
   const save = useCallback(
-    (event: CalendarEvent) => {
-      updateEvent(event)
+    async (event: CalendarEvent) => {
+      await updateEvent(event)
       setEditing(null)
     },
     [updateEvent],
   )
 
   const remove = useCallback(
-    (id: string) => {
-      removeEvent(id)
+    async (id: string) => {
+      await removeEvent(id)
       setEditing(null)
     },
     [removeEvent],
@@ -166,6 +218,16 @@ export default function Calendar() {
     <section>
       {/* Topbar breadcrumb 이 이미 화면 이름을 말하므로 제목은 읽어 주기만 합니다. */}
       <h1 className="sr-only">캘린더</h1>
+
+      {error && (
+        <div role="alert">
+          <span>{error}</span>{' '}
+          <Button variant="outline" size="sm" onClick={reload}>
+            다시 시도
+          </Button>
+        </div>
+      )}
+      {loading && <p role="status">일정을 불러오는 중입니다.</p>}
 
       <div className={styles.layout}>
         <MonthGrid
@@ -178,7 +240,7 @@ export default function Calendar() {
           dropISO={dropISO}
           onCursorChange={setCursor}
           onSelect={setSelectedISO}
-          onOpenEvent={(event) => setViewingId(event.id)}
+          onOpenEvent={setEditing}
           onCreate={setCreating}
           onGrabEvent={grabEvent}
         />
@@ -192,7 +254,7 @@ export default function Calendar() {
             onDismiss={dismiss}
             onGrab={grabSuggestion}
             onRefresh={refresh}
-            refreshing={refreshing}
+            refreshing={refreshing || loading}
           />
         </div>
       </div>
@@ -202,22 +264,6 @@ export default function Calendar() {
         <div className={styles.dragChip} style={{ left: point.x, top: point.y }} aria-hidden="true">
           {dragging.label}
         </div>
-      )}
-
-      {viewed && (
-        <RecordDrawer
-          item={viewed}
-          done={viewed.done}
-          onClose={() => setViewingId(null)}
-          onEdit={(item) => {
-            setViewingId(null)
-            setEditing(item)
-          }}
-          onDelete={(id) => {
-            setViewingId(null)
-            removeEvent(id)
-          }}
-        />
       )}
 
       {creating && (

--- a/frontend/src/pages/Calendar/components/EventModal/EventModal.tsx
+++ b/frontend/src/pages/Calendar/components/EventModal/EventModal.tsx
@@ -1,14 +1,22 @@
-import { useRef, useState, type KeyboardEvent, type ReactNode } from 'react'
+import {
+  useDeferredValue,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from 'react'
 import { createPortal } from 'react-dom'
 import DatePicker, { registerLocale } from 'react-datepicker'
 import { ko } from 'date-fns/locale'
 
+import { client } from '@/api/client'
 import Button from '@/components/Button'
 import { ChevronDownIcon, SearchIcon, TrashIcon } from '@/components/icons'
 import Modal from '@/components/Modal'
 import { EXTERNAL_STATUSES, INTERNAL_STATUSES } from '@/shared/agenda'
-import { customers } from '@/shared/customers'
-import type { CalendarEvent, Customer, ScheduleStatus } from '@/types'
+import type { CalendarEvent, CustomerContactResponse, PageResponse, ScheduleStatus } from '@/types'
 import { iso, parseISO } from '@/utils/date'
 
 import 'react-datepicker/dist/react-datepicker.css'
@@ -22,8 +30,8 @@ interface Props {
   /** 새로 만드는 중이면 지울 것이 아직 없어 삭제를 감춥니다. */
   mode?: 'edit' | 'create'
   onClose: () => void
-  onSave: (event: CalendarEvent) => void
-  onDelete?: (id: string) => void
+  onSave: (event: CalendarEvent) => void | Promise<void>
+  onDelete?: (id: string) => void | Promise<void>
 }
 
 /**
@@ -40,6 +48,24 @@ type EventType = '미팅' | '업무'
  * (태그 색은 저장된 값을 보고 statusScope 가 알아서 가릅니다.)
  */
 const STATUSES: readonly ScheduleStatus[] = [...EXTERNAL_STATUSES, ...INTERNAL_STATUSES]
+
+interface CustomerOption {
+  id: string
+  name: string
+  org: string
+  dept: string
+  title: string
+}
+
+function toCustomerOption(contact: CustomerContactResponse): CustomerOption {
+  return {
+    id: contact.id,
+    name: contact.name,
+    org: contact.company_name,
+    dept: contact.department ?? '',
+    title: contact.job_title ?? '',
+  }
+}
 
 // 폼은 시작·끝 두 시점으로 다루고, 저장은 '40분' 같은 소요 문구로 합니다.
 // 목록·드로어가 그 문구를 그대로 읽으므로 두 표현을 여기서 오갑니다.
@@ -76,9 +102,17 @@ export default function EventModal({ draft, mode = 'edit', onClose, onSave, onDe
   const [end, setEnd] = useState(
     () => new Date(at(draft.date, draft.time).getTime() + parseDur(draft.dur) * MINUTE),
   )
-  const [type, setType] = useState<EventType>(draft.kind === 'internal' ? '업무' : '미팅')
+  const [hasEnd, setHasEnd] = useState(draft.endsAt !== null)
+  const [type, setType] = useState<EventType>(
+    (draft.activityType ?? (draft.kind === 'internal' ? 'task' : 'meeting')) === 'task'
+      ? '업무'
+      : '미팅',
+  )
   const [error, setError] = useState('')
+  const [customerError, setCustomerError] = useState('')
   const [rangeError, setRangeError] = useState('')
+  const [requestError, setRequestError] = useState('')
+  const [pending, setPending] = useState(false)
 
   const set = <K extends keyof CalendarEvent>(key: K, value: CalendarEvent[K]) =>
     setForm((prev) => ({ ...prev, [key]: value }))
@@ -96,57 +130,94 @@ export default function EventModal({ draft, mode = 'edit', onClose, onSave, onDe
   // 화면에는 사라졌는데 값은 살아 있는 상태가 생겨 여기서 함께 정리합니다.
   const changeType = (next: EventType) => {
     setType(next)
+    setCustomerError('')
     if (next === '업무') {
       setForm((prev) => ({
         ...prev,
+        activityType: 'task',
         kind: 'internal',
         stage: undefined,
         hospital: '',
         dept: '',
         contact: '',
+        customerContactId: null,
+        customerContactName: '',
+        productId: null,
+        product: '',
       }))
     } else {
-      setForm((prev) => ({ ...prev, kind: 'visit' }))
+      setForm((prev) => ({ ...prev, activityType: 'meeting', kind: 'visit' }))
     }
   }
 
   // 고객을 고르면 회사·부서가 따라옵니다. 직접 입력하지 않는 값들입니다.
-  const pickCustomer = (name: string, found?: Customer) => {
-    const match = found ?? customers.find((c) => c.name === name)
+  const pickCustomer = (name: string, found?: CustomerOption) => {
+    setCustomerError('')
     setForm((prev) => ({
       ...prev,
-      contact: name,
-      hospital: match?.org ?? '',
-      dept: match?.dept ?? '',
+      contact: found ? [found.name, found.title].filter(Boolean).join(' ') : name,
+      hospital: found?.org ?? '',
+      dept: found?.dept ?? '',
+      customerContactId: found?.id ?? null,
+      customerContactName: name,
     }))
   }
 
-  const submit = () => {
+  const submit = async () => {
     if (form.title.trim() === '') {
       setError('제목을 입력하세요.')
       return
     }
 
+    if (type === '미팅' && form.customerContactName?.trim() && !form.customerContactId) {
+      setCustomerError('검색 결과에서 고객을 선택하세요.')
+      return
+    }
+
     // 소요는 시작과 끝의 차이입니다. 목록·드로어는 이 문구만 읽습니다.
     const minutes = Math.round((end.getTime() - start.getTime()) / MINUTE)
-    if (minutes <= 0) {
+    if (hasEnd && minutes <= 0) {
       setRangeError('종료가 시작보다 빠릅니다.')
       return
     }
 
-    onSave({
-      ...form,
-      title: form.title.trim(),
-      date: iso(start),
-      time: hhmm(start),
-      dur: durLabel(minutes),
-    })
+    setPending(true)
+    setRequestError('')
+    try {
+      await onSave({
+        ...form,
+        title: form.title.trim(),
+        date: iso(start),
+        time: hhmm(start),
+        dur: form.allDay ? '종일' : hasEnd ? durLabel(minutes) : '',
+        allDay: form.allDay ?? false,
+      })
+    } catch {
+      setRequestError(
+        mode === 'create' ? '일정을 등록하지 못했습니다.' : '일정을 수정하지 못했습니다.',
+      )
+    } finally {
+      setPending(false)
+    }
+  }
+
+  const remove = async () => {
+    if (!onDelete) return
+    setPending(true)
+    setRequestError('')
+    try {
+      await onDelete(form.id)
+    } catch {
+      setRequestError('일정을 삭제하지 못했습니다.')
+    } finally {
+      setPending(false)
+    }
   }
 
   return (
     <Modal
       title={mode === 'create' ? '일정 등록' : '일정 수정'}
-      onClose={onClose}
+      onClose={() => !pending && onClose()}
       onSubmit={submit}
       footer={
         <>
@@ -155,16 +226,19 @@ export default function EventModal({ draft, mode = 'edit', onClose, onSave, onDe
               type="button"
               variant="ghost"
               className={styles.delete}
-              onClick={() => onDelete(form.id)}
+              disabled={pending}
+              onClick={() => void remove()}
             >
               <TrashIcon width={15} height={15} />
               삭제
             </Button>
           )}
-          <Button type="button" variant="outline" onClick={onClose}>
+          <Button type="button" variant="outline" disabled={pending} onClick={onClose}>
             취소
           </Button>
-          <Button type="submit">저장</Button>
+          <Button type="submit" disabled={pending}>
+            {pending ? '저장 중…' : '저장'}
+          </Button>
         </>
       }
     >
@@ -202,7 +276,16 @@ export default function EventModal({ draft, mode = 'edit', onClose, onSave, onDe
           </span>
           <div className={styles.range}>
             <Picker selected={start} onChange={moveStart} label="시작" />
-            <Picker selected={end} onChange={(d) => d && setEnd(d)} label="종료" minDate={start} />
+            <Picker
+              selected={end}
+              onChange={(date) => {
+                if (!date) return
+                setEnd(date)
+                setHasEnd(true)
+              }}
+              label="종료"
+              minDate={start}
+            />
           </div>
           {rangeError && <span className={styles.error}>{rangeError}</span>}
         </div>
@@ -237,8 +320,10 @@ export default function EventModal({ draft, mode = 'edit', onClose, onSave, onDe
           <div className={`${styles.field} ${styles.isWide}`}>
             <span className={styles.label}>고객</span>
             <CustomerPicker
-              value={form.contact ?? ''}
+              value={form.customerContactName ?? form.contact ?? ''}
+              selectedId={form.customerContactId ?? null}
               tag={form.hospital ? `${form.hospital}${form.dept ? ` · ${form.dept}` : ''}` : ''}
+              error={customerError}
               onChange={pickCustomer}
             />
           </div>
@@ -252,6 +337,12 @@ export default function EventModal({ draft, mode = 'edit', onClose, onSave, onDe
             onChange={(e) => set('brief', e.target.value)}
           />
         </Field>
+
+        {requestError && (
+          <p className={`${styles.error} ${styles.isWide}`} role="alert">
+            {requestError}
+          </p>
+        )}
       </div>
     </Modal>
   )
@@ -306,25 +397,54 @@ const MAX_MATCHES = 8
 
 function CustomerPicker({
   value,
+  selectedId,
   tag,
+  error,
   onChange,
 }: {
   value: string
+  selectedId: string | null
   tag: string
-  onChange: (name: string, found?: Customer) => void
+  error: string
+  onChange: (name: string, found?: CustomerOption) => void
 }) {
   const [open, setOpen] = useState(false)
   const [active, setActive] = useState(0)
+  const [matches, setMatches] = useState<CustomerOption[]>([])
   const boxRef = useRef<HTMLDivElement>(null)
+  const listboxId = `customers-${useId().replaceAll(':', '')}`
+  const errorId = `${listboxId}-error`
 
-  // 빈 칸이면 이름 순 앞부분을 그대로 보여 줍니다. 무엇을 칠 수 있는지
-  // 한 번 훑고 고르는 쪽이 빈 목록을 마주하는 것보다 빠릅니다.
   const query = value.trim()
-  const matches = customers
-    .filter((c) => query === '' || c.name.includes(query) || c.org.includes(query))
-    .slice(0, MAX_MATCHES)
+  const deferredQuery = useDeferredValue(query)
 
-  const choose = (c: Customer) => {
+  useEffect(() => {
+    if (!open) return
+    const controller = new AbortController()
+
+    void client
+      .get<PageResponse<CustomerContactResponse>>('/customer-contacts', {
+        params: {
+          q: deferredQuery === '' ? undefined : deferredQuery.slice(0, 100),
+          skip: 0,
+          limit: MAX_MATCHES,
+        },
+        signal: controller.signal,
+      })
+      .then(({ data }) => {
+        if (!controller.signal.aborted) {
+          setActive(0)
+          setMatches(data.items.map(toCustomerOption))
+        }
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) setMatches([])
+      })
+
+    return () => controller.abort()
+  }, [deferredQuery, open])
+
+  const choose = (c: CustomerOption) => {
     onChange(c.name, c)
     setOpen(false)
   }
@@ -359,6 +479,7 @@ function CustomerPicker({
         setOpen(true)
         return
       }
+      if (matches.length === 0) return
       const delta = e.key === 'ArrowDown' ? 1 : -1
       setActive((prev) => (prev + delta + matches.length) % matches.length)
       return
@@ -387,6 +508,12 @@ function CustomerPicker({
           role="combobox"
           aria-expanded={open}
           aria-autocomplete="list"
+          aria-controls={open && matches.length > 0 ? listboxId : undefined}
+          aria-activedescendant={
+            open && matches[active] ? `${listboxId}-${matches[active].id}` : undefined
+          }
+          aria-invalid={error ? true : undefined}
+          aria-describedby={error ? errorId : undefined}
           autoComplete="off"
           onChange={(e) => {
             onChange(e.target.value)
@@ -407,16 +534,29 @@ function CustomerPicker({
         </button>
       </div>
 
+      {error && (
+        <span id={errorId} className={styles.error} role="alert">
+          {error}
+        </span>
+      )}
+
       {open &&
         matches.length > 0 &&
         createPortal(
-          <div className={styles.menu} style={menuStyle} role="listbox" aria-label="고객">
+          <div
+            id={listboxId}
+            className={styles.menu}
+            style={menuStyle}
+            role="listbox"
+            aria-label="고객"
+          >
             {matches.map((c, i) => (
               <button
                 key={c.id}
+                id={`${listboxId}-${c.id}`}
                 type="button"
                 role="option"
-                aria-selected={c.name === value}
+                aria-selected={c.id === selectedId}
                 className={`${styles.option} ${i === active ? styles.isActive : ''}`}
                 onPointerMove={() => setActive(i)}
                 // 목록은 입력칸 밖(body)에 있어, 누르는 순간 포커스가 빠지면

--- a/frontend/src/pages/Calendar/useCalendarEvents.ts
+++ b/frontend/src/pages/Calendar/useCalendarEvents.ts
@@ -1,30 +1,186 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { isAxiosError } from 'axios'
 
-import {
-  addAgenda,
-  agendaByDate,
-  agendaById,
-  removeAgenda,
-  updateAgenda,
-  useAgenda,
-} from '@/shared/agenda'
-import type { AgendaItem, CalendarEvent } from '@/types'
+import { client } from '@/api/client'
 import { useCurrentUser } from '@/auth/sessionContext'
-
-// 일정 목록 자체는 shared/agenda.ts 한 곳에 있습니다. 대시보드와 캘린더가 같은
-// 목록을 보게 하려고 여기서는 그 스토어를 캘린더의 어휘로 감싸기만 합니다.
-// 백엔드가 붙는 지점도 그쪽 mutator 셋입니다.
+import { addAgenda, agendaById, removeAgenda, updateAgenda } from '@/shared/agenda'
+import type {
+  ActivityActionTagCode,
+  ActivityCategoryCode,
+  ActivityCreateRequest,
+  ActivityPatchRequest,
+  ActivityRead,
+  AgendaItem,
+  AgendaKind,
+  CalendarEvent,
+  PageResponse,
+  ScheduleStatus,
+} from '@/types'
+import { iso, monthMatrix } from '@/utils/date'
 
 /** 새 일정의 기본값. 인라인 추가는 제목만 받고 나머지는 여기서 채웁니다. */
 export const DEFAULTS = { time: '09:00', dur: '1시간', kind: 'internal', done: false } as const
 
-/**
- * 화면에서 만든 일정에는 시드가 들고 있는 영업 맥락이 없습니다. 빈 값으로 두면
- * 드로어·목록이 그 칸을 아예 그리지 않습니다.
- *
- * reported 를 true 로 두는 이유: 방금 만든 일정을 곧바로 '보고서 미작성' 으로
- * 몰지 않기 위함입니다. 실제 보고 여부는 useMeetingReports 가 따로 봅니다.
- */
+const CATEGORY_BY_KIND: Record<AgendaKind, ActivityCategoryCode> = {
+  visit: 'visit',
+  demo: 'demo',
+  edu: 'education',
+  call: 'call',
+  delivery: 'delivery',
+  booth: 'conference',
+  internal: 'internal',
+}
+
+const KIND_BY_CATEGORY: Record<ActivityCategoryCode, AgendaKind> = {
+  visit: 'visit',
+  demo: 'demo',
+  education: 'edu',
+  call: 'call',
+  delivery: 'delivery',
+  conference: 'booth',
+  internal: 'internal',
+}
+
+const ACTION_TAG_BY_STATUS: Record<ScheduleStatus, ActivityActionTagCode> = {
+  '첫 전화': 'first_call',
+  미팅: 'meeting',
+  '데모 요청': 'demo_requested',
+  '데모 진행': 'demo_in_progress',
+  '데모 완료': 'demo_completed',
+  견적완료: 'quote_completed',
+  계약완료: 'contract_completed',
+  제품교육: 'product_training',
+  납품완료: 'delivery_completed',
+  내부회의: 'internal_meeting',
+  주간점검: 'weekly_review',
+  월간점검: 'monthly_review',
+  분기점검: 'quarterly_review',
+  컨퍼런스: 'conference',
+  OJT: 'ojt',
+}
+
+const STATUS_BY_ACTION_TAG = Object.fromEntries(
+  Object.entries(ACTION_TAG_BY_STATUS).map(([label, code]) => [code, label]),
+) as Record<ActivityActionTagCode, ScheduleStatus>
+
+const MINUTE = 60_000
+const DAY = 86_400_000
+const KST_OFFSET = 9 * 60 * MINUTE
+const PAGE_LIMIT = 100
+
+function kstIso(value: number | Date): string {
+  const time = typeof value === 'number' ? value : value.getTime()
+  return `${new Date(time + KST_OFFSET).toISOString().slice(0, 19)}+09:00`
+}
+
+function kstParts(value: string): { date: string; time: string } {
+  const shifted = new Date(new Date(value).getTime() + KST_OFFSET).toISOString()
+  return { date: shifted.slice(0, 10), time: shifted.slice(11, 16) }
+}
+
+function durationMinutes(label: string): number | null {
+  const hours = /(\d+)\s*시간/.exec(label)
+  const minutes = /(\d+)\s*분/.exec(label)
+  const total = (hours ? Number(hours[1]) * 60 : 0) + (minutes ? Number(minutes[1]) : 0)
+  return total > 0 ? total : null
+}
+
+function durationLabel(start: string, end: string): string {
+  const minutes = Math.round((new Date(end).getTime() - new Date(start).getTime()) / MINUTE)
+  if (minutes <= 0) return ''
+  const hours = Math.floor(minutes / 60)
+  const rest = minutes % 60
+  if (hours === 0) return `${rest}분`
+  return rest === 0 ? `${hours}시간` : `${hours}시간 ${rest}분`
+}
+
+function contactLabel(activity: ActivityRead): string {
+  return [activity.customer_contact_name, activity.customer_contact_job_title]
+    .filter(Boolean)
+    .join(' ')
+}
+
+function toCalendarEvent(activity: ActivityRead): CalendarEvent {
+  const start = kstParts(activity.starts_at)
+  return {
+    id: activity.id,
+    date: start.date,
+    time: start.time,
+    dur: activity.all_day
+      ? '종일'
+      : activity.ends_at
+        ? durationLabel(activity.starts_at, activity.ends_at)
+        : '',
+    kind: KIND_BY_CATEGORY[activity.category_code],
+    stage: activity.action_tag ? STATUS_BY_ACTION_TAG[activity.action_tag] : undefined,
+    title: activity.title,
+    hospital: activity.customer_company_name ?? '',
+    dept: activity.customer_contact_department ?? '',
+    contact: contactLabel(activity),
+    place: activity.location ?? '',
+    brief: activity.note ?? '',
+    done: activity.completed_at !== null,
+    activityType: activity.activity_type,
+    customerContactId: activity.customer_contact_id,
+    customerContactName: activity.customer_contact_name ?? '',
+    productId: activity.product_id,
+    product: activity.product_name ?? '',
+    owner: activity.owner_display_name,
+    startsAt: kstIso(new Date(activity.starts_at)),
+    endsAt: activity.ends_at ? kstIso(new Date(activity.ends_at)) : null,
+    allDay: activity.all_day,
+  }
+}
+
+function nullableText(value?: string): string | null {
+  const trimmed = value?.trim() ?? ''
+  return trimmed === '' ? null : trimmed
+}
+
+function eventTimes(
+  event: CalendarEvent,
+): Pick<ActivityCreateRequest, 'starts_at' | 'ends_at' | 'all_day'> {
+  const start = new Date(`${event.date}T${event.time}:00+09:00`)
+  if (Number.isNaN(start.getTime())) throw new Error('invalid_activity_start')
+
+  const allDay = event.allDay ?? false
+  const minutes = durationMinutes(event.dur)
+  return {
+    starts_at: kstIso(start),
+    ends_at: allDay || minutes === null ? null : kstIso(start.getTime() + minutes * MINUTE),
+    all_day: allDay,
+  }
+}
+
+function toActivityPayload(event: CalendarEvent): ActivityCreateRequest {
+  return {
+    customer_contact_id: event.customerContactId ?? null,
+    product_id: event.productId ?? null,
+    activity_type: event.activityType ?? (event.kind === 'internal' ? 'task' : 'meeting'),
+    category_code: CATEGORY_BY_KIND[event.kind],
+    title: event.title.trim(),
+    ...eventTimes(event),
+    location: nullableText(event.place),
+    action_tag: event.stage ? ACTION_TAG_BY_STATUS[event.stage] : null,
+    note: nullableText(event.brief),
+  }
+}
+
+function shiftDateTime(value: string, days: number): string {
+  return kstIso(new Date(value).getTime() + days * DAY)
+}
+
+function requestError(error: unknown, fallback: string): string {
+  if (!isAxiosError(error)) return fallback
+  if (error.response?.status === 401) return '로그인이 만료되었습니다. 다시 로그인해 주세요.'
+  if (error.response?.status === 403) return '이 일정을 변경할 권한이 없습니다.'
+  if (error.response?.status === 404) return '일정을 찾을 수 없습니다. 목록을 다시 불러오세요.'
+  if (error.response?.status === 422) return '일정 정보를 확인해 주세요.'
+  return '서버에 연결할 수 없습니다. 잠시 후 다시 시도해 주세요.'
+}
+
+type NewEvent = Partial<Omit<CalendarEvent, 'id'>> & { date: string; title: string }
+
 const BLANK = () => ({
   off: 0,
   hospital: '',
@@ -38,21 +194,179 @@ const BLANK = () => ({
   reported: true,
 })
 
-// Date.now() 는 같은 밀리초 안에 두 번 부르면 같은 값이 나옵니다. id 가 겹치면
-// 드래그가 엉뚱한 일정을 옮기고 React 키도 중복되므로 증가하는 번호를 씁니다.
 let seq = 0
 
-type NewEvent = Partial<Omit<CalendarEvent, 'id'>> & { date: string; title: string }
+interface ApiCalendarEvents {
+  events: CalendarEvent[]
+  eventsByDate: Map<string, CalendarEvent[]>
+  loading: boolean
+  error: string | null
+  reload: () => void
+  addEvent: (draft: NewEvent) => Promise<CalendarEvent>
+  updateEvent: (next: CalendarEvent) => Promise<CalendarEvent>
+  moveEvent: (id: string, date: string) => Promise<CalendarEvent | undefined>
+  removeEvent: (id: string) => Promise<void>
+}
 
-export default function useCalendarEvents() {
-  // 목록이 바뀌면 이 훅을 쓰는 화면이 다시 그려집니다.
-  useAgenda()
+interface LegacyCalendarEvents {
+  addEvent: (draft: NewEvent) => AgendaItem
+  updateEvent: (next: CalendarEvent) => void
+  removeEvent: (id: string) => void
+}
+
+function useCalendarEvents(cursor: Date): ApiCalendarEvents
+function useCalendarEvents(): LegacyCalendarEvents
+function useCalendarEvents(cursor?: Date): ApiCalendarEvents | LegacyCalendarEvents {
+  const [events, setEvents] = useState<CalendarEvent[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [reloadKey, setReloadKey] = useState(0)
+  const mutationRevision = useRef(0)
   const { profile } = useCurrentUser()
 
-  const addEvent = useCallback(
+  const range = useMemo(() => {
+    if (!cursor) return null
+    const days = monthMatrix(cursor)
+    return { startDate: iso(days[0]), endDate: iso(days[days.length - 1]) }
+  }, [cursor])
+
+  useEffect(() => {
+    if (!range) return
+    const controller = new AbortController()
+    const revision = mutationRevision.current
+
+    setLoading(true)
+    setError(null)
+
+    void (async () => {
+      try {
+        const items: ActivityRead[] = []
+        let skip = 0
+
+        while (!controller.signal.aborted && revision === mutationRevision.current) {
+          const { data } = await client.get<PageResponse<ActivityRead>>('/activities', {
+            params: {
+              start_date: range.startDate,
+              end_date: range.endDate,
+              skip,
+              limit: PAGE_LIMIT,
+            },
+            signal: controller.signal,
+          })
+          items.push(...data.items)
+          if (!data.has_more || data.next_skip === null) break
+          skip = data.next_skip
+        }
+
+        if (!controller.signal.aborted) {
+          if (revision === mutationRevision.current) setEvents(items.map(toCalendarEvent))
+          else setReloadKey((value) => value + 1)
+        }
+      } catch (reason: unknown) {
+        if (!controller.signal.aborted) {
+          if (revision === mutationRevision.current) {
+            setError(requestError(reason, '일정 목록을 불러오지 못했습니다.'))
+          } else {
+            setReloadKey((value) => value + 1)
+          }
+        }
+      } finally {
+        if (!controller.signal.aborted) setLoading(false)
+      }
+    })()
+
+    return () => controller.abort()
+  }, [range, reloadKey])
+
+  const eventsByDate = useMemo(() => {
+    const grouped = new Map<string, CalendarEvent[]>()
+    for (const event of events) {
+      const list = grouped.get(event.date)
+      if (list) list.push(event)
+      else grouped.set(event.date, [event])
+    }
+    for (const list of grouped.values()) list.sort((a, b) => a.time.localeCompare(b.time))
+    return grouped
+  }, [events])
+
+  const addApiEvent = useCallback(async (draft: NewEvent) => {
+    const event: CalendarEvent = { ...DEFAULTS, ...draft, id: '' }
+    setError(null)
+    try {
+      const { data } = await client.post<ActivityRead>('/activities', toActivityPayload(event))
+      const added = toCalendarEvent(data)
+      mutationRevision.current += 1
+      setEvents((current) => [...current, added])
+      return added
+    } catch (reason: unknown) {
+      setError(requestError(reason, '일정을 등록하지 못했습니다.'))
+      throw reason
+    }
+  }, [])
+
+  const updateApiEvent = useCallback(async (next: CalendarEvent) => {
+    setError(null)
+    try {
+      const payload: ActivityPatchRequest = toActivityPayload(next)
+      const { data } = await client.patch<ActivityRead>(`/activities/${next.id}`, payload)
+      const updated = toCalendarEvent(data)
+      mutationRevision.current += 1
+      setEvents((current) => current.map((event) => (event.id === updated.id ? updated : event)))
+      return updated
+    } catch (reason: unknown) {
+      setError(requestError(reason, '일정을 수정하지 못했습니다.'))
+      throw reason
+    }
+  }, [])
+
+  const moveApiEvent = useCallback(
+    async (id: string, date: string) => {
+      const current = events.find((event) => event.id === id)
+      if (!current || current.date === date) return current
+
+      const startsAt = current.startsAt ?? eventTimes(current).starts_at
+      const endsAt = current.endsAt ?? eventTimes(current).ends_at ?? null
+      const days = Math.round(
+        (new Date(`${date}T00:00:00+09:00`).getTime() -
+          new Date(`${current.date}T00:00:00+09:00`).getTime()) /
+          DAY,
+      )
+      const payload: ActivityPatchRequest = {
+        starts_at: shiftDateTime(startsAt, days),
+        ends_at: endsAt ? shiftDateTime(endsAt, days) : null,
+      }
+
+      setError(null)
+      try {
+        const { data } = await client.patch<ActivityRead>(`/activities/${id}`, payload)
+        const moved = toCalendarEvent(data)
+        mutationRevision.current += 1
+        setEvents((list) => list.map((event) => (event.id === moved.id ? moved : event)))
+        return moved
+      } catch (reason: unknown) {
+        setError(requestError(reason, '일정을 옮기지 못했습니다.'))
+        throw reason
+      }
+    },
+    [events],
+  )
+
+  const removeApiEvent = useCallback(async (id: string) => {
+    setError(null)
+    try {
+      await client.delete(`/activities/${id}`)
+      mutationRevision.current += 1
+      setEvents((current) => current.filter((event) => event.id !== id))
+    } catch (reason: unknown) {
+      setError(requestError(reason, '일정을 삭제하지 못했습니다.'))
+      throw reason
+    }
+  }, [])
+
+  const reload = useCallback(() => setReloadKey((value) => value + 1), [])
+
+  const addLegacyEvent = useCallback(
     (draft: NewEvent) => {
-      // 목업이라 서버가 id 를 주지 않습니다. 화면 안에서만 겹치지 않으면 됩니다.
-      // owner 는 로그인한 사람입니다. 비어 있으면 프로필 필터에서 일정이 사라집니다.
       const item: AgendaItem = {
         ...BLANK(),
         ...DEFAULTS,
@@ -66,24 +380,32 @@ export default function useCalendarEvents() {
     [profile.name],
   )
 
-  /** 모달이 돌려주는 것은 느슨한 CalendarEvent 라, 원본에 덮어써야 나머지 칸이 남습니다. */
-  const updateEvent = useCallback((next: CalendarEvent) => {
+  const updateLegacyEvent = useCallback((next: CalendarEvent) => {
     const current = agendaById(next.id)
     if (current) updateAgenda({ ...current, ...next })
   }, [])
 
-  /** 날짜만 옮깁니다. 시간은 그대로 두어 그날 안에서의 순서가 유지됩니다. */
-  const moveEvent = useCallback((id: string, date: string) => {
-    const current = agendaById(id)
-    if (current && current.date !== date) updateAgenda({ ...current, date })
-  }, [])
+  const removeLegacyEvent = useCallback((id: string) => removeAgenda(id), [])
 
-  const removeEvent = useCallback((id: string) => removeAgenda(id), [])
+  if (!cursor) {
+    return {
+      addEvent: addLegacyEvent,
+      updateEvent: updateLegacyEvent,
+      removeEvent: removeLegacyEvent,
+    }
+  }
 
-  const toggleDone = useCallback((id: string) => {
-    const current = agendaById(id)
-    if (current) updateAgenda({ ...current, done: !current.done })
-  }, [])
-
-  return { eventsByDate: agendaByDate(), addEvent, updateEvent, moveEvent, removeEvent, toggleDone }
+  return {
+    events,
+    eventsByDate,
+    loading,
+    error,
+    reload,
+    addEvent: addApiEvent,
+    updateEvent: updateApiEvent,
+    moveEvent: moveApiEvent,
+    removeEvent: removeApiEvent,
+  }
 }
+
+export default useCalendarEvents

--- a/frontend/src/types/agenda.ts
+++ b/frontend/src/types/agenda.ts
@@ -1,6 +1,28 @@
 /** 일정 종류. 배지 색이 여기에 묶여 있습니다. */
 export type AgendaKind = 'visit' | 'demo' | 'edu' | 'call' | 'delivery' | 'booth' | 'internal'
 
+export type ActivityTypeCode = 'meeting' | 'task'
+
+export type ActivityCategoryCode =
+  'visit' | 'demo' | 'education' | 'call' | 'delivery' | 'conference' | 'internal'
+
+export type ActivityActionTagCode =
+  | 'first_call'
+  | 'meeting'
+  | 'demo_requested'
+  | 'demo_in_progress'
+  | 'demo_completed'
+  | 'quote_completed'
+  | 'contract_completed'
+  | 'product_training'
+  | 'delivery_completed'
+  | 'internal_meeting'
+  | 'weekly_review'
+  | 'monthly_review'
+  | 'quarterly_review'
+  | 'conference'
+  | 'ojt'
+
 /** 고객을 만나서 하는 일. 영업이 어디까지 갔는지를 말합니다. */
 export type ExternalStatus =
   | '첫 전화'
@@ -76,4 +98,55 @@ export interface CalendarEvent {
   place?: string
   brief?: string
   done: boolean
+  activityType?: ActivityTypeCode
+  customerContactId?: string | null
+  customerContactName?: string
+  productId?: string | null
+  product?: string
+  owner?: string
+  startsAt?: string
+  endsAt?: string | null
+  allDay?: boolean
 }
+
+export interface ActivityRead {
+  id: string
+  owner_member_id: string
+  owner_display_name: string
+  customer_contact_id: string | null
+  customer_contact_name: string | null
+  customer_contact_department: string | null
+  customer_contact_job_title: string | null
+  customer_company_id: string | null
+  customer_company_name: string | null
+  product_id: string | null
+  product_name: string | null
+  activity_type: ActivityTypeCode
+  category_code: ActivityCategoryCode
+  title: string
+  starts_at: string
+  ends_at: string | null
+  all_day: boolean
+  location: string | null
+  action_tag: ActivityActionTagCode | null
+  completed_at: string | null
+  note: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface ActivityCreateRequest {
+  customer_contact_id?: string | null
+  product_id?: string | null
+  activity_type: ActivityTypeCode
+  category_code: ActivityCategoryCode
+  title: string
+  starts_at: string
+  ends_at?: string | null
+  all_day: boolean
+  location?: string | null
+  action_tag?: ActivityActionTagCode | null
+  note?: string | null
+}
+
+export type ActivityPatchRequest = Partial<ActivityCreateRequest>


### PR DESCRIPTION
## 변경 요약

- `activity` 일정 목록·상세·등록·수정·삭제 API와 팀·담당자 권한 경계를 구현했습니다.
- 기존 캘린더를 실제 API에 연결해 조회·등록·수정·이동·삭제 결과가 Supabase에 저장되도록 했습니다.
- 합성 상품 3개와 일정 12개를 데이터 팀에만 반복 적용하는 개발 seed를 추가했습니다.
- 고객 UUID 선택, `+09:00` 시간 계약, 추천 일정 중복 저장을 검증했습니다.

## 검증

- 백엔드 Ruff 및 포맷 검사 통과
- 백엔드 테스트: `33 passed, 2 skipped`
- 프론트엔드 typecheck, lint, format, mock 검사, production build 통과
- 개발 Supabase 권한 조회: 데이터 팀 팀장 12건·팀원 7건, 빈 팀 0건
- 브라우저에서 일정 등록·조회·수정·삭제 왕복 확인

## 영향 및 주의 사항

- 개발 Supabase에는 상품 3개와 일정 12개 seed가 적용되어 있습니다.
- 완료·재개, 동행자, 실제 팀원 UUID 기반 담당자 선택은 후속 작업입니다.
- 생성된 캐시는 제거했고 `.venv`와 `node_modules`는 커밋하지 않았습니다.
