### PR TITLE
feat: 발주 현황을 실제 API와 연결

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api import activities, auth, contracts, customers, health
+from app.api import activities, auth, contracts, customers, health, orders
 
 api_router = APIRouter()
 api_router.include_router(health.router)
@@ -8,3 +8,4 @@ api_router.include_router(auth.router)
 api_router.include_router(customers.router)
 api_router.include_router(activities.router)
 api_router.include_router(contracts.router)
+api_router.include_router(orders.router)

--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -1,0 +1,617 @@
+from datetime import UTC, datetime
+from typing import Annotated
+from uuid import UUID, uuid4
+from zoneinfo import ZoneInfo
+
+from fastapi import APIRouter, HTTPException, Query, Response, status
+from sqlalchemy import and_, delete, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from app.api.deps import CurrentMember, DbSession
+from app.models.crm import CustomerCompany
+from app.models.sales import Contract, Product, PurchaseOrder, PurchaseOrderItem
+from app.models.workspace import Member, Team
+from app.schemas.orders import (
+    OrderCreate,
+    OrderItemRead,
+    OrderItemWrite,
+    OrderMove,
+    OrderPage,
+    OrderPageParams,
+    OrderPatch,
+    OrderRead,
+)
+
+router = APIRouter(tags=["orders"])
+
+_SEOUL = ZoneInfo("Asia/Seoul")
+_owner = aliased(Member)
+_company = aliased(CustomerCompany)
+_contract = aliased(Contract)
+_search_item = aliased(PurchaseOrderItem)
+_search_product = aliased(Product)
+
+
+def _contains(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return f"%{escaped}%"
+
+
+def _joined_select(*entities):
+    return (
+        select(*entities)
+        .select_from(PurchaseOrder)
+        .join(_owner, PurchaseOrder.owner_member_id == _owner.id)
+        .join(_company, PurchaseOrder.customer_company_id == _company.id)
+        .outerjoin(_contract, PurchaseOrder.contract_id == _contract.id)
+    )
+
+
+def _items_are_team_scoped(team_id: UUID):
+    item = aliased(PurchaseOrderItem)
+    product = aliased(Product)
+    invalid_item = (
+        select(1)
+        .select_from(item)
+        .outerjoin(product, item.product_id == product.id)
+        .where(
+            item.order_id == PurchaseOrder.id,
+            or_(product.id.is_(None), product.team_id != team_id),
+        )
+        .exists()
+    )
+    return ~invalid_item
+
+
+def _scope(member: Member, owner_ids: tuple[UUID, ...] | None = None):
+    conditions = [
+        PurchaseOrder.team_id == member.team_id,
+        PurchaseOrder.deleted_at.is_(None),
+        _owner.team_id == member.team_id,
+        _owner.active.is_(True),
+        _owner.role_code.in_(("member", "manager")),
+        _company.team_id == member.team_id,
+        or_(
+            PurchaseOrder.contract_id.is_(None),
+            and_(
+                _contract.team_id == member.team_id,
+                _contract.deleted_at.is_(None),
+                _contract.customer_company_id == PurchaseOrder.customer_company_id,
+                _contract.owner_member_id == PurchaseOrder.owner_member_id,
+            ),
+        ),
+        _items_are_team_scoped(member.team_id),
+    ]
+    if member.role_code == "member":
+        conditions.append(PurchaseOrder.owner_member_id == member.id)
+    elif owner_ids is not None:
+        conditions.append(PurchaseOrder.owner_member_id.in_(owner_ids))
+    return conditions
+
+
+def _read_entities():
+    return (
+        PurchaseOrder,
+        _owner.display_name,
+        _company.name,
+        _contract.contract_no,
+    )
+
+
+def _seoul(value: datetime) -> datetime:
+    return value.astimezone(_SEOUL)
+
+
+def _order_read(
+    order: PurchaseOrder,
+    owner_display_name: str,
+    company_name: str,
+    contract_no: str | None,
+    items: list[OrderItemRead],
+) -> OrderRead:
+    return OrderRead(
+        id=order.id,
+        order_no=order.order_no,
+        contract_id=order.contract_id,
+        contract_no=contract_no,
+        customer_company_id=order.customer_company_id,
+        customer_company_name=company_name,
+        owner_member_id=order.owner_member_id,
+        owner_display_name=owner_display_name,
+        supplier_name=order.supplier_name,
+        stage_code=order.stage_code,
+        ordered_on=order.ordered_on,
+        due_on=order.due_on,
+        expected_receipt_on=order.expected_receipt_on,
+        memo=order.memo,
+        items=items,
+        created_at=_seoul(order.created_at),
+        updated_at=_seoul(order.updated_at),
+    )
+
+
+async def _items_by_order_ids(
+    db: AsyncSession,
+    member: Member,
+    order_ids: list[UUID],
+) -> dict[UUID, list[OrderItemRead]]:
+    items_by_order = {order_id: [] for order_id in order_ids}
+    if not order_ids:
+        return items_by_order
+    result = await db.execute(
+        select(PurchaseOrderItem, Product.name)
+        .join(Product, PurchaseOrderItem.product_id == Product.id)
+        .where(
+            PurchaseOrderItem.order_id.in_(order_ids),
+            Product.team_id == member.team_id,
+        )
+        .order_by(PurchaseOrderItem.order_id, PurchaseOrderItem.position, PurchaseOrderItem.id)
+    )
+    for item, product_name in result.all():
+        items_by_order[item.order_id].append(
+            OrderItemRead(
+                id=item.id,
+                product_id=item.product_id,
+                product_name=product_name,
+                quantity=item.quantity,
+                unit_price=item.unit_price,
+                position=item.position,
+            )
+        )
+    return items_by_order
+
+
+async def _owner_filter(
+    db: AsyncSession,
+    member: Member,
+    requested: list[UUID] | None,
+) -> tuple[UUID, ...] | None:
+    if requested is None:
+        return None
+    if member.role_code != "manager":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="scope_not_allowed",
+        )
+    owner_ids = tuple(dict.fromkeys(requested))
+    result = await db.execute(
+        select(Member.id).where(
+            Member.id.in_(owner_ids),
+            Member.team_id == member.team_id,
+            Member.active.is_(True),
+            Member.role_code.in_(("member", "manager")),
+        )
+    )
+    if set(result.scalars().all()) != set(owner_ids):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="scope_not_allowed",
+        )
+    return owner_ids
+
+
+async def _order_row(db: AsyncSession, member: Member, order_id: UUID):
+    result = await db.execute(
+        _joined_select(*_read_entities()).where(
+            PurchaseOrder.id == order_id,
+            *_scope(member),
+        )
+    )
+    row = result.one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="order_not_found",
+        )
+    return row
+
+
+async def _locked_order(db: AsyncSession, member: Member, order_id: UUID) -> PurchaseOrder:
+    conditions = [
+        PurchaseOrder.id == order_id,
+        PurchaseOrder.team_id == member.team_id,
+        PurchaseOrder.deleted_at.is_(None),
+        Member.team_id == member.team_id,
+        Member.active.is_(True),
+        Member.role_code.in_(("member", "manager")),
+        CustomerCompany.team_id == member.team_id,
+        or_(
+            PurchaseOrder.contract_id.is_(None),
+            and_(
+                Contract.team_id == member.team_id,
+                Contract.deleted_at.is_(None),
+                Contract.customer_company_id == PurchaseOrder.customer_company_id,
+                Contract.owner_member_id == PurchaseOrder.owner_member_id,
+            ),
+        ),
+        _items_are_team_scoped(member.team_id),
+    ]
+    if member.role_code == "member":
+        conditions.append(PurchaseOrder.owner_member_id == member.id)
+    result = await db.execute(
+        select(PurchaseOrder)
+        .join(Member, PurchaseOrder.owner_member_id == Member.id)
+        .join(CustomerCompany, PurchaseOrder.customer_company_id == CustomerCompany.id)
+        .outerjoin(Contract, PurchaseOrder.contract_id == Contract.id)
+        .where(*conditions)
+        .with_for_update(of=PurchaseOrder)
+    )
+    order = result.scalar_one_or_none()
+    if order is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="order_not_found",
+        )
+    return order
+
+
+async def _team_company(
+    db: AsyncSession,
+    member: Member,
+    company_id: UUID,
+) -> CustomerCompany:
+    result = await db.execute(
+        select(CustomerCompany).where(
+            CustomerCompany.id == company_id,
+            CustomerCompany.team_id == member.team_id,
+        )
+    )
+    company = result.scalar_one_or_none()
+    if company is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="customer_company_not_found",
+        )
+    return company
+
+
+async def _team_contract(
+    db: AsyncSession,
+    member: Member,
+    contract_id: UUID,
+) -> tuple[Contract, str]:
+    conditions = [
+        Contract.id == contract_id,
+        Contract.team_id == member.team_id,
+        Contract.deleted_at.is_(None),
+        Member.team_id == member.team_id,
+        Member.active.is_(True),
+        Member.role_code.in_(("member", "manager")),
+    ]
+    if member.role_code == "member":
+        conditions.append(Contract.owner_member_id == member.id)
+    result = await db.execute(
+        select(Contract, Member.display_name)
+        .join(Member, Contract.owner_member_id == Member.id)
+        .where(*conditions)
+    )
+    row = result.one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="contract_not_found",
+        )
+    return row
+
+
+async def _team_products(
+    db: AsyncSession,
+    member: Member,
+    items: list[OrderItemWrite],
+) -> dict[UUID, Product]:
+    product_ids = tuple(dict.fromkeys(item.product_id for item in items))
+    result = await db.execute(
+        select(Product).where(
+            Product.id.in_(product_ids),
+            Product.team_id == member.team_id,
+            Product.active.is_(True),
+        )
+    )
+    products = {product.id: product for product in result.scalars().all()}
+    if set(products) != set(product_ids):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="product_not_found",
+        )
+    return products
+
+
+async def _next_order_no(
+    db: AsyncSession,
+    member: Member,
+    year: int,
+) -> str:
+    team_result = await db.execute(
+        select(Team.id).where(Team.id == member.team_id).with_for_update(of=Team)
+    )
+    if team_result.scalar_one_or_none() is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="team_not_found",
+        )
+
+    prefix = f"SL-PO-{year}-"
+    numbers_result = await db.execute(
+        select(PurchaseOrder.order_no).where(
+            PurchaseOrder.team_id == member.team_id,
+            PurchaseOrder.order_no.like(f"{prefix}%"),
+        )
+    )
+    numbers = []
+    for order_no in numbers_result.scalars().all():
+        suffix = order_no.removeprefix(prefix)
+        if len(suffix) == 4 and suffix.isascii() and suffix.isdigit():
+            numbers.append(int(suffix))
+    next_number = max(numbers, default=0) + 1
+    if next_number > 9_999:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="order_number_exhausted",
+        )
+    return f"{prefix}{next_number:04d}"
+
+
+def _new_items(
+    order_id: UUID,
+    values: list[OrderItemWrite],
+) -> list[PurchaseOrderItem]:
+    return [
+        PurchaseOrderItem(
+            id=uuid4(),
+            order_id=order_id,
+            product_id=value.product_id,
+            quantity=value.quantity,
+            unit_price=value.unit_price,
+            position=position,
+        )
+        for position, value in enumerate(values)
+    ]
+
+
+def _item_reads(
+    items: list[PurchaseOrderItem],
+    products: dict[UUID, Product],
+) -> list[OrderItemRead]:
+    return [
+        OrderItemRead(
+            id=item.id,
+            product_id=item.product_id,
+            product_name=products[item.product_id].name,
+            quantity=item.quantity,
+            unit_price=item.unit_price,
+            position=item.position,
+        )
+        for item in items
+    ]
+
+
+@router.get("/orders", response_model=OrderPage)
+async def list_orders(
+    page: Annotated[OrderPageParams, Query()],
+    member: CurrentMember,
+    db: DbSession,
+) -> OrderPage:
+    owner_ids = await _owner_filter(db, member, page.owner_member_id)
+    scope = _scope(member, owner_ids)
+    if page.supplier_name is not None:
+        scope.append(PurchaseOrder.supplier_name == page.supplier_name)
+    if page.stage_code is not None:
+        scope.append(PurchaseOrder.stage_code.in_(tuple(dict.fromkeys(page.stage_code))))
+    if page.start_date is not None:
+        scope.append(PurchaseOrder.ordered_on >= page.start_date)
+    if page.end_date is not None:
+        scope.append(PurchaseOrder.ordered_on <= page.end_date)
+    if page.q is not None:
+        pattern = _contains(page.q)
+        product_match = (
+            select(1)
+            .select_from(_search_item)
+            .join(_search_product, _search_item.product_id == _search_product.id)
+            .where(
+                _search_item.order_id == PurchaseOrder.id,
+                _search_product.team_id == member.team_id,
+                _search_product.name.ilike(pattern, escape="\\"),
+            )
+            .exists()
+        )
+        scope.append(
+            or_(
+                PurchaseOrder.order_no.ilike(pattern, escape="\\"),
+                PurchaseOrder.supplier_name.ilike(pattern, escape="\\"),
+                PurchaseOrder.memo.ilike(pattern, escape="\\"),
+                _company.name.ilike(pattern, escape="\\"),
+                _contract.contract_no.ilike(pattern, escape="\\"),
+                product_match,
+            )
+        )
+
+    total_result = await db.execute(_joined_select(func.count(PurchaseOrder.id)).where(*scope))
+    total = total_result.scalar_one()
+    rows_result = await db.execute(
+        _joined_select(*_read_entities())
+        .where(*scope)
+        .order_by(PurchaseOrder.ordered_on.desc(), PurchaseOrder.id)
+        .offset(page.skip)
+        .limit(page.limit)
+    )
+    rows = rows_result.all()
+    item_map = await _items_by_order_ids(db, member, [row[0].id for row in rows])
+    items = [_order_read(*row, item_map[row[0].id]) for row in rows]
+    has_more = page.skip + len(items) < total
+    return OrderPage(
+        items=items,
+        skip=page.skip,
+        limit=page.limit,
+        total=total,
+        has_more=has_more,
+        next_skip=page.skip + len(items) if has_more else None,
+    )
+
+
+@router.get("/orders/{order_id}", response_model=OrderRead)
+async def get_order(
+    order_id: UUID,
+    member: CurrentMember,
+    db: DbSession,
+) -> OrderRead:
+    row = await _order_row(db, member, order_id)
+    item_map = await _items_by_order_ids(db, member, [order_id])
+    return _order_read(*row, item_map[order_id])
+
+
+@router.post(
+    "/orders",
+    response_model=OrderRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_order(
+    payload: OrderCreate,
+    response: Response,
+    member: CurrentMember,
+    db: DbSession,
+) -> OrderRead:
+    try:
+        company = await _team_company(db, member, payload.customer_company_id)
+        contract = None
+        contract_no = None
+        owner_id = member.id
+        owner_display_name = member.display_name
+        if payload.contract_id is not None:
+            contract, owner_display_name = await _team_contract(db, member, payload.contract_id)
+            if contract.customer_company_id != company.id:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                    detail="contract_company_mismatch",
+                )
+            contract_no = contract.contract_no
+            owner_id = contract.owner_member_id
+
+        products = await _team_products(db, member, payload.items)
+        order_no = await _next_order_no(db, member, payload.ordered_on.year)
+        order = PurchaseOrder(
+            id=uuid4(),
+            team_id=member.team_id,
+            order_no=order_no,
+            contract_id=payload.contract_id,
+            customer_company_id=payload.customer_company_id,
+            owner_member_id=owner_id,
+            supplier_name=payload.supplier_name,
+            stage_code=payload.stage_code,
+            ordered_on=payload.ordered_on,
+            due_on=payload.due_on,
+            expected_receipt_on=payload.expected_receipt_on,
+            memo=payload.memo,
+            deleted_at=None,
+        )
+        order_items = _new_items(order.id, payload.items)
+        db.add(order)
+        for item in order_items:
+            db.add(item)
+        await db.flush()
+        read = _order_read(
+            order,
+            owner_display_name,
+            company.name,
+            contract_no,
+            _item_reads(order_items, products),
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    response.headers["Location"] = f"/api/orders/{order.id}"
+    return read
+
+
+@router.patch("/orders/{order_id}", response_model=OrderRead)
+async def update_order(
+    order_id: UUID,
+    payload: OrderPatch,
+    member: CurrentMember,
+    db: DbSession,
+) -> OrderRead:
+    try:
+        order = await _locked_order(db, member, order_id)
+        values = payload.model_dump(exclude_unset=True, exclude={"items"})
+        company_id = values.get("customer_company_id", order.customer_company_id)
+        if "customer_company_id" in values:
+            await _team_company(db, member, company_id)
+
+        contract_id = values.get("contract_id", order.contract_id)
+        if contract_id is not None:
+            contract, _owner_display_name = await _team_contract(db, member, contract_id)
+            if contract.customer_company_id != company_id:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                    detail="contract_company_mismatch",
+                )
+            order.owner_member_id = contract.owner_member_id
+
+        for field_name, value in values.items():
+            setattr(order, field_name, value)
+
+        if "items" in payload.model_fields_set:
+            assert payload.items is not None
+            await _team_products(db, member, payload.items)
+            await db.execute(
+                delete(PurchaseOrderItem).where(PurchaseOrderItem.order_id == order.id)
+            )
+            for item in _new_items(order.id, payload.items):
+                db.add(item)
+
+        order.updated_at = datetime.now(UTC)
+        await db.flush()
+        row = await _order_row(db, member, order_id)
+        item_map = await _items_by_order_ids(db, member, [order_id])
+        read = _order_read(*row, item_map[order_id])
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return read
+
+
+@router.post("/orders/{order_id}/move", response_model=OrderRead)
+async def move_order(
+    order_id: UUID,
+    payload: OrderMove,
+    member: CurrentMember,
+    db: DbSession,
+) -> OrderRead:
+    try:
+        order = await _locked_order(db, member, order_id)
+        if order.stage_code != payload.expected_stage_code:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="invalid_state_transition",
+            )
+        order.stage_code = payload.stage_code
+        order.updated_at = datetime.now(UTC)
+        await db.flush()
+        row = await _order_row(db, member, order_id)
+        item_map = await _items_by_order_ids(db, member, [order_id])
+        read = _order_read(*row, item_map[order_id])
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return read
+
+
+@router.delete("/orders/{order_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_order(
+    order_id: UUID,
+    member: CurrentMember,
+    db: DbSession,
+) -> None:
+    try:
+        order = await _locked_order(db, member, order_id)
+        now = datetime.now(UTC)
+        order.deleted_at = now
+        order.updated_at = now
+        await db.flush()
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise

--- a/backend/app/schemas/orders.py
+++ b/backend/app/schemas/orders.py
@@ -1,0 +1,144 @@
+from datetime import date, datetime
+from typing import Annotated, Literal, Self
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, StringConstraints, model_validator
+
+Text = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=254),
+]
+LongText = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=5_000),
+]
+SearchQuery = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=100),
+]
+Quantity = Annotated[StrictInt, Field(ge=1, le=2_147_483_647)]
+Money = Annotated[StrictInt, Field(ge=0, le=9_223_372_036_854_775_807)]
+OrderStage = Literal[
+    "order_received",
+    "dispatch_request_completed",
+    "in_production",
+    "stock_received",
+    "delivered",
+    "cancelled",
+]
+
+
+class _WriteModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class OrderItemWrite(_WriteModel):
+    product_id: UUID
+    quantity: Quantity
+    unit_price: Money
+
+
+OrderItems = Annotated[list[OrderItemWrite], Field(min_length=1, max_length=100)]
+
+
+class OrderCreate(_WriteModel):
+    contract_id: UUID | None = None
+    customer_company_id: UUID
+    supplier_name: Text
+    stage_code: OrderStage
+    ordered_on: date
+    due_on: date
+    expected_receipt_on: date
+    memo: LongText | None = None
+    items: OrderItems
+
+
+class OrderPatch(_WriteModel):
+    contract_id: UUID | None = None
+    customer_company_id: UUID | None = None
+    supplier_name: Text | None = None
+    ordered_on: date | None = None
+    due_on: date | None = None
+    expected_receipt_on: date | None = None
+    memo: LongText | None = None
+    items: OrderItems | None = None
+
+    @model_validator(mode="after")
+    def required_fields_cannot_be_null(self) -> Self:
+        for field_name in (
+            "customer_company_id",
+            "supplier_name",
+            "ordered_on",
+            "due_on",
+            "expected_receipt_on",
+            "items",
+        ):
+            if field_name in self.model_fields_set and getattr(self, field_name) is None:
+                raise ValueError(f"{field_name} cannot be null")
+        return self
+
+
+class OrderMove(_WriteModel):
+    expected_stage_code: OrderStage
+    stage_code: OrderStage
+
+
+class OrderItemRead(BaseModel):
+    id: UUID
+    product_id: UUID
+    product_name: str
+    quantity: int
+    unit_price: int
+    position: int
+
+
+class OrderRead(BaseModel):
+    id: UUID
+    order_no: str
+    contract_id: UUID | None
+    contract_no: str | None
+    customer_company_id: UUID
+    customer_company_name: str
+    owner_member_id: UUID
+    owner_display_name: str
+    supplier_name: str
+    stage_code: OrderStage
+    ordered_on: date
+    due_on: date
+    expected_receipt_on: date
+    memo: str | None
+    items: list[OrderItemRead]
+    created_at: datetime
+    updated_at: datetime
+
+
+class OrderPage(BaseModel):
+    items: list[OrderRead]
+    skip: int
+    limit: int
+    total: int
+    has_more: bool
+    next_skip: int | None
+
+
+class OrderPageParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    q: SearchQuery | None = None
+    supplier_name: Text | None = None
+    stage_code: list[OrderStage] | None = None
+    start_date: date | None = None
+    end_date: date | None = None
+    owner_member_id: list[UUID] | None = None
+    skip: int = Field(default=0, ge=0, le=9_223_372_036_854_775_807)
+    limit: int = Field(default=30, ge=1, le=100)
+
+    @model_validator(mode="after")
+    def dates_in_order(self) -> Self:
+        if (
+            self.start_date is not None
+            and self.end_date is not None
+            and self.end_date < self.start_date
+        ):
+            raise ValueError("end_date must not be before start_date")
+        return self

--- a/backend/scripts/seed_demo_orders.py
+++ b/backend/scripts/seed_demo_orders.py
@@ -1,0 +1,348 @@
+"""filled 데모팀에만 관계가 정확한 합성 발주 2건과 품목 2건을 반복 가능하게 넣는다."""
+
+import asyncio
+from datetime import timedelta
+from typing import NamedTuple
+from uuid import UUID, uuid5
+
+from sqlalchemy import and_, or_, select
+from sqlalchemy.dialects.postgresql import insert
+
+from app.db.session import get_sessionmaker
+from app.models.crm import CustomerCompany
+from app.models.sales import Contract, Product, PurchaseOrder, PurchaseOrderItem
+from app.models.workspace import Member, Team
+from scripts.seed_demo_activities import REFERENCE_DATE, product_id
+from scripts.seed_demo_auth import FILLED_TEAM_ID
+from scripts.seed_demo_contracts import contract_id
+from scripts.seed_demo_customers import FILLED_TEAM_NAME, company_id
+
+
+class PurchaseOrderSeed(NamedTuple):
+    order_no: str
+    contract_no: str
+    company_name: str
+    product_name: str
+    supplier_name: str
+    ordered_day_offset: int
+    due_day_offset: int
+    expected_receipt_day_offset: int
+    stage_code: str
+    memo: str | None
+    quantity: int
+    unit_price: int
+
+
+# 프론트 발주 5건 중 현재 고객사·상품·계약 관계가 모두 정확한 2건만 옮긴다.
+PURCHASE_ORDER_SEEDS = (
+    PurchaseOrderSeed(
+        "FM-PO-2026-0020",
+        "FM-CT-2026-0020",
+        "한빛대학교병원",
+        "CardioView X7",
+        "본사 생산팀",
+        -13,
+        6,
+        6,
+        "in_production",
+        "분할 납품 1차",
+        2,
+        24_000_000,
+    ),
+    PurchaseOrderSeed(
+        "FM-PO-2026-0019",
+        "FM-CT-2026-0013",
+        "서림메디컬센터",
+        "OrthoScan Mini",
+        "외부 벤더 (메디파츠)",
+        -21,
+        -7,
+        -8,
+        "delivered",
+        None,
+        3,
+        8_600_000,
+    ),
+)
+
+
+def purchase_order_id(order_no: str) -> UUID:
+    return uuid5(FILLED_TEAM_ID, f"purchase-order:{order_no}")
+
+
+def purchase_order_item_id(order_no: str, position: int) -> UUID:
+    return uuid5(FILLED_TEAM_ID, f"purchase-order-item:{order_no}:{position}")
+
+
+def purchase_order_row(seed: PurchaseOrderSeed, owner_member_id: UUID) -> dict:
+    return {
+        "id": purchase_order_id(seed.order_no),
+        "team_id": FILLED_TEAM_ID,
+        "order_no": seed.order_no,
+        "contract_id": contract_id(seed.contract_no),
+        "customer_company_id": company_id(seed.company_name),
+        "owner_member_id": owner_member_id,
+        "supplier_name": seed.supplier_name,
+        "stage_code": seed.stage_code,
+        "ordered_on": REFERENCE_DATE + timedelta(days=seed.ordered_day_offset),
+        "due_on": REFERENCE_DATE + timedelta(days=seed.due_day_offset),
+        "expected_receipt_on": REFERENCE_DATE + timedelta(days=seed.expected_receipt_day_offset),
+        "memo": seed.memo,
+        "deleted_at": None,
+    }
+
+
+def purchase_order_item_row(seed: PurchaseOrderSeed, position: int = 0) -> dict:
+    return {
+        "id": purchase_order_item_id(seed.order_no, position),
+        "order_id": purchase_order_id(seed.order_no),
+        "product_id": product_id(seed.product_name),
+        "quantity": seed.quantity,
+        "unit_price": seed.unit_price,
+        "position": position,
+    }
+
+
+def purchase_order_upsert(row: dict):
+    order_insert = insert(PurchaseOrder).values(**row)
+    update_fields = {
+        key: getattr(order_insert.excluded, key)
+        for key in row
+        if key not in {"id", "team_id", "order_no"}
+    }
+    return order_insert.on_conflict_do_update(
+        index_elements=[PurchaseOrder.id],
+        set_=update_fields,
+        where=and_(
+            PurchaseOrder.team_id == FILLED_TEAM_ID,
+            PurchaseOrder.order_no == row["order_no"],
+        ),
+    ).returning(PurchaseOrder.id)
+
+
+def purchase_order_item_upsert(row: dict):
+    item_insert = insert(PurchaseOrderItem).values(**row)
+    update_fields = {
+        key: getattr(item_insert.excluded, key)
+        for key in row
+        if key not in {"id", "order_id", "position"}
+    }
+    return item_insert.on_conflict_do_update(
+        index_elements=[PurchaseOrderItem.id],
+        set_=update_fields,
+        where=and_(
+            PurchaseOrderItem.order_id == row["order_id"],
+            PurchaseOrderItem.position == row["position"],
+        ),
+    ).returning(PurchaseOrderItem.id)
+
+
+async def seed_demo_orders() -> None:
+    expected_companies = {
+        company_id(seed.company_name): seed.company_name for seed in PURCHASE_ORDER_SEEDS
+    }
+    expected_products = {
+        product_id(seed.product_name): seed.product_name for seed in PURCHASE_ORDER_SEEDS
+    }
+    expected_contract_seeds = {contract_id(seed.contract_no): seed for seed in PURCHASE_ORDER_SEEDS}
+    expected_contract_ids_by_no = {
+        seed.contract_no: id_ for id_, seed in expected_contract_seeds.items()
+    }
+
+    async with get_sessionmaker()() as session, session.begin():
+        filled_team_name = (
+            await session.execute(
+                select(Team.name).where(Team.id == FILLED_TEAM_ID).with_for_update()
+            )
+        ).scalar_one_or_none()
+        if filled_team_name != FILLED_TEAM_NAME:
+            raise SystemExit("filled 인증 seed를 먼저 실행하세요.")
+
+        existing_companies = (
+            await session.execute(
+                select(CustomerCompany.id, CustomerCompany.team_id, CustomerCompany.name)
+                .where(
+                    or_(
+                        CustomerCompany.id.in_(expected_companies),
+                        and_(
+                            CustomerCompany.team_id == FILLED_TEAM_ID,
+                            CustomerCompany.name.in_(expected_companies.values()),
+                        ),
+                    )
+                )
+                .with_for_update()
+            )
+        ).all()
+        expected_company_ids_by_name = {name: id_ for id_, name in expected_companies.items()}
+        for row in existing_companies:
+            if (
+                row.team_id != FILLED_TEAM_ID
+                or expected_companies.get(row.id) != row.name
+                or expected_company_ids_by_name.get(row.name) != row.id
+            ):
+                raise SystemExit("합성 발주 고객사 ID, 이름 또는 팀이 충돌합니다.")
+        if {row.id for row in existing_companies} != set(expected_companies):
+            raise SystemExit("고객 seed를 먼저 실행해 발주 고객사를 준비하세요.")
+
+        existing_products = (
+            await session.execute(
+                select(Product.id, Product.team_id, Product.name, Product.active)
+                .where(
+                    or_(
+                        Product.id.in_(expected_products),
+                        and_(
+                            Product.team_id == FILLED_TEAM_ID,
+                            Product.name.in_(expected_products.values()),
+                        ),
+                    )
+                )
+                .with_for_update()
+            )
+        ).all()
+        expected_product_ids_by_name = {name: id_ for id_, name in expected_products.items()}
+        for row in existing_products:
+            if (
+                row.team_id != FILLED_TEAM_ID
+                or expected_products.get(row.id) != row.name
+                or expected_product_ids_by_name.get(row.name) != row.id
+                or not row.active
+            ):
+                raise SystemExit("합성 발주 상품 ID, 이름, 팀 또는 상태가 충돌합니다.")
+        if {row.id for row in existing_products} != set(expected_products):
+            raise SystemExit("일정 seed를 먼저 실행해 발주 상품을 준비하세요.")
+
+        existing_contracts = (
+            await session.execute(
+                select(
+                    Contract.id,
+                    Contract.team_id,
+                    Contract.contract_no,
+                    Contract.customer_company_id,
+                    Contract.product_id,
+                    Contract.owner_member_id,
+                    Contract.deleted_at,
+                )
+                .where(
+                    or_(
+                        Contract.id.in_(expected_contract_seeds),
+                        and_(
+                            Contract.team_id == FILLED_TEAM_ID,
+                            Contract.contract_no.in_(expected_contract_ids_by_no),
+                        ),
+                    )
+                )
+                .with_for_update()
+            )
+        ).all()
+        contracts_by_id = {row.id: row for row in existing_contracts}
+        for row in existing_contracts:
+            seed = expected_contract_seeds.get(row.id)
+            if (
+                seed is None
+                or row.team_id != FILLED_TEAM_ID
+                or row.contract_no != seed.contract_no
+                or expected_contract_ids_by_no.get(row.contract_no) != row.id
+                or row.customer_company_id != company_id(seed.company_name)
+                or row.product_id != product_id(seed.product_name)
+                or row.deleted_at is not None
+            ):
+                raise SystemExit("합성 발주 계약 ID, 번호, 고객사, 상품 또는 팀이 충돌합니다.")
+        if set(contracts_by_id) != set(expected_contract_seeds):
+            raise SystemExit("계약 seed를 먼저 실행해 발주 계약을 준비하세요.")
+
+        expected_owner_ids = {row.owner_member_id for row in existing_contracts}
+        existing_owners = (
+            await session.execute(
+                select(Member.id, Member.team_id, Member.active)
+                .where(Member.id.in_(expected_owner_ids))
+                .with_for_update()
+            )
+        ).all()
+        if {row.id for row in existing_owners} != expected_owner_ids or any(
+            row.team_id != FILLED_TEAM_ID or not row.active for row in existing_owners
+        ):
+            raise SystemExit("합성 발주 계약 담당자 ID, 팀 또는 상태가 충돌합니다.")
+
+        orders = tuple(
+            purchase_order_row(
+                seed,
+                contracts_by_id[contract_id(seed.contract_no)].owner_member_id,
+            )
+            for seed in PURCHASE_ORDER_SEEDS
+        )
+        items = tuple(purchase_order_item_row(seed) for seed in PURCHASE_ORDER_SEEDS)
+        expected_orders = {row["id"]: row for row in orders}
+        expected_order_ids_by_no = {row["order_no"]: row["id"] for row in orders}
+        expected_items = {row["id"]: row for row in items}
+        expected_item_ids_by_order_position = {
+            (row["order_id"], row["position"]): row["id"] for row in items
+        }
+
+        existing_orders = (
+            await session.execute(
+                select(PurchaseOrder.id, PurchaseOrder.team_id, PurchaseOrder.order_no)
+                .where(
+                    or_(
+                        PurchaseOrder.id.in_(expected_orders),
+                        and_(
+                            PurchaseOrder.team_id == FILLED_TEAM_ID,
+                            PurchaseOrder.order_no.in_(expected_order_ids_by_no),
+                        ),
+                    )
+                )
+                .with_for_update()
+            )
+        ).all()
+        for row in existing_orders:
+            expected = expected_orders.get(row.id)
+            if (
+                expected is None
+                or row.team_id != FILLED_TEAM_ID
+                or expected["order_no"] != row.order_no
+                or expected_order_ids_by_no.get(row.order_no) != row.id
+            ):
+                raise SystemExit("합성 발주 ID, 발주번호 또는 팀이 충돌합니다.")
+
+        existing_items = (
+            await session.execute(
+                select(
+                    PurchaseOrderItem.id,
+                    PurchaseOrderItem.order_id,
+                    PurchaseOrderItem.position,
+                )
+                .where(
+                    or_(
+                        PurchaseOrderItem.id.in_(expected_items),
+                        PurchaseOrderItem.order_id.in_(expected_orders),
+                    )
+                )
+                .with_for_update()
+            )
+        ).all()
+        for row in existing_items:
+            expected = expected_items.get(row.id)
+            if (
+                expected is None
+                or expected["order_id"] != row.order_id
+                or expected["position"] != row.position
+                or expected_item_ids_by_order_position.get((row.order_id, row.position)) != row.id
+            ):
+                raise SystemExit("합성 발주 품목 ID, 발주 또는 순서가 충돌합니다.")
+
+        for row in orders:
+            upserted_id = (await session.execute(purchase_order_upsert(row))).scalar_one_or_none()
+            if upserted_id is None:
+                raise SystemExit("합성 발주 ID, 발주번호 또는 팀이 충돌합니다.")
+
+        for row in items:
+            upserted_id = (
+                await session.execute(purchase_order_item_upsert(row))
+            ).scalar_one_or_none()
+            if upserted_id is None:
+                raise SystemExit("합성 발주 품목 ID, 발주 또는 순서가 충돌합니다.")
+
+    print("개발 DB의 filled 합성 팀에 발주 2건과 발주 품목 2건을 준비했습니다.")
+
+
+if __name__ == "__main__":
+    asyncio.run(seed_demo_orders())

--- a/backend/sql/README.md
+++ b/backend/sql/README.md
@@ -80,3 +80,12 @@ DEBUG=false uv run python -m scripts.seed_demo_activities
 cd backend
 DEBUG=false uv run python -m scripts.seed_demo_contracts
 ```
+
+발주 seed는 인증·고객·일정·계약 seed를 차례로 실행한 뒤 적용합니다. 데이터가 있는 팀에만
+현재 고객사·상품·계약 관계가 모두 정확한 합성 발주 2건과 품목 2건을 upsert합니다. 관계가
+누락되거나 불일치하는 나머지 프론트 목업 발주 3건은 넣지 않으며 비어 있는 팀은 건드리지 않습니다.
+
+```bash
+cd backend
+DEBUG=false uv run python -m scripts.seed_demo_orders
+```

--- a/backend/tests/test_orders.py
+++ b/backend/tests/test_orders.py
@@ -1,0 +1,664 @@
+from datetime import UTC, date, datetime
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from app.api.deps import get_current_member
+from app.core.config import settings
+from app.db.session import get_db
+from app.main import app
+from app.models.crm import CustomerCompany
+from app.models.sales import Contract, Product, PurchaseOrder, PurchaseOrderItem
+from app.models.workspace import Member
+from app.schemas.orders import OrderCreate, OrderMove, OrderPageParams, OrderPatch
+
+ORIGIN = settings.cors_origin_list[0]
+NOW = datetime(2026, 8, 17, 9, tzinfo=UTC)
+_MISSING = object()
+
+
+class _Scalars:
+    def __init__(self, values):
+        self.values = values
+
+    def all(self):
+        return self.values
+
+
+class _Result:
+    def __init__(self, *, scalar=_MISSING, rows=None, scalar_values=None):
+        self.scalar = scalar
+        self.rows = [] if rows is None else rows
+        self.scalar_values = [] if scalar_values is None else scalar_values
+
+    def scalar_one(self):
+        assert self.scalar is not _MISSING
+        return self.scalar
+
+    def scalar_one_or_none(self):
+        assert self.scalar is not _MISSING
+        return self.scalar
+
+    def one_or_none(self):
+        assert len(self.rows) <= 1
+        return self.rows[0] if self.rows else None
+
+    def all(self):
+        return self.rows
+
+    def scalars(self):
+        return _Scalars(self.scalar_values)
+
+
+class _Db:
+    def __init__(self, *results: _Result, flush_error: Exception | None = None):
+        self.results = list(results)
+        self.flush_error = flush_error
+        self.statements = []
+        self.added = []
+        self.flush_count = 0
+        self.commit_count = 0
+        self.rollback_count = 0
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        assert self.results
+        return self.results.pop(0)
+
+    def add(self, value):
+        self.added.append(value)
+
+    async def flush(self):
+        self.flush_count += 1
+        if self.flush_error is not None:
+            raise self.flush_error
+        for value in self.added:
+            if isinstance(value, PurchaseOrder):
+                value.created_at = value.created_at or NOW
+                value.updated_at = value.updated_at or NOW
+
+    async def commit(self):
+        self.commit_count += 1
+
+    async def rollback(self):
+        self.rollback_count += 1
+
+
+@pytest.fixture(autouse=True)
+def reset_dependency_overrides():
+    app.dependency_overrides.clear()
+    yield
+    app.dependency_overrides.clear()
+
+
+def _member(*, role: str = "member", team_id: UUID | None = None) -> Member:
+    return Member(
+        id=uuid4(),
+        team_id=team_id or uuid4(),
+        login_id=f"{uuid4()}@salesluv.demo",
+        password_hash="unused",
+        display_name="합성 영업 담당자",
+        role_code=role,
+        job_title="영업 담당자",
+        active=True,
+    )
+
+
+def _company(team_id: UUID, *, name: str = "합성 고객사") -> CustomerCompany:
+    return CustomerCompany(
+        id=uuid4(),
+        team_id=team_id,
+        name=name,
+        region_code="seoul",
+        created_at=NOW,
+    )
+
+
+def _product(team_id: UUID, *, name: str = "합성 상품", active: bool = True) -> Product:
+    return Product(id=uuid4(), team_id=team_id, name=name, active=active)
+
+
+def _contract(member: Member, company: CustomerCompany) -> Contract:
+    return Contract(
+        id=uuid4(),
+        team_id=member.team_id,
+        contract_no="FM-CT-2026-0020",
+        customer_company_id=company.id,
+        contact_id=None,
+        owner_member_id=member.id,
+        product_id=None,
+        stage_id=uuid4(),
+        title="합성 계약",
+        description=None,
+        contract_type="new_installation",
+        amount=10_000_000,
+        contract_date=date(2026, 8, 1),
+        ends_on=None,
+        warranty_terms=None,
+        expected_delivery_at=None,
+        memo=None,
+        position=0,
+        deleted_at=None,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _order(
+    member: Member,
+    company: CustomerCompany,
+    *,
+    contract: Contract | None = None,
+    stage_code: str = "order_received",
+) -> PurchaseOrder:
+    return PurchaseOrder(
+        id=uuid4(),
+        team_id=member.team_id,
+        order_no="SL-PO-2026-0001",
+        contract_id=None if contract is None else contract.id,
+        customer_company_id=company.id,
+        owner_member_id=member.id,
+        supplier_name="합성 공급처",
+        stage_code=stage_code,
+        ordered_on=date(2026, 8, 17),
+        due_on=date(2026, 8, 31),
+        expected_receipt_on=date(2026, 8, 30),
+        memo="합성 메모",
+        deleted_at=None,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _item(order: PurchaseOrder, product: Product, *, position: int = 0) -> PurchaseOrderItem:
+    return PurchaseOrderItem(
+        id=uuid4(),
+        order_id=order.id,
+        product_id=product.id,
+        quantity=position + 1,
+        unit_price=1_000_000,
+        position=position,
+    )
+
+
+def _row(
+    order: PurchaseOrder,
+    owner: Member,
+    company: CustomerCompany,
+    contract: Contract | None = None,
+):
+    return (
+        order,
+        owner.display_name,
+        company.name,
+        None if contract is None else contract.contract_no,
+    )
+
+
+def _client(db: _Db, member: Member) -> TestClient:
+    async def override_db():
+        yield db
+
+    async def override_member():
+        return member
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_member] = override_member
+    return TestClient(app)
+
+
+def _payload(company: CustomerCompany, product: Product, **overrides):
+    values = {
+        "customer_company_id": str(company.id),
+        "supplier_name": " 합성 공급처 ",
+        "stage_code": "order_received",
+        "ordered_on": "2026-08-17",
+        "due_on": "2026-08-31",
+        "expected_receipt_on": "2026-08-30",
+        "memo": " 합성 메모 ",
+        "items": [
+            {
+                "product_id": str(product.id),
+                "quantity": 2,
+                "unit_price": 1_000_000,
+            }
+        ],
+    }
+    return values | overrides
+
+
+def test_order_request_contract_is_strict_and_uses_six_stage_codes():
+    company_id = uuid4()
+    product_id = uuid4()
+    stages = (
+        "order_received",
+        "dispatch_request_completed",
+        "in_production",
+        "stock_received",
+        "delivered",
+        "cancelled",
+    )
+    parsed = tuple(
+        OrderMove(expected_stage_code="order_received", stage_code=stage).stage_code
+        for stage in stages
+    )
+    assert parsed == stages
+    assert OrderPatch(contract_id=None).model_dump(exclude_unset=True) == {"contract_id": None}
+    # ERD에 없는 날짜 선후 규칙은 API가 임의로 만들지 않는다.
+    assert OrderCreate(
+        customer_company_id=company_id,
+        supplier_name="공급처",
+        stage_code="order_received",
+        ordered_on="2026-08-17",
+        due_on="2026-08-16",
+        expected_receipt_on="2026-08-15",
+        items=[{"product_id": product_id, "quantity": 1, "unit_price": 0}],
+    )
+
+    with pytest.raises(ValidationError):
+        OrderCreate(
+            customer_company_id=company_id,
+            supplier_name="공급처",
+            stage_code="발주 접수",
+            ordered_on="2026-08-17",
+            due_on="2026-08-31",
+            expected_receipt_on="2026-08-30",
+            items=[{"product_id": product_id, "quantity": 1, "unit_price": 0}],
+        )
+    with pytest.raises(ValidationError):
+        OrderCreate(
+            customer_company_id=company_id,
+            supplier_name="공급처",
+            stage_code="order_received",
+            ordered_on="2026-08-17",
+            due_on="2026-08-31",
+            expected_receipt_on="2026-08-30",
+            items=[],
+        )
+    with pytest.raises(ValidationError):
+        OrderCreate(
+            customer_company_id=company_id,
+            supplier_name="공급처",
+            stage_code="order_received",
+            ordered_on="2026-08-17",
+            due_on="2026-08-31",
+            expected_receipt_on="2026-08-30",
+            items=[{"product_id": product_id, "quantity": 1.5, "unit_price": 0}],
+        )
+    with pytest.raises(ValidationError):
+        OrderPatch(stage_code="delivered")
+    with pytest.raises(ValidationError):
+        OrderPatch(items=None)
+    assert OrderPageParams(start_date="2026-08-17", end_date="2026-08-17")
+    with pytest.raises(ValidationError):
+        OrderPageParams(start_date="2026-08-18", end_date="2026-08-17")
+
+
+def test_member_order_list_and_detail_are_scoped_and_include_items():
+    member = _member()
+    company = _company(member.team_id)
+    product = _product(member.team_id)
+    contract = _contract(member, company)
+    order = _order(member, company, contract=contract)
+    item = _item(order, product)
+    list_db = _Db(
+        _Result(scalar=1),
+        _Result(rows=[_row(order, member, company, contract)]),
+        _Result(rows=[(item, product.name)]),
+    )
+
+    with _client(list_db, member) as client:
+        response = client.get(
+            "/api/orders",
+            params=[
+                ("q", " 합성 "),
+                ("supplier_name", order.supplier_name),
+                ("stage_code", "order_received"),
+                ("start_date", "2026-08-01"),
+                ("end_date", "2026-08-31"),
+            ],
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    assert data["items"][0] | {} == {
+        "id": str(order.id),
+        "order_no": order.order_no,
+        "contract_id": str(contract.id),
+        "contract_no": contract.contract_no,
+        "customer_company_id": str(company.id),
+        "customer_company_name": company.name,
+        "owner_member_id": str(member.id),
+        "owner_display_name": member.display_name,
+        "supplier_name": order.supplier_name,
+        "stage_code": order.stage_code,
+        "ordered_on": "2026-08-17",
+        "due_on": "2026-08-31",
+        "expected_receipt_on": "2026-08-30",
+        "memo": order.memo,
+        "items": [
+            {
+                "id": str(item.id),
+                "product_id": str(product.id),
+                "product_name": product.name,
+                "quantity": 1,
+                "unit_price": 1_000_000,
+                "position": 0,
+            }
+        ],
+        "created_at": "2026-08-17T18:00:00+09:00",
+        "updated_at": "2026-08-17T18:00:00+09:00",
+    }
+    for statement in list_db.statements[:2]:
+        sql = str(statement)
+        assert "purchase_order.deleted_at IS NULL" in sql
+        assert member.id in statement.compile().params.values()
+        assert member.team_id in statement.compile().params.values()
+        assert "%합성%" in statement.compile().params.values()
+        assert "EXISTS" in sql
+    assert "product.active" not in str(list_db.statements[2])
+
+    detail_db = _Db(
+        _Result(rows=[_row(order, member, company, contract)]),
+        _Result(rows=[(item, product.name)]),
+    )
+    with _client(detail_db, member) as client:
+        detail = client.get(f"/api/orders/{order.id}")
+    assert detail.status_code == 200
+    assert detail.json()["items"][0]["product_name"] == product.name
+
+
+def test_owner_filter_rules_and_cross_team_detail_are_hidden():
+    manager = _member(role="manager")
+    owner = _member(team_id=manager.team_id)
+    manager_db = _Db(
+        _Result(scalar_values=[owner.id]),
+        _Result(scalar=0),
+        _Result(rows=[]),
+    )
+    with _client(manager_db, manager) as client:
+        response = client.get("/api/orders", params={"owner_member_id": str(owner.id)})
+    assert response.status_code == 200
+    assert response.json()["items"] == []
+    assert [owner.id] in manager_db.statements[2].compile().params.values()
+
+    member = _member()
+    scope_db = _Db()
+    with _client(scope_db, member) as client:
+        denied = client.get("/api/orders", params={"owner_member_id": str(member.id)})
+    assert denied.status_code == 403
+    assert denied.json() == {"detail": "scope_not_allowed"}
+    assert not scope_db.statements
+
+    detail_db = _Db(_Result(rows=[]))
+    with _client(detail_db, member) as client:
+        hidden = client.get(f"/api/orders/{uuid4()}")
+    assert hidden.status_code == 404
+    assert hidden.json() == {"detail": "order_not_found"}
+
+
+def test_order_scope_hides_invalid_contracts_and_cross_team_items_without_hiding_inactive_items():
+    member = _member()
+
+    list_db = _Db(_Result(scalar=0), _Result(rows=[]))
+    with _client(list_db, member) as client:
+        listed = client.get("/api/orders")
+    assert listed.status_code == 200
+
+    detail_db = _Db(_Result(rows=[]))
+    with _client(detail_db, member) as client:
+        detail = client.get(f"/api/orders/{uuid4()}")
+    assert detail.status_code == 404
+
+    lock_db = _Db(_Result(scalar=None))
+    with _client(lock_db, member) as client:
+        locked = client.delete(
+            f"/api/orders/{uuid4()}",
+            headers={"Origin": ORIGIN},
+        )
+    assert locked.status_code == 404
+
+    for statement in [*list_db.statements, *detail_db.statements, *lock_db.statements]:
+        sql = str(statement)
+        assert "contract.deleted_at IS NULL" in sql or "contract_1.deleted_at IS NULL" in sql
+        assert "customer_company_id = public.purchase_order.customer_company_id" in sql
+        assert "owner_member_id = public.purchase_order.owner_member_id" in sql
+        assert "NOT (EXISTS" in sql
+        assert "product" in sql and "team_id !=" in sql
+        assert "product_1.active" not in sql
+
+
+def test_create_derives_owner_from_contract_and_assigns_server_number():
+    manager = _member(role="manager")
+    contract_owner = _member(team_id=manager.team_id)
+    company = _company(manager.team_id)
+    product = _product(manager.team_id)
+    contract = _contract(contract_owner, company)
+    db = _Db(
+        _Result(scalar=company),
+        _Result(rows=[(contract, contract_owner.display_name)]),
+        _Result(scalar_values=[product]),
+        _Result(scalar=manager.team_id),
+        _Result(
+            scalar_values=[
+                "FM-PO-2026-9999",
+                "SL-PO-2025-9999",
+                "SL-PO-2026-0003",
+                "SL-PO-2026-nope",
+                "SL-PO-2026-10000",
+            ]
+        ),
+    )
+
+    with _client(db, manager) as client:
+        response = client.post(
+            "/api/orders",
+            headers={"Origin": ORIGIN},
+            json=_payload(company, product, contract_id=str(contract.id)),
+        )
+
+    assert response.status_code == 201
+    item = response.json()
+    assert item["order_no"] == "SL-PO-2026-0004"
+    assert item["owner_member_id"] == str(contract_owner.id)
+    assert item["owner_display_name"] == contract_owner.display_name
+    assert item["contract_no"] == contract.contract_no
+    assert item["items"][0]["position"] == 0
+    assert response.headers["location"] == f"/api/orders/{item['id']}"
+    created_order = next(value for value in db.added if isinstance(value, PurchaseOrder))
+    assert created_order.team_id == manager.team_id
+    assert created_order.owner_member_id == contract_owner.id
+    assert len([value for value in db.added if isinstance(value, PurchaseOrderItem)]) == 1
+    assert "contract.deleted_at IS NULL" in str(db.statements[1])
+    assert "product.active IS true" in str(db.statements[2])
+    assert "FOR UPDATE" in str(db.statements[3])
+    assert "SL-PO-2026-%" in db.statements[4].compile().params.values()
+    assert db.flush_count == db.commit_count == 1
+    assert db.rollback_count == 0
+
+
+def test_create_without_contract_uses_current_member_and_rejects_company_mismatch():
+    member = _member()
+    company = _company(member.team_id)
+    product = _product(member.team_id)
+    db = _Db(
+        _Result(scalar=company),
+        _Result(scalar_values=[product]),
+        _Result(scalar=member.team_id),
+        _Result(scalar_values=[]),
+    )
+    with _client(db, member) as client:
+        response = client.post(
+            "/api/orders",
+            headers={"Origin": ORIGIN},
+            json=_payload(company, product),
+        )
+    assert response.status_code == 201
+    assert response.json()["owner_member_id"] == str(member.id)
+    assert response.json()["contract_id"] is None
+
+    other_company = _company(member.team_id, name="다른 합성 고객사")
+    contract = _contract(member, other_company)
+    mismatch_db = _Db(
+        _Result(scalar=company),
+        _Result(rows=[(contract, member.display_name)]),
+    )
+    with _client(mismatch_db, member) as client:
+        mismatch = client.post(
+            "/api/orders",
+            headers={"Origin": ORIGIN},
+            json=_payload(company, product, contract_id=str(contract.id)),
+        )
+    assert mismatch.status_code == 422
+    assert mismatch.json() == {"detail": "contract_company_mismatch"}
+    assert mismatch_db.commit_count == 0
+    assert mismatch_db.rollback_count == 1
+
+
+def test_patch_unlinks_contract_preserves_owner_and_replaces_items_atomically():
+    member = _member()
+    company = _company(member.team_id)
+    old_product = _product(member.team_id, name="기존 상품", active=False)
+    new_product = _product(member.team_id, name="새 상품")
+    contract = _contract(member, company)
+    order = _order(member, company, contract=contract)
+    replacement = _item(order, new_product)
+    db = _Db(
+        _Result(scalar=order),
+        _Result(scalar_values=[new_product]),
+        _Result(),
+        _Result(rows=[_row(order, member, company)]),
+        _Result(rows=[(replacement, new_product.name)]),
+    )
+
+    with _client(db, member) as client:
+        response = client.patch(
+            f"/api/orders/{order.id}",
+            headers={"Origin": ORIGIN},
+            json={
+                "contract_id": None,
+                "memo": None,
+                "items": [
+                    {
+                        "product_id": str(new_product.id),
+                        "quantity": 3,
+                        "unit_price": 2_000_000,
+                    }
+                ],
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["contract_id"] is None
+    assert response.json()["owner_member_id"] == str(member.id)
+    assert response.json()["memo"] is None
+    assert order.contract_id is None
+    assert order.owner_member_id == member.id
+    assert "DELETE FROM public.purchase_order_item" in str(db.statements[2])
+    added_item = next(value for value in db.added if isinstance(value, PurchaseOrderItem))
+    added_values = (
+        added_item.product_id,
+        added_item.quantity,
+        added_item.unit_price,
+        added_item.position,
+    )
+    assert added_values == (
+        new_product.id,
+        3,
+        2_000_000,
+        0,
+    )
+    assert db.flush_count == db.commit_count == 1
+    assert db.rollback_count == 0
+    # 읽기에서는 과거 비활성 상품도 제외하지 않는다.
+    assert old_product.active is False
+    assert "product.active" not in str(db.statements[4])
+
+    failing_order = _order(member, company)
+    failing_db = _Db(
+        _Result(scalar=failing_order),
+        _Result(scalar_values=[new_product]),
+        _Result(),
+        flush_error=RuntimeError("synthetic failure"),
+    )
+    with (
+        _client(failing_db, member) as client,
+        pytest.raises(RuntimeError, match="synthetic failure"),
+    ):
+        client.patch(
+            f"/api/orders/{failing_order.id}",
+            headers={"Origin": ORIGIN},
+            json={
+                "items": [
+                    {
+                        "product_id": str(new_product.id),
+                        "quantity": 1,
+                        "unit_price": 0,
+                    }
+                ]
+            },
+        )
+    assert failing_db.commit_count == 0
+    assert failing_db.rollback_count == 1
+
+
+def test_move_uses_stale_guard_and_delete_is_soft():
+    member = _member()
+    company = _company(member.team_id)
+    product = _product(member.team_id)
+    order = _order(member, company)
+    item = _item(order, product)
+    move_db = _Db(
+        _Result(scalar=order),
+        _Result(rows=[_row(order, member, company)]),
+        _Result(rows=[(item, product.name)]),
+    )
+    with _client(move_db, member) as client:
+        moved = client.post(
+            f"/api/orders/{order.id}/move",
+            headers={"Origin": ORIGIN},
+            json={
+                "expected_stage_code": "order_received",
+                "stage_code": "delivered",
+            },
+        )
+    assert moved.status_code == 200
+    assert moved.json()["stage_code"] == "delivered"
+    assert order.stage_code == "delivered"
+    assert "FOR UPDATE" in str(move_db.statements[0])
+    assert move_db.flush_count == move_db.commit_count == 1
+
+    stale_order = _order(member, company, stage_code="in_production")
+    stale_db = _Db(_Result(scalar=stale_order))
+    with _client(stale_db, member) as client:
+        conflict = client.post(
+            f"/api/orders/{stale_order.id}/move",
+            headers={"Origin": ORIGIN},
+            json={
+                "expected_stage_code": "order_received",
+                "stage_code": "stock_received",
+            },
+        )
+    assert conflict.status_code == 409
+    assert conflict.json() == {"detail": "invalid_state_transition"}
+    assert stale_db.flush_count == stale_db.commit_count == 0
+    assert stale_db.rollback_count == 1
+
+    delete_db = _Db(_Result(scalar=order))
+    with _client(delete_db, member) as client:
+        deleted = client.delete(
+            f"/api/orders/{order.id}",
+            headers={"Origin": ORIGIN},
+        )
+    assert deleted.status_code == 204
+    assert deleted.content == b""
+    assert order.deleted_at is not None
+    assert order.updated_at == order.deleted_at
+    assert all(
+        not str(statement).startswith("DELETE FROM public.purchase_order_item")
+        for statement in delete_db.statements
+    )
+    assert delete_db.flush_count == delete_db.commit_count == 1

--- a/backend/tests/test_seed_demo_orders.py
+++ b/backend/tests/test_seed_demo_orders.py
@@ -1,0 +1,143 @@
+from datetime import date
+from uuid import uuid5
+
+from sqlalchemy.dialects import postgresql
+
+from scripts.seed_demo_activities import REFERENCE_DATE, product_id
+from scripts.seed_demo_auth import EMPTY_TEAM_ID, FILLED_TEAM_ID
+from scripts.seed_demo_contracts import contract_id
+from scripts.seed_demo_customers import OWNER_IDS, company_id
+from scripts.seed_demo_orders import (
+    PURCHASE_ORDER_SEEDS,
+    purchase_order_id,
+    purchase_order_item_id,
+    purchase_order_item_row,
+    purchase_order_item_upsert,
+    purchase_order_row,
+    purchase_order_upsert,
+)
+
+
+def test_demo_order_seed_shape_is_fixed_and_lossless():
+    owner_by_contract = {
+        contract_id("FM-CT-2026-0020"): OWNER_IDS["김지훈"],
+        contract_id("FM-CT-2026-0013"): OWNER_IDS["김지훈"],
+    }
+    order_rows = {
+        seed.order_no: purchase_order_row(
+            seed,
+            owner_by_contract[contract_id(seed.contract_no)],
+        )
+        for seed in PURCHASE_ORDER_SEEDS
+    }
+    item_rows = {seed.order_no: purchase_order_item_row(seed) for seed in PURCHASE_ORDER_SEEDS}
+
+    assert REFERENCE_DATE == date(2026, 8, 17)
+    assert [seed.order_no for seed in PURCHASE_ORDER_SEEDS] == [
+        "FM-PO-2026-0020",
+        "FM-PO-2026-0019",
+    ]
+    assert len(order_rows) == len(item_rows) == len(PURCHASE_ORDER_SEEDS) == 2
+    assert len({row["id"] for row in order_rows.values()}) == 2
+    assert len({row["id"] for row in item_rows.values()}) == 2
+    assert all(row["team_id"] == FILLED_TEAM_ID != EMPTY_TEAM_ID for row in order_rows.values())
+
+    for seed in PURCHASE_ORDER_SEEDS:
+        order = order_rows[seed.order_no]
+        item = item_rows[seed.order_no]
+        assert (
+            order["id"]
+            == purchase_order_id(seed.order_no)
+            == uuid5(FILLED_TEAM_ID, f"purchase-order:{seed.order_no}")
+        )
+        assert (
+            item["id"]
+            == purchase_order_item_id(seed.order_no, 0)
+            == uuid5(FILLED_TEAM_ID, f"purchase-order-item:{seed.order_no}:0")
+        )
+        assert order["contract_id"] == contract_id(seed.contract_no)
+        assert order["customer_company_id"] == company_id(seed.company_name)
+        assert order["owner_member_id"] == owner_by_contract[order["contract_id"]]
+        assert order["deleted_at"] is None
+        assert item == {
+            "id": purchase_order_item_id(seed.order_no, 0),
+            "order_id": purchase_order_id(seed.order_no),
+            "product_id": product_id(seed.product_name),
+            "quantity": seed.quantity,
+            "unit_price": seed.unit_price,
+            "position": 0,
+        }
+
+    assert order_rows["FM-PO-2026-0020"] | {
+        "product_id": item_rows["FM-PO-2026-0020"]["product_id"],
+        "quantity": item_rows["FM-PO-2026-0020"]["quantity"],
+        "unit_price": item_rows["FM-PO-2026-0020"]["unit_price"],
+    } == {
+        "id": purchase_order_id("FM-PO-2026-0020"),
+        "team_id": FILLED_TEAM_ID,
+        "order_no": "FM-PO-2026-0020",
+        "contract_id": contract_id("FM-CT-2026-0020"),
+        "customer_company_id": company_id("한빛대학교병원"),
+        "owner_member_id": OWNER_IDS["김지훈"],
+        "supplier_name": "본사 생산팀",
+        "stage_code": "in_production",
+        "ordered_on": date(2026, 8, 4),
+        "due_on": date(2026, 8, 23),
+        "expected_receipt_on": date(2026, 8, 23),
+        "memo": "분할 납품 1차",
+        "deleted_at": None,
+        "product_id": product_id("CardioView X7"),
+        "quantity": 2,
+        "unit_price": 24_000_000,
+    }
+    assert order_rows["FM-PO-2026-0019"] | {
+        "product_id": item_rows["FM-PO-2026-0019"]["product_id"],
+        "quantity": item_rows["FM-PO-2026-0019"]["quantity"],
+        "unit_price": item_rows["FM-PO-2026-0019"]["unit_price"],
+    } == {
+        "id": purchase_order_id("FM-PO-2026-0019"),
+        "team_id": FILLED_TEAM_ID,
+        "order_no": "FM-PO-2026-0019",
+        "contract_id": contract_id("FM-CT-2026-0013"),
+        "customer_company_id": company_id("서림메디컬센터"),
+        "owner_member_id": OWNER_IDS["김지훈"],
+        "supplier_name": "외부 벤더 (메디파츠)",
+        "stage_code": "delivered",
+        "ordered_on": date(2026, 7, 27),
+        "due_on": date(2026, 8, 10),
+        "expected_receipt_on": date(2026, 8, 9),
+        "memo": None,
+        "deleted_at": None,
+        "product_id": product_id("OrthoScan Mini"),
+        "quantity": 3,
+        "unit_price": 8_600_000,
+    }
+
+
+def test_demo_order_rows_and_upserts_are_idempotent_and_filled_only():
+    owner_id = OWNER_IDS["김지훈"]
+    first_orders = tuple(purchase_order_row(seed, owner_id) for seed in PURCHASE_ORDER_SEEDS)
+    second_orders = tuple(purchase_order_row(seed, owner_id) for seed in PURCHASE_ORDER_SEEDS)
+    first_items = tuple(purchase_order_item_row(seed) for seed in PURCHASE_ORDER_SEEDS)
+    second_items = tuple(purchase_order_item_row(seed) for seed in PURCHASE_ORDER_SEEDS)
+
+    assert first_orders == second_orders
+    assert first_items == second_items
+    assert all(row["team_id"] == FILLED_TEAM_ID for row in first_orders)
+    assert all(row["team_id"] != EMPTY_TEAM_ID for row in first_orders)
+    assert {row["order_id"] for row in first_items} == {row["id"] for row in first_orders}
+
+    dialect = postgresql.dialect()
+    for row in first_orders:
+        sql = str(purchase_order_upsert(row).compile(dialect=dialect))
+        assert "ON CONFLICT (id) DO UPDATE" in sql
+        assert "RETURNING public.purchase_order.id" in sql
+        assert "team_id = excluded.team_id" not in sql
+        assert "order_no = excluded.order_no" not in sql
+
+    for row in first_items:
+        sql = str(purchase_order_item_upsert(row).compile(dialect=dialect))
+        assert "ON CONFLICT (id) DO UPDATE" in sql
+        assert "RETURNING public.purchase_order_item.id" in sql
+        assert "order_id = excluded.order_id" not in sql
+        assert "position = excluded.position" not in sql

--- a/frontend/src/components/layout/Topbar/Topbar.tsx
+++ b/frontend/src/components/layout/Topbar/Topbar.tsx
@@ -31,6 +31,7 @@ export default function Topbar() {
 
   const pageLabel = findNavLabel(pathname) ?? '페이지를 찾을 수 없음'
   const isVisits = pathname === ROUTES.VISITS || pathname.startsWith(`${ROUTES.VISITS}/`)
+  const isOrders = pathname === ROUTES.ORDERS || pathname.startsWith(`${ROUTES.ORDERS}/`)
 
   return (
     <header className={styles.topbar}>
@@ -52,11 +53,15 @@ export default function Topbar() {
       <div className={styles.spacer} />
 
       {/* 실제 팀원 UUID 목록이 붙기 전까지 DB 화면에는 목업 담당자 필터를 노출하지 않습니다. */}
-      {isManager && pathname !== ROUTES.CUSTOMERS && pathname !== ROUTES.CALENDAR && !isVisits && (
-        <div className={styles.scope}>
-          <ScopeSwitcher />
-        </div>
-      )}
+      {isManager &&
+        pathname !== ROUTES.CUSTOMERS &&
+        pathname !== ROUTES.CALENDAR &&
+        !isVisits &&
+        !isOrders && (
+          <div className={styles.scope}>
+            <ScopeSwitcher />
+          </div>
+        )}
 
       {/* 알림은 화면 하나입니다. 벨은 그리로 가는 통로일 뿐이라 점만 얹습니다. */}
       <Link

--- a/frontend/src/pages/Orders/Detail.tsx
+++ b/frontend/src/pages/Orders/Detail.tsx
@@ -6,7 +6,7 @@ import { Link, useNavigate, useParams } from 'react-router'
 import Button from '@/components/Button'
 import Modal from '@/components/Modal'
 import { ChevronLeftIcon } from '@/components/icons'
-import { ROUTES, contractPath, orderPath } from '@/constants/routes'
+import { ROUTES, orderPath } from '@/constants/routes'
 import { isLate, orderItemLabel, orderTotal } from '@/shared/orders'
 import type { OrderStatus } from '@/types'
 import { fmtDot, fmtDotShort, parseISO } from '@/utils/date'
@@ -21,12 +21,50 @@ import styles from './Detail.module.scss'
 export default function OrderDetail() {
   const { orderNo = '' } = useParams()
   const navigate = useNavigate()
-  const { orders, findOrder, updateOrder, setStatus, removeOrder } = useOrderList()
+  const {
+    orders,
+    companies,
+    contracts,
+    products,
+    suppliers,
+    loading,
+    error,
+    reload,
+    detail,
+    detailLoading,
+    detailError,
+    reloadDetail,
+    mutationError,
+    isPending,
+    findOrderByNo,
+    updateOrder,
+    setStatus,
+    removeOrder,
+  } = useOrderList(orderNo)
 
   const [editing, setEditing] = useState(false)
   const [deleting, setDeleting] = useState(false)
 
-  const order = findOrder(orderNo)
+  const order = detail ?? findOrderByNo(orderNo)
+
+  if ((loading || detailLoading) && !order) {
+    return (
+      <section className={styles.missing} role="status">
+        <h1>발주를 불러오는 중입니다.</h1>
+      </section>
+    )
+  }
+
+  if (error || detailError) {
+    return (
+      <section className={styles.missing} role="alert">
+        <h1>{detailError ?? error}</h1>
+        <Button variant="outline" onClick={detailError ? reloadDetail : reload}>
+          다시 시도
+        </Button>
+      </section>
+    )
+  }
 
   if (!order) {
     return (
@@ -47,7 +85,7 @@ export default function OrderDetail() {
     .slice(0, 8)
 
   return (
-    <section className={styles.page}>
+    <section className={styles.page} aria-busy={detailLoading || isPending(order.id)}>
       <Link className={styles.back} to={ROUTES.ORDERS}>
         <ChevronLeftIcon />
         발주 관리
@@ -69,7 +107,12 @@ export default function OrderDetail() {
           <select
             className={styles.select}
             value={order.status}
-            onChange={(event) => setStatus(order.no, event.target.value as OrderStatus)}
+            disabled={isPending(order.id)}
+            onChange={(event) => {
+              const next = event.target.value as OrderStatus
+              if (next !== order.status)
+                void setStatus(order.id, order.status, next).catch(() => undefined)
+            }}
           >
             {ORDER_STATUSES.map((status) => (
               <option key={status}>{status}</option>
@@ -77,10 +120,20 @@ export default function OrderDetail() {
           </select>
         </label>
 
-        <Button type="button" variant="outline" onClick={() => setEditing(true)}>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={isPending(order.id)}
+          onClick={() => setEditing(true)}
+        >
           수정
         </Button>
-        <Button type="button" variant="ghost" onClick={() => setDeleting(true)}>
+        <Button
+          type="button"
+          variant="ghost"
+          disabled={isPending(order.id)}
+          onClick={() => setDeleting(true)}
+        >
           삭제
         </Button>
       </div>
@@ -98,7 +151,10 @@ export default function OrderDetail() {
           <dt>계약</dt>
           <dd>
             {order.contract ? (
-              <Link className={styles.link} to={contractPath(order.contract)}>
+              <Link
+                className={styles.link}
+                to={`${ROUTES.VISITS}?q=${encodeURIComponent(order.contract)}`}
+              >
                 {order.contract}
               </Link>
             ) : (
@@ -129,7 +185,7 @@ export default function OrderDetail() {
         <h2 className={styles.blockTitle}>품목</h2>
         <ul className={styles.items}>
           {order.items.map((item) => (
-            <li key={item.product} className={styles.item}>
+            <li key={item.id} className={styles.item}>
               <span className={styles.itemProduct}>{item.product}</span>
               {/* 소모품은 단가가 몇만 원이라 요약 표기로는 ₩0.0M 이 됩니다. */}
               <span className={`${styles.itemQty} tnum`}>
@@ -166,9 +222,14 @@ export default function OrderDetail() {
       {editing && (
         <OrderForm
           order={order}
+          companies={companies}
+          contracts={contracts}
+          products={products}
+          suppliers={suppliers}
+          optionsLoading={loading}
           onClose={() => setEditing(false)}
-          onSubmit={(draft) => {
-            updateOrder(order.no, draft)
+          onSubmit={async (draft) => {
+            await updateOrder(order.id, draft)
             setEditing(false)
           }}
         />
@@ -178,21 +239,27 @@ export default function OrderDetail() {
         <Modal
           title="발주를 삭제할까요?"
           description={`${order.no} · ${order.hospital}. 되돌릴 수 없습니다.`}
-          onClose={() => setDeleting(false)}
+          onClose={isPending(order.id) ? () => {} : () => setDeleting(false)}
           footer={
             <>
-              <Button type="button" variant="outline" onClick={() => setDeleting(false)}>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={isPending(order.id)}
+                onClick={() => setDeleting(false)}
+              >
                 취소
               </Button>
               <Button
                 type="button"
+                disabled={isPending(order.id)}
                 onClick={() => {
-                  removeOrder(order.no)
-                  // 지운 발주의 상세에 머물면 "찾을 수 없습니다" 만 보입니다.
-                  navigate(ROUTES.ORDERS, { replace: true })
+                  void removeOrder(order.id)
+                    .then(() => navigate(ROUTES.ORDERS, { replace: true }))
+                    .catch(() => undefined)
                 }}
               >
-                삭제
+                {isPending(order.id) ? '삭제 중…' : '삭제'}
               </Button>
             </>
           }
@@ -200,8 +267,11 @@ export default function OrderDetail() {
           <p className={styles.empty}>
             {orderItemLabel(order)} · {order.supplier}
           </p>
+          {mutationError && <p role="alert">{mutationError}</p>}
         </Modal>
       )}
+
+      {mutationError && !deleting && <p role="alert">{mutationError}</p>}
     </section>
   )
 }

--- a/frontend/src/pages/Orders/New.tsx
+++ b/frontend/src/pages/Orders/New.tsx
@@ -1,7 +1,7 @@
 // 발주 추가 화면입니다. 목록에서 "발주 추가"로 들어옵니다.
 //
 // 품목 줄이 몇 개까지 늘어날지 모르므로 모달이 아니라 화면 하나를 씁니다.
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router'
 
 import Button from '@/components/Button'
@@ -23,7 +23,17 @@ import useOrderList from './useOrderList'
 import styles from './New.module.scss'
 
 export default function New() {
-  const { addOrder } = useOrderList()
+  const {
+    companies,
+    contracts,
+    products,
+    suppliers,
+    loading,
+    error,
+    reload,
+    isCreating,
+    addOrder,
+  } = useOrderList()
   const navigate = useNavigate()
   const [params] = useSearchParams()
 
@@ -34,20 +44,30 @@ export default function New() {
     return (ORDER_STATUSES as string[]).includes(wanted) ? { ...base, status: wanted } : base
   })
   const [errors, setErrors] = useState<FormErrors>({})
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const submittingRef = useRef(false)
 
   const set = (key: Exclude<keyof FormState, 'items'>, value: string) =>
     setForm((prev) => ({ ...prev, [key]: value }))
 
   const setItems = (items: ItemState[]) => setForm((prev) => ({ ...prev, items }))
 
-  const submit = () => {
+  const submit = async () => {
+    if (submittingRef.current) return
     const found = validate(form)
     setErrors(found)
     if (Object.keys(found).length > 0) return
 
-    addOrder(toDraft(form))
-    // 새 발주는 맨 위에 들어갑니다. 목록으로 돌아가면 바로 보입니다.
-    navigate(ROUTES.ORDERS)
+    submittingRef.current = true
+    setSubmitError(null)
+    try {
+      await addOrder(toDraft(form))
+      navigate(ROUTES.ORDERS)
+    } catch (caught) {
+      setSubmitError(caught instanceof Error ? caught.message : '발주를 등록하지 못했습니다.')
+    } finally {
+      submittingRef.current = false
+    }
   }
 
   return (
@@ -66,7 +86,7 @@ export default function New() {
         noValidate
         onSubmit={(event) => {
           event.preventDefault()
-          submit()
+          void submit()
         }}
       >
         <div className={styles.panelHead}>
@@ -74,13 +94,51 @@ export default function New() {
           <p>발주번호는 저장할 때 자동으로 매깁니다.</p>
         </div>
 
-        <OrderFields form={form} errors={errors} onChange={set} onItemsChange={setItems} />
+        {error ? (
+          <div role="alert">
+            <p>{error}</p>
+            <Button type="button" variant="outline" onClick={reload}>
+              다시 시도
+            </Button>
+          </div>
+        ) : (
+          <OrderFields
+            form={form}
+            errors={errors}
+            companies={companies}
+            contracts={contracts}
+            products={products}
+            suppliers={suppliers}
+            optionsLoading={loading}
+            disabled={isCreating}
+            onChange={set}
+            onItemsChange={setItems}
+          />
+        )}
+
+        {submitError && <p role="alert">{submitError}</p>}
 
         <div className={styles.actions}>
-          <Button type="button" variant="outline" onClick={() => navigate(ROUTES.ORDERS)}>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={isCreating}
+            onClick={() => navigate(ROUTES.ORDERS)}
+          >
             취소
           </Button>
-          <Button type="submit">발주 추가</Button>
+          <Button
+            type="submit"
+            disabled={
+              isCreating ||
+              loading ||
+              error !== null ||
+              companies.length === 0 ||
+              products.length === 0
+            }
+          >
+            {isCreating ? '등록 중…' : '발주 추가'}
+          </Button>
         </div>
       </form>
     </section>

--- a/frontend/src/pages/Orders/Orders.tsx
+++ b/frontend/src/pages/Orders/Orders.tsx
@@ -6,6 +6,7 @@
 import { useCallback, useDeferredValue, useMemo, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router'
 
+import { useCurrentUser } from '@/auth/sessionContext'
 import Button from '@/components/Button'
 import DataTable, { compareBy, type SortState } from '@/components/DataTable'
 import FilterSelect from '@/components/FilterSelect'
@@ -18,14 +19,13 @@ import StageChip from '@/components/StageChip'
 import StageTabs from '@/components/StageTabs'
 import { orderNewPath, orderPath } from '@/constants/routes'
 import { isLate, orderItemLabel, orderTotal } from '@/shared/orders'
-import type { OrderStatus, PurchaseOrder } from '@/types'
-import { useOwnerScope } from '@/scope/scopeContext'
+import type { ApiPurchaseOrder, OrderStatus } from '@/types'
 import { addDays, fmtDotShort, iso, parseISO, TODAY } from '@/utils/date'
 import { won } from '@/utils/format'
 
 import { ORDER_COLUMNS } from './columns'
 import OrderForm from './components/OrderForm'
-import { ORDER_STAGES, ownerOfOrder, SUPPLIERS, TONE_OF } from './pipeline'
+import { ORDER_STAGES, TONE_OF } from './pipeline'
 import useOrderList from './useOrderList'
 
 import styles from '@/pages/listPage.module.scss'
@@ -38,18 +38,28 @@ const RANGES = [
   { value: '0', label: '전체' },
 ]
 
-const SUPPLIER_OPTIONS = [
-  { value: '', label: '공급처 전체' },
-  ...SUPPLIERS.map((name) => ({ value: name, label: name })),
-]
-
 /** 기본 기간. 발주일 기준입니다. */
 const DEFAULT_RANGE = '6'
 
 export default function Orders() {
-  const { orders, findOrder, updateOrder, removeOrder } = useOrderList()
+  const {
+    orders,
+    companies,
+    contracts,
+    products,
+    suppliers,
+    loading,
+    error,
+    reload,
+    mutationError,
+    clearMutationError,
+    isPending,
+    findOrderById,
+    updateOrder,
+    removeOrder,
+  } = useOrderList()
   const navigate = useNavigate()
-  const { matchesOwner, isTeamView } = useOwnerScope()
+  const { isManager } = useCurrentUser()
 
   const [params, setParams] = useSearchParams()
   const query = params.get('q') ?? ''
@@ -63,15 +73,23 @@ export default function Orders() {
   const [sort, setSort] = useState<SortState>(null)
   const [page, setPage] = useState(1)
   const [pageSize, setPageSize] = useState(25)
-  const [openNo, setOpenNo] = useState<string | null>(null)
-  const [editingNo, setEditingNo] = useState<string | null>(null)
-  const [deletingNo, setDeletingNo] = useState<string | null>(null)
+  const [openId, setOpenId] = useState<string | null>(null)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
   const [openFilter, setOpenFilter] = useState<'supplier' | 'range' | null>(null)
 
   // 한 사람만 보고 있으면 담당 영업 열은 모든 줄이 같은 값이라 자리만 차지합니다.
   const columns = useMemo(
-    () => ORDER_COLUMNS.filter((col) => col.id !== 'owner' || isTeamView),
-    [isTeamView],
+    () => ORDER_COLUMNS.filter((col) => col.id !== 'owner' || isManager),
+    [isManager],
+  )
+
+  const supplierOptions = useMemo(
+    () => [
+      { value: '', label: '공급처 전체' },
+      ...suppliers.map((name) => ({ value: name, label: name })),
+    ],
+    [suppliers],
   )
 
   // 기본값은 쿼리에서 지웁니다. 주소를 복사했을 때 조건이 그대로 살아나되 짧게 남습니다.
@@ -97,9 +115,6 @@ export default function Orders() {
   const beforeStatus = useMemo(() => {
     const needle = deferredQuery.trim().toLowerCase()
     return orders.filter((order) => {
-      // 계약 없는 선발주는 담당자를 알 수 없어 팀 전체에서만 보입니다.
-      const owner = ownerOfOrder(order)
-      if (owner === undefined ? !isTeamView : !matchesOwner(owner)) return false
       if (supplier !== '' && order.supplier !== supplier) return false
       if (fromISO !== null && order.ordered < fromISO) return false
       if (needle === '') return true
@@ -109,7 +124,7 @@ export default function Orders() {
         .toLowerCase()
         .includes(needle)
     })
-  }, [orders, matchesOwner, isTeamView, supplier, fromISO, deferredQuery])
+  }, [orders, supplier, fromISO, deferredQuery])
 
   const statusCounts = useMemo(() => {
     const map = new Map<OrderStatus, number>()
@@ -149,15 +164,16 @@ export default function Orders() {
 
   // 객체가 아니라 발주번호를 들고 목록에서 찾습니다. 열어 둔 발주를 지우면
   // 여기가 비면서 드로어가 알아서 닫힙니다.
-  const openOrder = openNo ? findOrder(openNo) : undefined
-  const editingOrder = editingNo ? findOrder(editingNo) : undefined
-  const deletingOrder = deletingNo ? findOrder(deletingNo) : undefined
+  const openOrder = openId ? findOrderById(openId) : undefined
+  const editingOrder = editingId ? findOrderById(editingId) : undefined
+  const deletingOrder = deletingId ? findOrderById(deletingId) : undefined
+  const isDeleting = deletingOrder ? isPending(deletingOrder.id) : false
 
   const isFiltered =
     query.trim() !== '' || supplier !== '' || status !== '' || range !== DEFAULT_RANGE
 
   return (
-    <section className={styles.page}>
+    <section className={styles.page} aria-busy={loading}>
       {/* Topbar 빵부스러기가 이미 화면 이름을 말하므로 제목은 읽어 주기만 합니다. */}
       <h1 className="sr-only">발주 관리</h1>
 
@@ -173,7 +189,7 @@ export default function Orders() {
         <FilterSelect
           label="공급처"
           value={supplier}
-          options={SUPPLIER_OPTIONS}
+          options={supplierOptions}
           open={openFilter === 'supplier'}
           onOpenChange={(open) => setOpenFilter(open ? 'supplier' : null)}
           onChange={(value) => setParam('supplier', value)}
@@ -189,7 +205,7 @@ export default function Orders() {
         />
 
         <div className={styles.actions}>
-          <Button onClick={() => navigate(orderNewPath(status || undefined))}>
+          <Button disabled={loading} onClick={() => navigate(orderNewPath(status || undefined))}>
             <PlusIcon width={15} height={15} />
             발주 추가
           </Button>
@@ -205,64 +221,89 @@ export default function Orders() {
         onChange={(next) => setParam('status', next)}
       />
 
-      <DataTable
-        rows={pageRows}
-        columns={columns}
-        rowKey={(order) => order.no}
-        handleColumn="hospital"
-        sort={sort}
-        onSort={onSort}
-        onOpen={(order) => setOpenNo(order.no)}
-        caption="발주 목록. 헤더를 눌러 정렬할 수 있습니다."
-        renderCell={(id, order) => {
-          if (id === 'status') return statusChip(order)
-          // 납기를 넘긴 건은 여기서 바로 알아야 해서 지연 일수를 납기 옆에 붙입니다.
-          if (id !== 'due' || !isLate(order)) return undefined
-          return (
-            <span className={styles.late}>
-              {fmtDotShort(parseISO(order.due))}
-              <i>{lateLabel(order)}</i>
-            </span>
-          )
-        }}
-        mini={(order) => ({
-          title: order.hospital,
-          badge: statusChip(order),
-          sub: orderItemLabel(order),
-          meta: [
-            <span key="m1" className="tnum">
-              {won(orderTotal(order))}
-            </span>,
-            <span key="m2" className="tnum">
-              납기 {fmtDotShort(parseISO(order.due))}
-            </span>,
-            isLate(order) ? (
-              <i key="m3" className={styles.lateOnly}>
-                {lateLabel(order)}
-              </i>
+      {mutationError && !deletingOrder && (
+        <div role="alert">
+          <p>{mutationError}</p>
+          <Button
+            variant="outline"
+            onClick={() => {
+              clearMutationError()
+              reload()
+            }}
+          >
+            목록 새로고침
+          </Button>
+        </div>
+      )}
+
+      {error ? (
+        <div role="alert">
+          <p>{error}</p>
+          <Button variant="outline" onClick={reload}>
+            다시 시도
+          </Button>
+        </div>
+      ) : loading && orders.length === 0 ? (
+        <p role="status">발주 목록을 불러오는 중입니다.</p>
+      ) : (
+        <DataTable
+          rows={pageRows}
+          columns={columns}
+          rowKey={(order) => order.id}
+          handleColumn="hospital"
+          sort={sort}
+          onSort={onSort}
+          onOpen={(order) => setOpenId(order.id)}
+          caption="발주 목록. 헤더를 눌러 정렬할 수 있습니다."
+          renderCell={(id, order) => {
+            if (id === 'status') return statusChip(order)
+            if (id !== 'due' || !isLate(order)) return undefined
+            return (
+              <span className={styles.late}>
+                {fmtDotShort(parseISO(order.due))}
+                <i>{lateLabel(order)}</i>
+              </span>
+            )
+          }}
+          mini={(order) => ({
+            title: order.hospital,
+            badge: statusChip(order),
+            sub: orderItemLabel(order),
+            meta: [
+              <span key="m1" className="tnum">
+                {won(orderTotal(order))}
+              </span>,
+              <span key="m2" className="tnum">
+                납기 {fmtDotShort(parseISO(order.due))}
+              </span>,
+              isLate(order) ? (
+                <i key="m3" className={styles.lateOnly}>
+                  {lateLabel(order)}
+                </i>
+              ) : (
+                order.supplier
+              ),
+            ],
+          })}
+          empty={
+            isFiltered ? (
+              <>
+                <SearchIcon width={34} height={34} strokeWidth={1.5} />
+                <p>조건에 맞는 발주가 없습니다.</p>
+                <Button variant="outline" onClick={clearFilters}>
+                  검색·필터 초기화
+                </Button>
+              </>
             ) : (
-              order.supplier
-            ),
-          ],
-        })}
-        empty={
-          isFiltered ? (
-            <>
-              <SearchIcon width={34} height={34} strokeWidth={1.5} />
-              <p>조건에 맞는 발주가 없습니다.</p>
-              <Button variant="outline" onClick={clearFilters}>
-                검색·필터 초기화
-              </Button>
-            </>
-          ) : (
-            <>
-              <OrdersIcon width={34} height={34} strokeWidth={1.5} />
-              <p>아직 등록한 발주가 없습니다.</p>
-              <Button onClick={() => navigate(orderNewPath())}>발주 추가</Button>
-            </>
-          )
-        }
-      />
+              <>
+                <OrdersIcon width={34} height={34} strokeWidth={1.5} />
+                <p>아직 등록한 발주가 없습니다.</p>
+                <Button onClick={() => navigate(orderNewPath())}>발주 추가</Button>
+              </>
+            )
+          }
+        />
+      )}
 
       {matched.length > 0 && (
         <Pagination
@@ -283,14 +324,14 @@ export default function Orders() {
         <OrderDrawer
           order={openOrder}
           detailTo={orderPath(openOrder.no)}
-          onClose={() => setOpenNo(null)}
+          onClose={() => setOpenId(null)}
           onEdit={() => {
-            setEditingNo(openOrder.no)
-            setOpenNo(null)
+            setEditingId(openOrder.id)
+            setOpenId(null)
           }}
           onDelete={() => {
-            setDeletingNo(openOrder.no)
-            setOpenNo(null)
+            setDeletingId(openOrder.id)
+            setOpenId(null)
           }}
         />
       )}
@@ -298,10 +339,15 @@ export default function Orders() {
       {editingOrder && (
         <OrderForm
           order={editingOrder}
-          onClose={() => setEditingNo(null)}
-          onSubmit={(draft) => {
-            updateOrder(editingOrder.no, draft)
-            setEditingNo(null)
+          companies={companies}
+          contracts={contracts}
+          products={products}
+          suppliers={suppliers}
+          optionsLoading={loading}
+          onClose={() => setEditingId(null)}
+          onSubmit={async (draft) => {
+            await updateOrder(editingOrder.id, draft)
+            setEditingId(null)
           }}
         />
       )}
@@ -309,10 +355,12 @@ export default function Orders() {
       {deletingOrder && (
         <DeleteConfirm
           order={deletingOrder}
-          onClose={() => setDeletingNo(null)}
-          onConfirm={() => {
-            removeOrder(deletingOrder.no)
-            setDeletingNo(null)
+          pending={isDeleting}
+          error={mutationError}
+          onClose={() => setDeletingId(null)}
+          onConfirm={async () => {
+            await removeOrder(deletingOrder.id)
+            setDeletingId(null)
           }}
         />
       )}
@@ -321,33 +369,39 @@ export default function Orders() {
 }
 
 /** 납기를 며칠 넘겼는지. 표와 카드가 같은 문구를 씁니다. */
-const lateLabel = (order: PurchaseOrder) => `${order.expectOff - order.dueOff}일 지연`
+const lateLabel = (order: ApiPurchaseOrder) => `${order.expectOff - order.dueOff}일 지연`
 
 /** 표와 카드가 같은 배지를 씁니다. */
-function statusChip(order: PurchaseOrder) {
+function statusChip(order: ApiPurchaseOrder) {
   return <StageChip tone={TONE_OF[order.status]}>{order.status}</StageChip>
 }
 
 interface DeleteConfirmProps {
-  order: PurchaseOrder
+  order: ApiPurchaseOrder
+  pending: boolean
+  error: string | null
   onClose: () => void
-  onConfirm: () => void
+  onConfirm: () => Promise<void>
 }
 
 /** 지우기 전 한 번 묻습니다. 계약 목록과 같은 문구를 씁니다. */
-function DeleteConfirm({ order, onClose, onConfirm }: DeleteConfirmProps) {
+function DeleteConfirm({ order, pending, error, onClose, onConfirm }: DeleteConfirmProps) {
   return (
     <Modal
       title="발주를 삭제할까요?"
       description={`${order.no} · ${order.hospital}. 되돌릴 수 없습니다.`}
-      onClose={onClose}
+      onClose={pending ? () => {} : onClose}
       footer={
         <>
-          <Button type="button" variant="outline" onClick={onClose}>
+          <Button type="button" variant="outline" disabled={pending} onClick={onClose}>
             취소
           </Button>
-          <Button type="button" onClick={onConfirm}>
-            삭제
+          <Button
+            type="button"
+            disabled={pending}
+            onClick={() => void onConfirm().catch(() => undefined)}
+          >
+            {pending ? '삭제 중…' : '삭제'}
           </Button>
         </>
       }
@@ -355,6 +409,7 @@ function DeleteConfirm({ order, onClose, onConfirm }: DeleteConfirmProps) {
       <p className={styles.confirm}>
         {orderItemLabel(order)} · {order.supplier}
       </p>
+      {error && <p role="alert">{error}</p>}
     </Modal>
   )
 }

--- a/frontend/src/pages/Orders/columns.ts
+++ b/frontend/src/pages/Orders/columns.ts
@@ -4,25 +4,23 @@
 // 같은 진행 순서가 흐트러져 ORDER_STATUSES 의 순서를 그대로 씁니다.
 import type { DataColumn } from '@/components/DataTable'
 import { orderItemLabel, orderTotal } from '@/shared/orders'
-import type { PurchaseOrder } from '@/types'
+import type { ApiPurchaseOrder } from '@/types'
 import { fmtDotShort, parseISO } from '@/utils/date'
 import { won } from '@/utils/format'
 
-import { ORDER_STATUSES, ownerOfOrder } from './pipeline'
+import { ORDER_STATUSES } from './pipeline'
 
-export const ORDER_COLUMNS: DataColumn<PurchaseOrder>[] = [
+export const ORDER_COLUMNS: DataColumn<ApiPurchaseOrder>[] = [
   { id: 'no', header: '발주번호', width: 132, numeric: true, sortable: true, text: (o) => o.no },
   { id: 'hospital', header: '고객사', width: 140, sortable: true, text: (o) => o.hospital },
   { id: 'items', header: '품목', width: 160, sortable: true, text: orderItemLabel },
   { id: 'supplier', header: '공급처', width: 124, sortable: true, text: (o) => o.supplier },
   {
-    // 발주에는 담당자가 없어 연결된 계약에서 가져옵니다. 계약 없는 선발주는 빈칸입니다.
-    // 여러 사람의 발주가 섞여 보일 때만 표에 나옵니다.
     id: 'owner',
     header: '담당 영업',
     width: 96,
     sortable: true,
-    text: (o) => ownerOfOrder(o) ?? '—',
+    text: (o) => o.owner,
   },
   {
     id: 'amount',

--- a/frontend/src/pages/Orders/components/OrderFields/OrderFields.tsx
+++ b/frontend/src/pages/Orders/components/OrderFields/OrderFields.tsx
@@ -15,7 +15,8 @@ import {
   type FormState,
   type ItemState,
 } from '../../orderForm'
-import { HOSPITALS, ORDER_STATUSES, PRODUCTS, SUPPLIERS } from '../../pipeline'
+import { ORDER_STATUSES } from '../../pipeline'
+import type { OrderContractOption, OrderOption } from '../../useOrderList'
 
 import styles from './OrderFields.module.scss'
 
@@ -24,78 +25,135 @@ interface Props {
   errors: FormErrors
   onChange: (key: Exclude<keyof FormState, 'items'>, value: string) => void
   onItemsChange: (items: ItemState[]) => void
+  companies: OrderOption[]
+  contracts: OrderContractOption[]
+  products: OrderOption[]
+  suppliers: string[]
+  optionsLoading?: boolean
+  disabled?: boolean
+  showStatus?: boolean
   /** 메모 앞에 들어갈 추가 항목 */
   children?: ReactNode
 }
 
-export default function OrderFields({ form, errors, onChange, onItemsChange, children }: Props) {
+export default function OrderFields({
+  form,
+  errors,
+  onChange,
+  onItemsChange,
+  companies,
+  contracts,
+  products,
+  suppliers,
+  optionsLoading = false,
+  disabled = false,
+  showStatus = true,
+  children,
+}: Props) {
   const setItem = (index: number, key: keyof ItemState, value: string) =>
     onItemsChange(form.items.map((item, i) => (i === index ? { ...item, [key]: value } : item)))
 
+  const availableContracts = contracts.filter(
+    (contract) => contract.customerCompanyId === form.customerCompanyId,
+  )
+
+  const changeCompany = (customerCompanyId: string) => {
+    onChange('customerCompanyId', customerCompanyId)
+    const selected = contracts.find((contract) => contract.id === form.contractId)
+    if (selected && selected.customerCompanyId !== customerCompanyId) onChange('contractId', '')
+  }
+
   return (
     <div className={styles.grid}>
-      <Field label="고객사" required error={errors.hospital}>
-        {/* 목록에 없는 곳도 새로 적을 수 있어야 해서 select 가 아니라 datalist 입니다. */}
-        <input
-          list="order-hospitals"
-          value={form.hospital}
-          placeholder="한빛대학교병원"
-          onChange={(e) => onChange('hospital', e.target.value)}
-        />
-        <datalist id="order-hospitals">
-          {HOSPITALS.map((hospital) => (
-            <option key={hospital} value={hospital} />
+      <Field label="고객사" required error={errors.customerCompanyId}>
+        <select
+          value={form.customerCompanyId}
+          disabled={disabled || optionsLoading || companies.length === 0}
+          onChange={(event) => changeCompany(event.target.value)}
+        >
+          <option value="">
+            {optionsLoading
+              ? '고객사를 불러오는 중…'
+              : companies.length === 0
+                ? '등록된 고객사가 없습니다'
+                : '고객사를 선택하세요'}
+          </option>
+          {companies.map((company) => (
+            <option key={company.id} value={company.id}>
+              {company.name}
+            </option>
           ))}
-        </datalist>
+        </select>
       </Field>
 
       <Field label="공급처" required error={errors.supplier}>
         <input
           list="order-suppliers"
           value={form.supplier}
+          disabled={disabled}
+          maxLength={254}
           placeholder="본사 생산팀"
           onChange={(e) => onChange('supplier', e.target.value)}
         />
         <datalist id="order-suppliers">
-          {SUPPLIERS.map((supplier) => (
+          {suppliers.map((supplier) => (
             <option key={supplier} value={supplier} />
           ))}
         </datalist>
       </Field>
 
       <Field label="계약번호">
-        {/* 계약을 걸지 않은 선발주도 있어 비워 둘 수 있습니다. */}
-        <input
-          value={form.contract}
-          placeholder="FM-CT-2026-0038 (선택)"
-          onChange={(e) => onChange('contract', e.target.value)}
-        />
-      </Field>
-
-      <Field label="상태">
-        <select value={form.status} onChange={(e) => onChange('status', e.target.value)}>
-          {ORDER_STATUSES.map((status) => (
-            <option key={status}>{status}</option>
+        <select
+          value={form.contractId}
+          disabled={disabled || optionsLoading || form.customerCompanyId === ''}
+          onChange={(event) => onChange('contractId', event.target.value)}
+        >
+          <option value="">계약 없는 선발주</option>
+          {availableContracts.map((contract) => (
+            <option key={contract.id} value={contract.id}>
+              {contract.no}
+            </option>
           ))}
         </select>
       </Field>
+
+      {showStatus && (
+        <Field label="상태">
+          <select
+            value={form.status}
+            disabled={disabled}
+            onChange={(e) => onChange('status', e.target.value)}
+          >
+            {ORDER_STATUSES.map((status) => (
+              <option key={status}>{status}</option>
+            ))}
+          </select>
+        </Field>
+      )}
 
       <Field label="발주일" error={errors.ordered}>
         <input
           type="date"
           value={form.ordered}
+          disabled={disabled}
           onChange={(e) => onChange('ordered', e.target.value)}
         />
       </Field>
 
       <Field label="납기" error={errors.due}>
-        <input type="date" value={form.due} onChange={(e) => onChange('due', e.target.value)} />
+        <input
+          type="date"
+          value={form.due}
+          disabled={disabled}
+          onChange={(e) => onChange('due', e.target.value)}
+        />
       </Field>
 
       <Field label="예상 입고" error={errors.expect}>
         <input
           type="date"
           value={form.expect}
+          disabled={disabled}
           onChange={(e) => onChange('expect', e.target.value)}
         />
       </Field>
@@ -119,18 +177,31 @@ export default function OrderFields({ form, errors, onChange, onItemsChange, chi
               // 줄을 지워도 남은 줄이 제 값을 그대로 들고 있습니다.
               <li key={index} className={styles.item}>
                 <div className={styles.itemRow}>
-                  <input
-                    list="order-products"
+                  <select
                     className={styles.product}
-                    value={item.product}
-                    placeholder="SonoFlex Pro"
+                    value={item.productId}
+                    disabled={disabled || optionsLoading || products.length === 0}
                     aria-label={`품목 ${index + 1} 제품`}
-                    onChange={(e) => setItem(index, 'product', e.target.value)}
-                  />
+                    onChange={(e) => setItem(index, 'productId', e.target.value)}
+                  >
+                    <option value="">
+                      {optionsLoading
+                        ? '제품을 불러오는 중…'
+                        : products.length === 0
+                          ? '등록된 제품이 없습니다'
+                          : '제품 선택'}
+                    </option>
+                    {products.map((product) => (
+                      <option key={product.id} value={product.id}>
+                        {product.name}
+                      </option>
+                    ))}
+                  </select>
                   <input
                     className={styles.qty}
                     inputMode="numeric"
                     value={item.qty}
+                    disabled={disabled}
                     placeholder="수량"
                     aria-label={`품목 ${index + 1} 수량`}
                     onChange={(e) => setItem(index, 'qty', e.target.value)}
@@ -139,6 +210,7 @@ export default function OrderFields({ form, errors, onChange, onItemsChange, chi
                     className={styles.price}
                     inputMode="numeric"
                     value={item.price}
+                    disabled={disabled}
                     placeholder="단가"
                     aria-label={`품목 ${index + 1} 단가`}
                     onChange={(e) => setItem(index, 'price', e.target.value)}
@@ -148,27 +220,24 @@ export default function OrderFields({ form, errors, onChange, onItemsChange, chi
                     type="button"
                     className={styles.remove}
                     aria-label={`품목 ${index + 1} 삭제`}
-                    disabled={form.items.length === 1}
+                    disabled={disabled || form.items.length === 1}
                     onClick={() => onItemsChange(form.items.filter((_, i) => i !== index))}
                   >
                     <TrashIcon width={14} height={14} />
                   </button>
                 </div>
-                {row && <span className={styles.error}>{row.product ?? row.qty ?? row.price}</span>}
+                {row && (
+                  <span className={styles.error}>{row.productId ?? row.qty ?? row.price}</span>
+                )}
               </li>
             )
           })}
         </ul>
 
-        <datalist id="order-products">
-          {PRODUCTS.map((product) => (
-            <option key={product} value={product} />
-          ))}
-        </datalist>
-
         <button
           type="button"
           className={styles.addItem}
+          disabled={disabled || optionsLoading || products.length === 0 || form.items.length >= 100}
           onClick={() => onItemsChange([...form.items, emptyItem()])}
         >
           + 품목 추가
@@ -181,6 +250,8 @@ export default function OrderFields({ form, errors, onChange, onItemsChange, chi
         <textarea
           rows={3}
           value={form.memo}
+          disabled={disabled}
+          maxLength={5000}
           placeholder="설치 공간 사전 확인 완료"
           onChange={(e) => onChange('memo', e.target.value)}
         />

--- a/frontend/src/pages/Orders/components/OrderForm/OrderForm.tsx
+++ b/frontend/src/pages/Orders/components/OrderForm/OrderForm.tsx
@@ -1,10 +1,10 @@
 // 발주 수정 모달입니다. 항목은 OrderFields 가, 검사는 orderForm 이 갖고
 // 여기서는 모달 껍데기와 제출만 다룹니다.
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 
 import Button from '@/components/Button'
 import Modal from '@/components/Modal'
-import type { PurchaseOrder } from '@/types'
+import type { ApiPurchaseOrder } from '@/types'
 
 import {
   initialState,
@@ -14,47 +14,100 @@ import {
   type FormState,
   type ItemState,
 } from '../../orderForm'
-import type { OrderDraft } from '../../useOrderList'
+import type { OrderContractOption, OrderDraft, OrderOption } from '../../useOrderList'
 import OrderFields from '../OrderFields'
 
 interface Props {
-  order: PurchaseOrder
+  order: ApiPurchaseOrder
+  companies: OrderOption[]
+  contracts: OrderContractOption[]
+  products: OrderOption[]
+  suppliers: string[]
+  optionsLoading?: boolean
   onClose: () => void
-  onSubmit: (draft: OrderDraft) => void
+  onSubmit: (draft: OrderDraft) => Promise<void>
 }
 
-export default function OrderForm({ order, onClose, onSubmit }: Props) {
+export default function OrderForm({
+  order,
+  companies,
+  contracts,
+  products,
+  suppliers,
+  optionsLoading = false,
+  onClose,
+  onSubmit,
+}: Props) {
   const [form, setForm] = useState<FormState>(() => initialState(order))
   const [errors, setErrors] = useState<FormErrors>({})
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const submittingRef = useRef(false)
 
   const set = (key: Exclude<keyof FormState, 'items'>, value: string) =>
     setForm((prev) => ({ ...prev, [key]: value }))
 
   const setItems = (items: ItemState[]) => setForm((prev) => ({ ...prev, items }))
 
-  const submit = () => {
+  const close = () => {
+    if (!submittingRef.current) onClose()
+  }
+
+  const submit = async () => {
+    if (submittingRef.current) return
     const found = validate(form)
     setErrors(found)
     if (Object.keys(found).length > 0) return
-    onSubmit(toDraft(form))
+
+    submittingRef.current = true
+    setSubmitting(true)
+    setSubmitError(null)
+    try {
+      await onSubmit(toDraft(form))
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : '발주를 저장하지 못했습니다.')
+    } finally {
+      submittingRef.current = false
+      setSubmitting(false)
+    }
   }
 
   return (
     <Modal
       title="발주 수정"
-      description={`${order.no} · 발주번호는 바꾸지 않습니다.`}
-      onClose={onClose}
-      onSubmit={submit}
+      description={`${order.no} · 발주번호와 상태는 여기서 바꾸지 않습니다.`}
+      onClose={close}
+      onSubmit={() => void submit()}
       footer={
         <>
-          <Button type="button" variant="outline" onClick={onClose}>
+          <Button type="button" variant="outline" disabled={submitting} onClick={close}>
             취소
           </Button>
-          <Button type="submit">저장</Button>
+          <Button
+            type="submit"
+            disabled={
+              submitting || optionsLoading || companies.length === 0 || products.length === 0
+            }
+          >
+            {submitting ? '저장 중…' : '저장'}
+          </Button>
         </>
       }
     >
-      <OrderFields form={form} errors={errors} onChange={set} onItemsChange={setItems} />
+      <OrderFields
+        form={form}
+        errors={errors}
+        companies={companies}
+        contracts={contracts}
+        products={products}
+        suppliers={suppliers}
+        optionsLoading={optionsLoading}
+        disabled={submitting}
+        showStatus={false}
+        onChange={set}
+        onItemsChange={setItems}
+      />
+      {submitError && <p role="alert">{submitError}</p>}
     </Modal>
   )
 }

--- a/frontend/src/pages/Orders/orderForm.ts
+++ b/frontend/src/pages/Orders/orderForm.ts
@@ -1,6 +1,6 @@
 // 발주 입력값을 다루는 규칙입니다. 모달(OrderForm)과 추가 화면(New)이 같은 항목을
 // 받으므로 검사와 변환을 여기 한 곳에 둡니다. 어느 쪽으로 넣든 결과가 같아야 합니다.
-import type { OrderStatus, PurchaseOrder } from '@/types'
+import type { ApiPurchaseOrder, OrderStatus } from '@/types'
 import { addDays, iso, TODAY, TODAY_ISO } from '@/utils/date'
 
 import type { OrderDraft } from './useOrderList'
@@ -8,15 +8,15 @@ import type { OrderDraft } from './useOrderList'
 // 입력값은 전부 문자열로 다룹니다. 지우는 도중 0 이 되어 버리지 않게 수량·단가도
 // 문자열로 두고 제출할 때 한 번에 숫자로 돌립니다.
 export interface ItemState {
-  product: string
+  productId: string
   qty: string
   price: string
 }
 
 export interface FormState {
-  hospital: string
+  customerCompanyId: string
   supplier: string
-  contract: string
+  contractId: string
   status: string
   ordered: string
   due: string
@@ -33,13 +33,13 @@ export interface FormErrors extends Partial<Record<Exclude<keyof FormState, 'ite
   itemRows?: ItemErrors
 }
 
-export const emptyItem = (): ItemState => ({ product: '', qty: '1', price: '' })
+export const emptyItem = (): ItemState => ({ productId: '', qty: '1', price: '' })
 
-export function initialState(order?: PurchaseOrder): FormState {
+export function initialState(order?: ApiPurchaseOrder): FormState {
   return {
-    hospital: order?.hospital ?? '',
+    customerCompanyId: order?.customerCompanyId ?? '',
     supplier: order?.supplier ?? '',
-    contract: order?.contract ?? '',
+    contractId: order?.contractId ?? '',
     status: order?.status ?? '발주 접수',
     ordered: order?.ordered ?? TODAY_ISO,
     // 새 발주는 납기를 2주 뒤로 잡아 둡니다. 대부분 그 언저리라 고치는 손이 줄어듭니다.
@@ -48,7 +48,7 @@ export function initialState(order?: PurchaseOrder): FormState {
     memo: order?.memo ?? '',
     items: order
       ? order.items.map((it) => ({
-          product: it.product,
+          productId: it.productId,
           qty: String(it.qty),
           price: String(it.price),
         }))
@@ -62,7 +62,7 @@ const DATE_RE = /^\d{4}-\d{2}-\d{2}$/
 
 export function validate(form: FormState): FormErrors {
   const errors: FormErrors = {}
-  if (form.hospital.trim() === '') errors.hospital = '고객사를 입력하세요.'
+  if (form.customerCompanyId === '') errors.customerCompanyId = '고객사를 선택하세요.'
   if (form.supplier.trim() === '') errors.supplier = '공급처를 입력하세요.'
 
   if (!DATE_RE.test(form.ordered)) errors.ordered = '날짜를 선택하세요.'
@@ -70,18 +70,20 @@ export function validate(form: FormState): FormErrors {
   if (!DATE_RE.test(form.expect)) errors.expect = '날짜를 선택하세요.'
 
   if (form.items.length === 0) errors.items = '품목을 한 줄 이상 넣으세요.'
+  else if (form.items.length > 100) errors.items = '품목은 100개까지 넣을 수 있습니다.'
 
   const rows: ItemErrors = {}
   form.items.forEach((item, index) => {
     const row: Partial<Record<keyof ItemState, string>> = {}
-    if (item.product.trim() === '') row.product = '제품을 입력하세요.'
+    if (item.productId === '') row.productId = '제품을 선택하세요.'
 
     const qty = num(item.qty)
-    if (item.qty.trim() === '' || Number.isNaN(qty) || qty <= 0) row.qty = '1 이상으로 입력하세요.'
+    if (!/^\d+$/.test(item.qty) || !Number.isSafeInteger(qty) || qty <= 0)
+      row.qty = '1 이상의 정수로 입력하세요.'
 
     const price = num(item.price)
-    if (item.price.trim() === '' || Number.isNaN(price) || price < 0)
-      row.price = '0 이상으로 입력하세요.'
+    if (!/^\d+$/.test(item.price) || !Number.isSafeInteger(price))
+      row.price = '0 이상의 정수로 입력하세요.'
 
     if (Object.keys(row).length > 0) rows[index] = row
   })
@@ -102,16 +104,16 @@ export function totalOf(form: FormState): number {
 
 export function toDraft(form: FormState): OrderDraft {
   return {
-    hospital: form.hospital.trim(),
+    customerCompanyId: form.customerCompanyId,
     supplier: form.supplier.trim(),
-    contract: form.contract.trim(),
+    contractId: form.contractId || null,
     status: form.status as OrderStatus,
     ordered: form.ordered,
     due: form.due,
     expect: form.expect,
-    memo: form.memo.trim(),
+    memo: form.memo.trim() || null,
     items: form.items.map((item) => ({
-      product: item.product.trim(),
+      productId: item.productId,
       qty: num(item.qty),
       price: num(item.price),
     })),

--- a/frontend/src/pages/Orders/pipeline.ts
+++ b/frontend/src/pages/Orders/pipeline.ts
@@ -4,9 +4,7 @@
 // 영업현황의 board.ts 와 달리 상태 집합은 데이터가 아니라 타입입니다. 발주 상태는
 // 결재·생산·물류 흐름이라 화면에서 늘리고 줄일 수 있는 것이 아닙니다.
 // (파일 이름이 orders.ts 가 아닌 이유: Orders.tsx 와 대소문자만 달라 충돌합니다.)
-import { contracts } from '@/shared/contracts'
-import { orders as seed } from '@/shared/orders'
-import type { ColumnTone, OrderStatus, PurchaseOrder, Stage } from '@/types'
+import type { ColumnTone, OrderStageCode, OrderStatus, Stage } from '@/types'
 
 /** 상태 선택지. 타입에 적힌 순서가 곧 진행 순서입니다. 탭·정렬이 이 순서를 씁니다. */
 export const ORDER_STATUSES: OrderStatus[] = [
@@ -17,6 +15,24 @@ export const ORDER_STATUSES: OrderStatus[] = [
   '납품 완료',
   '취소',
 ]
+
+export const STATUS_BY_CODE: Record<OrderStageCode, OrderStatus> = {
+  order_received: '발주 접수',
+  dispatch_request_completed: '출고 의뢰서 완료',
+  in_production: '생산중',
+  stock_received: '입고 완료',
+  delivered: '납품 완료',
+  cancelled: '취소',
+}
+
+export const CODE_BY_STATUS: Record<OrderStatus, OrderStageCode> = {
+  '발주 접수': 'order_received',
+  '출고 의뢰서 완료': 'dispatch_request_completed',
+  생산중: 'in_production',
+  '입고 완료': 'stock_received',
+  '납품 완료': 'delivered',
+  취소: 'cancelled',
+}
 
 export const TONE_OF: Record<OrderStatus, ColumnTone> = {
   '발주 접수': 'gray',
@@ -39,37 +55,3 @@ export const ORDER_STEPS: OrderStatus[] = ORDER_STATUSES.filter((status) => stat
 
 /** 상태가 놓이는 칸. 취소는 흐름 밖이라 -1 입니다. */
 export const stepOf = (status: OrderStatus): number => ORDER_STEPS.indexOf(status)
-
-/** 필터와 폼의 선택지. 데이터에서 뽑아야 목록과 어긋나지 않습니다. */
-export const SUPPLIERS: string[] = [...new Set(seed.map((o) => o.supplier))].sort()
-export const HOSPITALS: string[] = [...new Set(seed.map((o) => o.hospital))].sort()
-export const PRODUCTS: string[] = [
-  ...new Set(seed.flatMap((o) => o.items.map((it) => it.product))),
-].sort()
-
-const OWNER_BY_CONTRACT = new Map(contracts.map((contract) => [contract.no, contract.owner]))
-
-/**
- * 발주의 담당 영업. 발주 자체에는 담당자가 없어 연결된 계약에서 가져옵니다.
- * 계약 없는 선발주는 누구 것인지 알 수 없어 undefined 입니다.
- */
-export function ownerOfOrder(order: PurchaseOrder): string | undefined {
-  return order.contract ? OWNER_BY_CONTRACT.get(order.contract) : undefined
-}
-
-/** 시드를 목록의 초기 상태로. 발주일 최신순으로 세워 둡니다. */
-export function initialOrders(): PurchaseOrder[] {
-  return [...seed].sort((a, b) => b.ordered.localeCompare(a.ordered))
-}
-
-/** 다음 발주번호. 올해 번호 중 가장 큰 것에 1 을 더합니다. */
-export function nextOrderNo(list: PurchaseOrder[]): string {
-  const year = new Date().getFullYear()
-  const prefix = `FM-PO-${year}-`
-  const last = list.reduce((max, o) => {
-    if (!o.no.startsWith(prefix)) return max
-    const n = Number(o.no.slice(prefix.length))
-    return Number.isNaN(n) ? max : Math.max(max, n)
-  }, 0)
-  return `${prefix}${String(last + 1).padStart(4, '0')}`
-}

--- a/frontend/src/pages/Orders/useOrderList.ts
+++ b/frontend/src/pages/Orders/useOrderList.ts
@@ -1,94 +1,347 @@
-// 백엔드가 붙는 지점은 이 파일 하나입니다. 화면은 아래 반환값만 알면 되므로
-// 시드를 API 응답으로, 각 mutator 를 요청으로 바꾸면 나머지는 그대로 둘 수 있습니다.
-//
-// 상태를 모듈 수준에 두는 이유: 목록(/orders)·추가(/orders/new)·상세(/orders/:no)가
-// 서로 다른 페이지라 훅 인스턴스가 따로 생깁니다. useState 로 두면 상세에서 고친 값이
-// 목록으로 돌아왔을 때 사라집니다. 계약의 useContractList 와 같은 방식입니다.
-import { useCallback, useSyncExternalStore } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { isAxiosError } from 'axios'
 
-import type { OrderLine, OrderStatus, PurchaseOrder } from '@/types'
+import { client } from '@/api/client'
+import type {
+  ApiPurchaseOrder,
+  ContractResponse,
+  CustomerCompanyResponse,
+  OrderCreateRequest,
+  OrderMoveRequest,
+  OrderPatchRequest,
+  OrderResponse,
+  OrderStatus,
+  PageResponse,
+  ProductResponse,
+} from '@/types'
 import { parseISO, TODAY } from '@/utils/date'
 
-import { initialOrders, nextOrderNo } from './pipeline'
+import { CODE_BY_STATUS, STATUS_BY_CODE } from './pipeline'
 
-let orders: PurchaseOrder[] = initialOrders()
-const listeners = new Set<() => void>()
+const PAGE_LIMIT = 100
 
-function publish(next: PurchaseOrder[]) {
-  orders = next
-  listeners.forEach((notify) => notify())
+export interface OrderOption {
+  id: string
+  name: string
 }
 
-function subscribe(listener: () => void) {
-  listeners.add(listener)
-  return () => listeners.delete(listener)
+export interface OrderContractOption {
+  id: string
+  no: string
+  customerCompanyId: string
 }
 
-/** 오늘로부터 며칠. isLate·dday 가 offset 을 보므로 저장할 때마다 다시 계산합니다. */
-const offsetOf = (dateISO: string) =>
-  Math.round((parseISO(dateISO).getTime() - TODAY.getTime()) / 86_400_000)
+export interface OrderDraftItem {
+  productId: string
+  qty: number
+  price: number
+}
 
 export interface OrderDraft {
-  /** 연결된 계약번호. 비우면 계약 없는 선발주입니다. */
-  contract: string
-  hospital: string
+  contractId: string | null
+  customerCompanyId: string
   supplier: string
   status: OrderStatus
-  /** YYYY-MM-DD */
   ordered: string
   due: string
   expect: string
-  memo: string
-  items: OrderLine[]
+  memo: string | null
+  items: OrderDraftItem[]
 }
 
-/** 초안을 저장 형태로. 날짜와 offset 이 늘 같은 값을 가리키게 합니다. */
-function toOrder(no: string, draft: OrderDraft): PurchaseOrder {
+const offsetOf = (dateISO: string) =>
+  Math.round((parseISO(dateISO).getTime() - TODAY.getTime()) / 86_400_000)
+
+function toOrder(order: OrderResponse): ApiPurchaseOrder {
   return {
-    no,
-    contract: draft.contract,
-    hospital: draft.hospital,
-    supplier: draft.supplier,
-    status: draft.status,
-    memo: draft.memo,
-    items: draft.items,
-    ordered: draft.ordered,
-    due: draft.due,
-    expect: draft.expect,
-    orderedOff: offsetOf(draft.ordered),
-    dueOff: offsetOf(draft.due),
-    expectOff: offsetOf(draft.expect),
+    id: order.id,
+    no: order.order_no,
+    contractId: order.contract_id,
+    contract: order.contract_no ?? '',
+    customerCompanyId: order.customer_company_id,
+    hospital: order.customer_company_name,
+    ownerMemberId: order.owner_member_id,
+    owner: order.owner_display_name,
+    supplier: order.supplier_name,
+    status: STATUS_BY_CODE[order.stage_code],
+    memo: order.memo ?? '',
+    items: [...order.items]
+      .sort((a, b) => a.position - b.position)
+      .map((item) => ({
+        id: item.id,
+        productId: item.product_id,
+        product: item.product_name,
+        qty: item.quantity,
+        price: item.unit_price,
+        position: item.position,
+      })),
+    ordered: order.ordered_on,
+    due: order.due_on,
+    expect: order.expected_receipt_on,
+    orderedOff: offsetOf(order.ordered_on),
+    dueOff: offsetOf(order.due_on),
+    expectOff: offsetOf(order.expected_receipt_on),
+    createdAt: order.created_at,
+    updatedAt: order.updated_at,
   }
 }
 
-export default function useOrderList() {
-  const list = useSyncExternalStore(
-    subscribe,
-    () => orders,
-    () => orders,
+async function fetchAllPage<T>(path: string, signal?: AbortSignal): Promise<T[]> {
+  // ponytail: 현재 화면의 필터·탭 건수는 전건 기준입니다. 데이터가 커지면 서버 집계로 바꿉니다.
+  const items: T[] = []
+  let skip = 0
+
+  while (!signal?.aborted) {
+    const { data } = await client.get<PageResponse<T>>(path, {
+      params: { skip, limit: PAGE_LIMIT },
+      signal,
+    })
+    items.push(...data.items)
+    if (!data.has_more || data.next_skip === null) break
+    if (data.next_skip <= skip) throw new Error('invalid_pagination')
+    skip = data.next_skip
+  }
+
+  return items
+}
+
+async function fetchAllOrders(signal?: AbortSignal): Promise<ApiPurchaseOrder[]> {
+  return (await fetchAllPage<OrderResponse>('/orders', signal)).map(toOrder)
+}
+
+function toWriteRequest(draft: OrderDraft): OrderPatchRequest {
+  return {
+    contract_id: draft.contractId,
+    customer_company_id: draft.customerCompanyId,
+    supplier_name: draft.supplier,
+    ordered_on: draft.ordered,
+    due_on: draft.due,
+    expected_receipt_on: draft.expect,
+    memo: draft.memo,
+    items: draft.items.map((item) => ({
+      product_id: item.productId,
+      quantity: item.qty,
+      unit_price: item.price,
+    })),
+  }
+}
+
+function requestErrorMessage(error: unknown, target: '목록' | '상세'): string {
+  if (!isAxiosError(error)) return `발주 ${target}을 불러오지 못했습니다.`
+  if (error.response?.status === 401) return '로그인이 만료되었습니다. 다시 로그인해 주세요.'
+  if (error.response?.status === 403) return `발주 ${target}을 조회할 권한이 없습니다.`
+  if (error.response?.status === 404) return '발주를 찾을 수 없습니다.'
+  if (error.response?.status === 422) return `발주 ${target} 조회 조건을 처리하지 못했습니다.`
+  return '서버에 연결할 수 없습니다. 잠시 후 다시 시도해 주세요.'
+}
+
+function mutationErrorMessage(error: unknown, action: string): string {
+  if (!isAxiosError(error)) return `${action}하지 못했습니다.`
+  if (error.response?.status === 401) return '로그인이 만료되었습니다. 다시 로그인해 주세요.'
+  if (error.response?.status === 403) return `${action}할 권한이 없습니다.`
+  if (error.response?.status === 404) return '발주를 찾을 수 없습니다. 목록을 새로고침해 주세요.'
+  if (error.response?.status === 409)
+    return '다른 변경이 먼저 반영되었습니다. 목록을 새로고침한 뒤 다시 시도해 주세요.'
+  if (error.response?.status === 422) return '입력한 값과 발주 상태를 확인해 주세요.'
+  return '서버에 연결할 수 없습니다. 잠시 후 다시 시도해 주세요.'
+}
+
+export default function useOrderList(detailNo?: string) {
+  const [orders, setOrders] = useState<ApiPurchaseOrder[]>([])
+  const [companies, setCompanies] = useState<OrderOption[]>([])
+  const [products, setProducts] = useState<OrderOption[]>([])
+  const [contracts, setContracts] = useState<OrderContractOption[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [reloadKey, setReloadKey] = useState(0)
+
+  const [detail, setDetail] = useState<ApiPurchaseOrder | null>(null)
+  const [detailLoading, setDetailLoading] = useState(false)
+  const [detailError, setDetailError] = useState<string | null>(null)
+  const [detailReloadKey, setDetailReloadKey] = useState(0)
+
+  const pendingRef = useRef(new Set<string>())
+  const [pendingKeys, setPendingKeys] = useState<ReadonlySet<string>>(() => new Set())
+  const [mutationError, setMutationError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    setLoading(true)
+    setError(null)
+
+    void Promise.all([
+      fetchAllOrders(controller.signal),
+      fetchAllPage<CustomerCompanyResponse>('/customer-companies', controller.signal),
+      fetchAllPage<ProductResponse>('/products', controller.signal),
+      fetchAllPage<ContractResponse>('/contracts', controller.signal),
+    ])
+      .then(([orderItems, companyItems, productItems, contractItems]) => {
+        if (controller.signal.aborted) return
+        setOrders(orderItems)
+        setCompanies(companyItems.map(({ id, name }) => ({ id, name })))
+        setProducts(productItems.map(({ id, name }) => ({ id, name })))
+        setContracts(
+          contractItems.map((contract) => ({
+            id: contract.id,
+            no: contract.contract_no,
+            customerCompanyId: contract.customer_company_id,
+          })),
+        )
+      })
+      .catch((caught: unknown) => {
+        if (!controller.signal.aborted) setError(requestErrorMessage(caught, '목록'))
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false)
+      })
+
+    return () => controller.abort()
+  }, [reloadKey])
+
+  useEffect(() => {
+    setDetail(null)
+    setDetailError(null)
+    if (detailNo === undefined || loading) {
+      setDetailLoading(detailNo !== undefined && loading)
+      return
+    }
+
+    const summary = orders.find((order) => order.no === detailNo)
+    if (!summary) {
+      setDetailLoading(false)
+      return
+    }
+
+    const controller = new AbortController()
+    setDetailLoading(true)
+    void client
+      .get<OrderResponse>(`/orders/${summary.id}`, { signal: controller.signal })
+      .then(({ data }) => {
+        if (!controller.signal.aborted) setDetail(toOrder(data))
+      })
+      .catch((caught: unknown) => {
+        if (!controller.signal.aborted) setDetailError(requestErrorMessage(caught, '상세'))
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setDetailLoading(false)
+      })
+
+    return () => controller.abort()
+  }, [detailNo, detailReloadKey, loading, orders])
+
+  const reload = useCallback(() => setReloadKey((value) => value + 1), [])
+  const reloadDetail = useCallback(() => setDetailReloadKey((value) => value + 1), [])
+  const clearMutationError = useCallback(() => setMutationError(null), [])
+
+  const runMutation = useCallback(
+    async <T>(key: string, action: string, request: () => Promise<T>): Promise<T> => {
+      if (pendingRef.current.has(key)) throw new Error('이미 요청을 처리하고 있습니다.')
+      pendingRef.current.add(key)
+      setPendingKeys(new Set(pendingRef.current))
+      setMutationError(null)
+      try {
+        return await request()
+      } catch (caught: unknown) {
+        const message = mutationErrorMessage(caught, action)
+        setMutationError(message)
+        throw new Error(message)
+      } finally {
+        pendingRef.current.delete(key)
+        setPendingKeys(new Set(pendingRef.current))
+      }
+    },
+    [],
   )
 
-  const findOrder = useCallback((no: string) => list.find((o) => o.no === no), [list])
+  const addOrder = useCallback(
+    (draft: OrderDraft) =>
+      runMutation('create', '발주를 등록', async () => {
+        const request: OrderCreateRequest = {
+          ...toWriteRequest(draft),
+          stage_code: CODE_BY_STATUS[draft.status],
+        }
+        const { data } = await client.post<OrderResponse>('/orders', request)
+        const created = toOrder(data)
+        setOrders((previous) => [created, ...previous])
+        return created
+      }),
+    [runMutation],
+  )
 
-  const addOrder = useCallback((draft: OrderDraft) => {
-    const order = toOrder(nextOrderNo(orders), draft)
-    // 새로 넣은 발주가 목록 아래로 묻히면 저장됐는지 알 수 없어 맨 위에 둡니다.
-    publish([order, ...orders])
-    return order.no
-  }, [])
+  const updateOrder = useCallback(
+    (id: string, draft: OrderDraft) =>
+      runMutation(id, '발주를 수정', async () => {
+        const { data } = await client.patch<OrderResponse>(`/orders/${id}`, toWriteRequest(draft))
+        const updated = toOrder(data)
+        setOrders((previous) => previous.map((order) => (order.id === id ? updated : order)))
+        setDetail((previous) => (previous?.id === id ? updated : previous))
+        return updated
+      }),
+    [runMutation],
+  )
 
-  const updateOrder = useCallback((no: string, draft: OrderDraft) => {
-    publish(orders.map((o) => (o.no === no ? toOrder(no, draft) : o)))
-  }, [])
+  const setStatus = useCallback(
+    (id: string, expected: OrderStatus, status: OrderStatus) =>
+      runMutation(id, '발주 상태를 변경', async () => {
+        const request: OrderMoveRequest = {
+          expected_stage_code: CODE_BY_STATUS[expected],
+          stage_code: CODE_BY_STATUS[status],
+        }
+        const { data } = await client.post<OrderResponse>(`/orders/${id}/move`, request)
+        const updated = toOrder(data)
+        setOrders((previous) => previous.map((order) => (order.id === id ? updated : order)))
+        setDetail((previous) => (previous?.id === id ? updated : previous))
+        return updated
+      }),
+    [runMutation],
+  )
 
-  /** 상태만 바꿉니다. 상세에서 결재·출고를 넘길 때 폼 전체를 열 필요가 없습니다. */
-  const setStatus = useCallback((no: string, status: OrderStatus) => {
-    publish(orders.map((o) => (o.no === no ? { ...o, status } : o)))
-  }, [])
+  const removeOrder = useCallback(
+    (id: string) =>
+      runMutation(id, '발주를 삭제', async () => {
+        await client.delete(`/orders/${id}`)
+        setOrders((previous) => previous.filter((order) => order.id !== id))
+        setDetail((previous) => (previous?.id === id ? null : previous))
+      }),
+    [runMutation],
+  )
 
-  const removeOrder = useCallback((no: string) => {
-    publish(orders.filter((o) => o.no !== no))
-  }, [])
+  const suppliers = useMemo(
+    () => [...new Set(orders.map((order) => order.supplier))].sort(),
+    [orders],
+  )
+  const findOrderById = useCallback(
+    (id: string) => orders.find((order) => order.id === id),
+    [orders],
+  )
+  const findOrderByNo = useCallback(
+    (no: string) => orders.find((order) => order.no === no),
+    [orders],
+  )
+  const isPending = useCallback((id: string) => pendingKeys.has(id), [pendingKeys])
 
-  return { orders: list, findOrder, addOrder, updateOrder, setStatus, removeOrder }
+  return {
+    orders,
+    companies,
+    products,
+    contracts,
+    suppliers,
+    loading,
+    error,
+    reload,
+    detail,
+    detailLoading,
+    detailError,
+    reloadDetail,
+    mutationError,
+    clearMutationError,
+    isCreating: pendingKeys.has('create'),
+    isPending,
+    findOrderById,
+    findOrderByNo,
+    addOrder,
+    updateOrder,
+    setStatus,
+    removeOrder,
+  }
 }

--- a/frontend/src/types/orders.ts
+++ b/frontend/src/types/orders.ts
@@ -4,6 +4,14 @@ export interface OrderLine {
   price: number
 }
 
+export type OrderStageCode =
+  | 'order_received'
+  | 'dispatch_request_completed'
+  | 'in_production'
+  | 'stock_received'
+  | 'delivered'
+  | 'cancelled'
+
 /**
  * 발주 상태. 결재·생산·물류 흐름을 다섯 단계로 두고, 흐름 밖의 취소를 하나 더 둡니다.
  * 순서가 곧 진행 순서라 탭·정렬·스텝바가 이 배열 순서를 그대로 씁니다.
@@ -29,4 +37,76 @@ export interface PurchaseOrder extends PurchaseOrderSeed {
   ordered: string
   due: string
   expect: string
+}
+
+export interface ApiOrderLine extends OrderLine {
+  id: string
+  productId: string
+  position: number
+}
+
+/** API 응답을 기존 발주 화면이 쓰는 표시 형태로 바꾼 값입니다. */
+export interface ApiPurchaseOrder extends PurchaseOrder {
+  id: string
+  contractId: string | null
+  customerCompanyId: string
+  ownerMemberId: string
+  owner: string
+  items: ApiOrderLine[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface OrderItemResponse {
+  id: string
+  product_id: string
+  product_name: string
+  quantity: number
+  unit_price: number
+  position: number
+}
+
+export interface OrderResponse {
+  id: string
+  order_no: string
+  contract_id: string | null
+  contract_no: string | null
+  customer_company_id: string
+  customer_company_name: string
+  owner_member_id: string
+  owner_display_name: string
+  supplier_name: string
+  stage_code: OrderStageCode
+  ordered_on: string
+  due_on: string
+  expected_receipt_on: string
+  memo: string | null
+  items: OrderItemResponse[]
+  created_at: string
+  updated_at: string
+}
+
+export interface OrderItemRequest {
+  product_id: string
+  quantity: number
+  unit_price: number
+}
+
+export interface OrderCreateRequest {
+  contract_id: string | null
+  customer_company_id: string
+  supplier_name: string
+  stage_code: OrderStageCode
+  ordered_on: string
+  due_on: string
+  expected_receipt_on: string
+  memo: string | null
+  items: OrderItemRequest[]
+}
+
+export type OrderPatchRequest = Omit<OrderCreateRequest, 'stage_code'>
+
+export interface OrderMoveRequest {
+  expected_stage_code: OrderStageCode
+  stage_code: OrderStageCode
 }


### PR DESCRIPTION
## 변경 요약

- 발주·품목 목록, 상세, 생성, 수정, 상태 변경, 소프트 삭제 API를 추가했습니다.
- 팀장·팀원 조회 범위와 계약·고객사·담당자·상품의 팀 경계를 검증합니다.
- `/orders` 화면을 UUID 기반 실제 API CRUD에 연결하고 기존 목업 소비처는 보존했습니다.
- 관계가 정확한 합성 발주 2건과 품목 2건을 filled 팀에만 넣는 반복 가능한 seed를 추가했습니다.

## 검증

- 백엔드: `uv run ruff check .`, `uv run ruff format --check .`, `uv run pytest -q` — 59 passed
- 프론트엔드: `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run build` — 통과
- 개발 DB: filled 팀 2건/2품목, empty 팀 0건/0품목 및 6개 계정 권한 범위 확인
- 브라우저: 로그인, 목록, 등록, 상태 변경, 수정, 삭제 왕복 및 콘솔 오류 0건 확인

## 영향 및 주의 사항

- 다른 화면이 사용하는 기존 발주 목업 5건은 삭제하거나 변경하지 않았습니다.
- 관계가 불완전한 목업 발주 3건은 개발 DB seed에 억지로 넣지 않았습니다.
- 개발 DB에는 filled 팀 합성 발주 seed가 적용되어 있습니다.