### PR TITLE
feat: 고객불만 관리를 실제 API와 연결

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api import activities, auth, contracts, customers, health, orders
+from app.api import activities, auth, contracts, customers, health, orders, support
 
 api_router = APIRouter()
 api_router.include_router(health.router)
@@ -9,3 +9,4 @@ api_router.include_router(customers.router)
 api_router.include_router(activities.router)
 api_router.include_router(contracts.router)
 api_router.include_router(orders.router)
+api_router.include_router(support.router)

--- a/backend/app/api/support.py
+++ b/backend/app/api/support.py
@@ -1,0 +1,356 @@
+from typing import Annotated
+from uuid import UUID, uuid4
+from zoneinfo import ZoneInfo
+
+from fastapi import APIRouter, HTTPException, Query, Response, status
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from app.api.deps import CurrentMember, DbSession
+from app.models.crm import CustomerCompany, CustomerContact, SupportRequest, SupportResponse
+from app.models.workspace import Member
+from app.schemas.support import (
+    SupportRequestCreate,
+    SupportRequestPage,
+    SupportRequestPageParams,
+    SupportRequestRead,
+    SupportResponseCreate,
+    SupportResponseRead,
+    SupportTransition,
+)
+
+router = APIRouter(tags=["support"])
+
+_SEOUL = ZoneInfo("Asia/Seoul")
+_assignee = aliased(Member)
+_contact = aliased(CustomerContact)
+_contact_owner = aliased(Member)
+_company = aliased(CustomerCompany)
+_responder = aliased(Member)
+
+
+def _contains(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return f"%{escaped}%"
+
+
+def _joined_select(*entities):
+    return (
+        select(*entities)
+        .select_from(SupportRequest)
+        .join(_assignee, SupportRequest.assignee_member_id == _assignee.id)
+        .join(_contact, SupportRequest.customer_contact_id == _contact.id)
+        .join(_company, _contact.company_id == _company.id)
+        .join(_contact_owner, _contact.owner_member_id == _contact_owner.id)
+    )
+
+
+def _scope(member: Member):
+    conditions = [
+        SupportRequest.team_id == member.team_id,
+        _assignee.team_id == member.team_id,
+        _assignee.active.is_(True),
+        _assignee.role_code.in_(("member", "manager")),
+        _company.team_id == member.team_id,
+        _contact_owner.team_id == member.team_id,
+        _contact_owner.active.is_(True),
+        _contact_owner.role_code.in_(("member", "manager")),
+    ]
+    if member.role_code == "member":
+        conditions.append(SupportRequest.assignee_member_id == member.id)
+    return conditions
+
+
+def _read_entities():
+    return (
+        SupportRequest,
+        _contact.name,
+        _company.id,
+        _company.name,
+        _assignee.display_name,
+    )
+
+
+def _response_read(response: SupportResponse, responder_display_name: str) -> SupportResponseRead:
+    return SupportResponseRead(
+        id=response.id,
+        request_id=response.request_id,
+        responder_member_id=response.responder_member_id,
+        responder_display_name=responder_display_name,
+        body=response.body,
+        responded_at=response.responded_at.astimezone(_SEOUL),
+    )
+
+
+def _request_read(
+    request: SupportRequest,
+    contact_name: str,
+    company_id: UUID,
+    company_name: str,
+    assignee_display_name: str,
+    responses: list[SupportResponseRead],
+) -> SupportRequestRead:
+    return SupportRequestRead(
+        id=request.id,
+        customer_contact_id=request.customer_contact_id,
+        customer_contact_name=contact_name,
+        customer_company_id=company_id,
+        customer_company_name=company_name,
+        assignee_member_id=request.assignee_member_id,
+        assignee_display_name=assignee_display_name,
+        title=request.title,
+        body=request.body,
+        is_urgent=request.is_urgent,
+        status_code=request.status_code,
+        registered_at=request.registered_at.astimezone(_SEOUL),
+        responses=responses,
+    )
+
+
+async def _responses_by_request_ids(
+    db: AsyncSession,
+    member: Member,
+    request_ids: list[UUID],
+) -> dict[UUID, list[SupportResponseRead]]:
+    responses = {request_id: [] for request_id in request_ids}
+    if not request_ids:
+        return responses
+    result = await db.execute(
+        select(SupportResponse, _responder.display_name)
+        .join(_responder, SupportResponse.responder_member_id == _responder.id)
+        .where(
+            SupportResponse.request_id.in_(request_ids),
+            _responder.team_id == member.team_id,
+            _responder.role_code.in_(("member", "manager")),
+        )
+        .order_by(SupportResponse.responded_at, SupportResponse.id)
+    )
+    for response, responder_name in result.all():
+        responses[response.request_id].append(_response_read(response, responder_name))
+    return responses
+
+
+async def _request_row(db: AsyncSession, member: Member, request_id: UUID):
+    result = await db.execute(
+        _joined_select(*_read_entities()).where(
+            SupportRequest.id == request_id,
+            *_scope(member),
+        )
+    )
+    row = result.one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="support_request_not_found",
+        )
+    return row
+
+
+async def _locked_request(
+    db: AsyncSession,
+    member: Member,
+    request_id: UUID,
+) -> SupportRequest:
+    result = await db.execute(
+        _joined_select(SupportRequest)
+        .where(SupportRequest.id == request_id, *_scope(member))
+        .with_for_update(of=SupportRequest)
+    )
+    request = result.scalar_one_or_none()
+    if request is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="support_request_not_found",
+        )
+    return request
+
+
+async def _visible_contact(
+    db: AsyncSession,
+    member: Member,
+    contact_id: UUID,
+) -> tuple[CustomerContact, CustomerCompany]:
+    conditions = [
+        CustomerContact.id == contact_id,
+        CustomerCompany.team_id == member.team_id,
+        Member.team_id == member.team_id,
+        Member.active.is_(True),
+        Member.role_code.in_(("member", "manager")),
+    ]
+    if member.role_code == "member":
+        conditions.append(CustomerContact.owner_member_id == member.id)
+    result = await db.execute(
+        select(CustomerContact, CustomerCompany)
+        .join(CustomerCompany, CustomerContact.company_id == CustomerCompany.id)
+        .join(Member, CustomerContact.owner_member_id == Member.id)
+        .where(*conditions)
+    )
+    row = result.one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="customer_contact_not_found",
+        )
+    return row
+
+
+@router.get("/support-requests", response_model=SupportRequestPage)
+async def list_support_requests(
+    page: Annotated[SupportRequestPageParams, Query()],
+    member: CurrentMember,
+    db: DbSession,
+) -> SupportRequestPage:
+    scope = _scope(member)
+    if page.status_code is not None:
+        scope.append(SupportRequest.status_code.in_(tuple(dict.fromkeys(page.status_code))))
+    if page.q is not None:
+        pattern = _contains(page.q)
+        scope.append(
+            or_(
+                SupportRequest.title.ilike(pattern, escape="\\"),
+                SupportRequest.body.ilike(pattern, escape="\\"),
+                _contact.name.ilike(pattern, escape="\\"),
+                _company.name.ilike(pattern, escape="\\"),
+                _assignee.display_name.ilike(pattern, escape="\\"),
+            )
+        )
+
+    total_result = await db.execute(_joined_select(func.count(SupportRequest.id)).where(*scope))
+    total = total_result.scalar_one()
+    rows_result = await db.execute(
+        _joined_select(*_read_entities())
+        .where(*scope)
+        .order_by(SupportRequest.registered_at.desc(), SupportRequest.id)
+        .offset(page.skip)
+        .limit(page.limit)
+    )
+    rows = rows_result.all()
+    response_map = await _responses_by_request_ids(db, member, [row[0].id for row in rows])
+    items = [_request_read(*row, response_map[row[0].id]) for row in rows]
+    has_more = page.skip + len(items) < total
+    return SupportRequestPage(
+        items=items,
+        skip=page.skip,
+        limit=page.limit,
+        total=total,
+        has_more=has_more,
+        next_skip=page.skip + len(items) if has_more else None,
+    )
+
+
+@router.get("/support-requests/{request_id}", response_model=SupportRequestRead)
+async def get_support_request(
+    request_id: UUID,
+    member: CurrentMember,
+    db: DbSession,
+) -> SupportRequestRead:
+    row = await _request_row(db, member, request_id)
+    response_map = await _responses_by_request_ids(db, member, [request_id])
+    return _request_read(*row, response_map[request_id])
+
+
+@router.post(
+    "/support-requests",
+    response_model=SupportRequestRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_support_request(
+    payload: SupportRequestCreate,
+    response: Response,
+    member: CurrentMember,
+    db: DbSession,
+) -> SupportRequestRead:
+    try:
+        contact, company = await _visible_contact(db, member, payload.customer_contact_id)
+        request = SupportRequest(
+            id=uuid4(),
+            team_id=member.team_id,
+            customer_contact_id=contact.id,
+            assignee_member_id=member.id,
+            title=payload.title,
+            body=payload.body,
+            is_urgent=payload.is_urgent,
+            status_code=payload.status_code,
+        )
+        db.add(request)
+        await db.flush()
+        read = _request_read(
+            request,
+            contact.name,
+            company.id,
+            company.name,
+            member.display_name,
+            [],
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    response.headers["Location"] = f"/api/support-requests/{request.id}"
+    return read
+
+
+@router.post(
+    "/support-requests/{request_id}/transition",
+    response_model=SupportRequestRead,
+)
+async def transition_support_request(
+    request_id: UUID,
+    payload: SupportTransition,
+    member: CurrentMember,
+    db: DbSession,
+) -> SupportRequestRead:
+    try:
+        request = await _locked_request(db, member, request_id)
+        if (
+            request.status_code != payload.expected_status_code
+            or payload.status_code == payload.expected_status_code
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="invalid_state_transition",
+            )
+        request.status_code = payload.status_code
+        await db.flush()
+        row = await _request_row(db, member, request_id)
+        response_map = await _responses_by_request_ids(db, member, [request_id])
+        read = _request_read(*row, response_map[request_id])
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return read
+
+
+@router.post(
+    "/support-requests/{request_id}/responses",
+    response_model=SupportResponseRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_support_response(
+    request_id: UUID,
+    payload: SupportResponseCreate,
+    response: Response,
+    member: CurrentMember,
+    db: DbSession,
+) -> SupportResponseRead:
+    try:
+        await _locked_request(db, member, request_id)
+        support_response = SupportResponse(
+            id=uuid4(),
+            request_id=request_id,
+            responder_member_id=member.id,
+            body=payload.body,
+        )
+        db.add(support_response)
+        await db.flush()
+        read = _response_read(support_response, member.display_name)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    response.headers["Location"] = (
+        f"/api/support-requests/{request_id}/responses/{support_response.id}"
+    )
+    return read

--- a/backend/app/schemas/support.py
+++ b/backend/app/schemas/support.py
@@ -1,0 +1,83 @@
+from datetime import datetime
+from typing import Annotated, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StringConstraints
+
+Text = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=254),
+]
+LongText = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=5_000),
+]
+SearchQuery = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=100),
+]
+SupportStatus = Literal["in_progress", "completed"]
+
+
+class _WriteModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class SupportRequestCreate(_WriteModel):
+    customer_contact_id: UUID
+    title: Text
+    body: LongText
+    is_urgent: StrictBool
+    status_code: SupportStatus
+
+
+class SupportTransition(_WriteModel):
+    expected_status_code: SupportStatus
+    status_code: SupportStatus
+
+
+class SupportResponseCreate(_WriteModel):
+    body: LongText
+
+
+class SupportResponseRead(BaseModel):
+    id: UUID
+    request_id: UUID
+    responder_member_id: UUID
+    responder_display_name: str
+    body: str
+    responded_at: datetime
+
+
+class SupportRequestRead(BaseModel):
+    id: UUID
+    customer_contact_id: UUID
+    customer_contact_name: str
+    customer_company_id: UUID
+    customer_company_name: str
+    assignee_member_id: UUID
+    assignee_display_name: str
+    title: str
+    body: str
+    is_urgent: bool
+    status_code: SupportStatus
+    registered_at: datetime
+    responses: list[SupportResponseRead]
+
+
+class SupportRequestPage(BaseModel):
+    items: list[SupportRequestRead]
+    skip: int
+    limit: int
+    total: int
+    has_more: bool
+    next_skip: int | None
+
+
+class SupportRequestPageParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    q: SearchQuery | None = None
+    status_code: list[SupportStatus] | None = None
+    skip: int = Field(default=0, ge=0, le=9_223_372_036_854_775_807)
+    limit: int = Field(default=30, ge=1, le=100)

--- a/backend/scripts/seed_demo_support.py
+++ b/backend/scripts/seed_demo_support.py
@@ -1,0 +1,269 @@
+"""filled 데모팀에만 관계가 정확한 합성 C/S 요청 3건을 반복 가능하게 넣는다."""
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from typing import NamedTuple
+from uuid import UUID, uuid5
+
+from sqlalchemy import and_, or_, select
+from sqlalchemy.dialects.postgresql import insert
+
+from app.db.session import get_sessionmaker
+from app.models.crm import CustomerCompany, CustomerContact, SupportRequest
+from app.models.workspace import Member, Team
+from scripts.seed_demo_auth import FILLED_TEAM_ID
+from scripts.seed_demo_customers import FILLED_TEAM_NAME, OWNER_IDS, company_id, contact_id
+
+REFERENCE_AT = datetime(2026, 8, 17, tzinfo=UTC)
+
+STATUS_CODES = {
+    "처리중": "in_progress",
+    "처리완료": "completed",
+}
+
+
+class SupportRequestSeed(NamedTuple):
+    mock_id: str
+    contact_mock_id: str
+    company_name: str
+    contact_name: str
+    department: str
+    assignee_name: str
+    title: str
+    body: str
+    is_urgent: bool
+    status: str
+    registered_day_offset: int
+
+
+# 프론트 C/S 4건 중 현재 고객사·접수자·담당자가 모두 정확한 3건만 옮긴다.
+SUPPORT_REQUEST_SEEDS = (
+    SupportRequestSeed(
+        "cs-1",
+        "FM-CU-2026-0001",
+        "한빛대학교병원",
+        "박서준",
+        "순환기내과",
+        "김지훈",
+        "부팅 시 화면 깜빡임",
+        "진료 중 재현되어 사용을 중단한 상태입니다. 기술지원팀 배정이 필요합니다.",
+        True,
+        "처리중",
+        0,
+    ),
+    SupportRequestSeed(
+        "cs-2",
+        "FM-CU-2026-0002",
+        "서림메디컬센터",
+        "윤가영",
+        "영상의학과",
+        "김지훈",
+        "프로브 케이블 접촉 불량",
+        "프로브 3종 중 1종에서만 발생합니다. 교체용 케이블 재고를 확인하세요.",
+        False,
+        "처리중",
+        -1,
+    ),
+    SupportRequestSeed(
+        "cs-3",
+        "FM-CU-2026-0003",
+        "새봄정형외과",
+        "오정민",
+        "원무팀",
+        "이수민",
+        "젤 워머 온도 편차",
+        "기술지원팀이 원격 점검 중입니다. 결과 회신 예정입니다.",
+        False,
+        "처리중",
+        -2,
+    ),
+)
+
+# 프론트 mock은 note 전체를 요청 내용으로 사용하고 별도 대응 이력을 갖고 있지 않다.
+SUPPORT_RESPONSE_SEEDS: tuple[()] = ()
+
+
+def support_request_id(mock_id: str) -> UUID:
+    return uuid5(FILLED_TEAM_ID, f"support-request:{mock_id}")
+
+
+def support_request_row(seed: SupportRequestSeed) -> dict:
+    return {
+        "id": support_request_id(seed.mock_id),
+        "team_id": FILLED_TEAM_ID,
+        "customer_contact_id": contact_id(seed.contact_mock_id),
+        "assignee_member_id": OWNER_IDS[seed.assignee_name],
+        "title": seed.title,
+        "body": seed.body,
+        "is_urgent": seed.is_urgent,
+        "status_code": STATUS_CODES[seed.status],
+        "registered_at": REFERENCE_AT + timedelta(days=seed.registered_day_offset),
+    }
+
+
+def support_request_upsert(row: dict):
+    request_insert = insert(SupportRequest).values(**row)
+    update_fields = {
+        key: getattr(request_insert.excluded, key)
+        for key in row
+        if key not in {"id", "team_id", "customer_contact_id", "title", "registered_at"}
+    }
+    return request_insert.on_conflict_do_update(
+        index_elements=[SupportRequest.id],
+        set_=update_fields,
+        where=and_(
+            SupportRequest.team_id == FILLED_TEAM_ID,
+            SupportRequest.customer_contact_id == row["customer_contact_id"],
+            SupportRequest.title == row["title"],
+            SupportRequest.registered_at == row["registered_at"],
+        ),
+    ).returning(SupportRequest.id)
+
+
+async def seed_demo_support() -> None:
+    request_rows = tuple(support_request_row(seed) for seed in SUPPORT_REQUEST_SEEDS)
+    expected_requests_by_id = {row["id"]: row for row in request_rows}
+    expected_request_id_by_natural = {
+        (row["customer_contact_id"], row["title"], row["registered_at"]): row["id"]
+        for row in request_rows
+    }
+    expected_contacts_by_id = {
+        contact_id(seed.contact_mock_id): seed for seed in SUPPORT_REQUEST_SEEDS
+    }
+    expected_contact_id_by_natural = {
+        (company_id(seed.company_name), seed.contact_name): contact_id(seed.contact_mock_id)
+        for seed in SUPPORT_REQUEST_SEEDS
+    }
+    expected_assignees = {
+        OWNER_IDS[seed.assignee_name]: seed.assignee_name for seed in SUPPORT_REQUEST_SEEDS
+    }
+    expected_assignee_id_by_name = {
+        name: member_id for member_id, name in expected_assignees.items()
+    }
+
+    async with get_sessionmaker()() as session, session.begin():
+        filled_team_name = (
+            await session.execute(
+                select(Team.name).where(Team.id == FILLED_TEAM_ID).with_for_update()
+            )
+        ).scalar_one_or_none()
+        if filled_team_name != FILLED_TEAM_NAME:
+            raise SystemExit("filled 인증 seed를 먼저 실행하세요.")
+
+        existing_contacts = (
+            await session.execute(
+                select(
+                    CustomerContact.id,
+                    CustomerContact.company_id,
+                    CustomerContact.owner_member_id,
+                    CustomerContact.name,
+                    CustomerContact.department,
+                    CustomerCompany.team_id,
+                    CustomerCompany.name.label("company_name"),
+                )
+                .join(CustomerCompany, CustomerCompany.id == CustomerContact.company_id)
+                .where(
+                    or_(
+                        CustomerContact.id.in_(expected_contacts_by_id),
+                        *(
+                            and_(
+                                CustomerContact.company_id == company_id(seed.company_name),
+                                CustomerContact.name == seed.contact_name,
+                            )
+                            for seed in SUPPORT_REQUEST_SEEDS
+                        ),
+                    )
+                )
+                .with_for_update()
+            )
+        ).all()
+        for row in existing_contacts:
+            expected = expected_contacts_by_id.get(row.id)
+            natural = (row.company_id, row.name)
+            if (
+                expected is None
+                or row.team_id != FILLED_TEAM_ID
+                or row.company_name != expected.company_name
+                or row.department != expected.department
+                or row.owner_member_id != OWNER_IDS[expected.assignee_name]
+                or expected_contact_id_by_natural.get(natural) != row.id
+            ):
+                raise SystemExit("합성 C/S 접수자 ID, 이름, 고객사 또는 팀이 충돌합니다.")
+        if {row.id for row in existing_contacts} != set(expected_contacts_by_id):
+            raise SystemExit("고객 seed를 먼저 실행해 C/S 접수자를 준비하세요.")
+
+        existing_assignees = (
+            await session.execute(
+                select(
+                    Member.id, Member.team_id, Member.display_name, Member.role_code, Member.active
+                )
+                .where(
+                    or_(
+                        Member.id.in_(expected_assignees),
+                        and_(
+                            Member.team_id == FILLED_TEAM_ID,
+                            Member.display_name.in_(expected_assignee_id_by_name),
+                        ),
+                    )
+                )
+                .with_for_update()
+            )
+        ).all()
+        for row in existing_assignees:
+            if (
+                row.team_id != FILLED_TEAM_ID
+                or expected_assignees.get(row.id) != row.display_name
+                or expected_assignee_id_by_name.get(row.display_name) != row.id
+                or row.role_code != "member"
+                or not row.active
+            ):
+                raise SystemExit("합성 C/S 담당자 ID, 이름, 팀, 역할 또는 상태가 충돌합니다.")
+        if {row.id for row in existing_assignees} != set(expected_assignees):
+            raise SystemExit("인증 seed를 먼저 실행해 C/S 담당자를 준비하세요.")
+
+        existing_requests = (
+            await session.execute(
+                select(
+                    SupportRequest.id,
+                    SupportRequest.team_id,
+                    SupportRequest.customer_contact_id,
+                    SupportRequest.title,
+                    SupportRequest.registered_at,
+                )
+                .where(
+                    or_(
+                        SupportRequest.id.in_(expected_requests_by_id),
+                        *(
+                            and_(
+                                SupportRequest.team_id == FILLED_TEAM_ID,
+                                SupportRequest.customer_contact_id == row["customer_contact_id"],
+                                SupportRequest.title == row["title"],
+                                SupportRequest.registered_at == row["registered_at"],
+                            )
+                            for row in request_rows
+                        ),
+                    )
+                )
+                .with_for_update()
+            )
+        ).all()
+        for row in existing_requests:
+            expected = expected_requests_by_id.get(row.id)
+            natural = (row.customer_contact_id, row.title, row.registered_at)
+            if (
+                expected is None
+                or row.team_id != FILLED_TEAM_ID
+                or expected_request_id_by_natural.get(natural) != row.id
+            ):
+                raise SystemExit("합성 C/S 요청 ID 또는 자연키 관계가 충돌합니다.")
+
+        for row in request_rows:
+            upserted_id = (await session.execute(support_request_upsert(row))).scalar_one_or_none()
+            if upserted_id is None:
+                raise SystemExit("합성 C/S 요청 ID 또는 자연키 관계가 충돌합니다.")
+
+    print("filled 데모팀의 합성 C/S 요청 3건을 준비했습니다.")
+
+
+if __name__ == "__main__":
+    asyncio.run(seed_demo_support())

--- a/backend/sql/README.md
+++ b/backend/sql/README.md
@@ -89,3 +89,13 @@ DEBUG=false uv run python -m scripts.seed_demo_contracts
 cd backend
 DEBUG=false uv run python -m scripts.seed_demo_orders
 ```
+
+C/S seed는 인증·고객 seed를 차례로 실행한 뒤 적용합니다. 데이터가 있는 팀에만 고객사,
+접수자, 담당자가 정확히 연결되는 합성 C/S 요청 3건을 upsert합니다. 접수자가 없는 나머지
+프론트 목업 1건은 넣지 않고, 별도 대응 이력이 없어 답변 이력도 만들지 않으며 비어 있는
+팀은 건드리지 않습니다.
+
+```bash
+cd backend
+DEBUG=false uv run python -m scripts.seed_demo_support
+```

--- a/backend/tests/test_seed_demo_support.py
+++ b/backend/tests/test_seed_demo_support.py
@@ -1,0 +1,90 @@
+from datetime import UTC, datetime
+from uuid import uuid5
+
+from sqlalchemy.dialects import postgresql
+
+from scripts.seed_demo_auth import EMPTY_TEAM_ID, FILLED_TEAM_ID
+from scripts.seed_demo_customers import OWNER_IDS, contact_id
+from scripts.seed_demo_support import (
+    REFERENCE_AT,
+    STATUS_CODES,
+    SUPPORT_REQUEST_SEEDS,
+    SUPPORT_RESPONSE_SEEDS,
+    support_request_id,
+    support_request_row,
+    support_request_upsert,
+)
+
+
+def test_demo_support_seed_shape_is_fixed_and_lossless():
+    rows = {seed.mock_id: support_request_row(seed) for seed in SUPPORT_REQUEST_SEEDS}
+
+    assert REFERENCE_AT == datetime(2026, 8, 17, tzinfo=UTC)
+    assert [seed.mock_id for seed in SUPPORT_REQUEST_SEEDS] == ["cs-1", "cs-2", "cs-3"]
+    assert len(rows) == len(SUPPORT_REQUEST_SEEDS) == 3
+    assert len({row["id"] for row in rows.values()}) == 3
+    assert all(row["team_id"] == FILLED_TEAM_ID != EMPTY_TEAM_ID for row in rows.values())
+    assert SUPPORT_RESPONSE_SEEDS == ()
+    assert STATUS_CODES == {"처리중": "in_progress", "처리완료": "completed"}
+
+    assert rows == {
+        "cs-1": {
+            "id": support_request_id("cs-1"),
+            "team_id": FILLED_TEAM_ID,
+            "customer_contact_id": contact_id("FM-CU-2026-0001"),
+            "assignee_member_id": OWNER_IDS["김지훈"],
+            "title": "부팅 시 화면 깜빡임",
+            "body": "진료 중 재현되어 사용을 중단한 상태입니다. 기술지원팀 배정이 필요합니다.",
+            "is_urgent": True,
+            "status_code": "in_progress",
+            "registered_at": datetime(2026, 8, 17, tzinfo=UTC),
+        },
+        "cs-2": {
+            "id": support_request_id("cs-2"),
+            "team_id": FILLED_TEAM_ID,
+            "customer_contact_id": contact_id("FM-CU-2026-0002"),
+            "assignee_member_id": OWNER_IDS["김지훈"],
+            "title": "프로브 케이블 접촉 불량",
+            "body": "프로브 3종 중 1종에서만 발생합니다. 교체용 케이블 재고를 확인하세요.",
+            "is_urgent": False,
+            "status_code": "in_progress",
+            "registered_at": datetime(2026, 8, 16, tzinfo=UTC),
+        },
+        "cs-3": {
+            "id": support_request_id("cs-3"),
+            "team_id": FILLED_TEAM_ID,
+            "customer_contact_id": contact_id("FM-CU-2026-0003"),
+            "assignee_member_id": OWNER_IDS["이수민"],
+            "title": "젤 워머 온도 편차",
+            "body": "기술지원팀이 원격 점검 중입니다. 결과 회신 예정입니다.",
+            "is_urgent": False,
+            "status_code": "in_progress",
+            "registered_at": datetime(2026, 8, 15, tzinfo=UTC),
+        },
+    }
+
+
+def test_demo_support_rows_and_upserts_are_idempotent_and_filled_only():
+    first = tuple(support_request_row(seed) for seed in SUPPORT_REQUEST_SEEDS)
+    second = tuple(support_request_row(seed) for seed in SUPPORT_REQUEST_SEEDS)
+
+    assert first == second
+    assert all(row["team_id"] == FILLED_TEAM_ID for row in first)
+    assert all(row["team_id"] != EMPTY_TEAM_ID for row in first)
+    assert all(
+        row["id"] == uuid5(FILLED_TEAM_ID, f"support-request:{seed.mock_id}")
+        for seed, row in zip(SUPPORT_REQUEST_SEEDS, first, strict=True)
+    )
+    assert len(
+        {(row["customer_contact_id"], row["title"], row["registered_at"]) for row in first}
+    ) == len(first)
+
+    dialect = postgresql.dialect()
+    for row in first:
+        sql = str(support_request_upsert(row).compile(dialect=dialect))
+        assert "ON CONFLICT (id) DO UPDATE" in sql
+        assert "RETURNING public.support_request.id" in sql
+        assert "team_id = excluded.team_id" not in sql
+        assert "customer_contact_id = excluded.customer_contact_id" not in sql
+        assert "title = excluded.title" not in sql
+        assert "registered_at = excluded.registered_at" not in sql

--- a/backend/tests/test_support.py
+++ b/backend/tests/test_support.py
@@ -1,0 +1,434 @@
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from app.api.deps import get_current_member
+from app.core.config import settings
+from app.db.session import get_db
+from app.main import app
+from app.models.crm import CustomerCompany, CustomerContact, SupportRequest, SupportResponse
+from app.models.workspace import Member
+from app.schemas.support import (
+    SupportRequestCreate,
+    SupportRequestPageParams,
+    SupportResponseCreate,
+    SupportTransition,
+)
+
+ORIGIN = settings.cors_origin_list[0]
+NOW = datetime(2026, 8, 17, 9, tzinfo=UTC)
+_MISSING = object()
+
+
+class _Result:
+    def __init__(self, *, scalar=_MISSING, rows=None):
+        self.scalar = scalar
+        self.rows = [] if rows is None else rows
+
+    def scalar_one(self):
+        assert self.scalar is not _MISSING
+        return self.scalar
+
+    def scalar_one_or_none(self):
+        assert self.scalar is not _MISSING
+        return self.scalar
+
+    def one_or_none(self):
+        assert len(self.rows) <= 1
+        return self.rows[0] if self.rows else None
+
+    def all(self):
+        return self.rows
+
+
+class _Db:
+    def __init__(self, *results: _Result, flush_error: Exception | None = None):
+        self.results = list(results)
+        self.flush_error = flush_error
+        self.statements = []
+        self.added = []
+        self.flush_count = 0
+        self.commit_count = 0
+        self.rollback_count = 0
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        assert self.results
+        return self.results.pop(0)
+
+    def add(self, value):
+        self.added.append(value)
+
+    async def flush(self):
+        self.flush_count += 1
+        if self.flush_error is not None:
+            raise self.flush_error
+        for value in self.added:
+            if isinstance(value, SupportRequest) and value.registered_at is None:
+                value.registered_at = NOW
+            if isinstance(value, SupportResponse) and value.responded_at is None:
+                value.responded_at = NOW
+
+    async def commit(self):
+        self.commit_count += 1
+
+    async def rollback(self):
+        self.rollback_count += 1
+
+
+@pytest.fixture(autouse=True)
+def reset_dependency_overrides():
+    app.dependency_overrides.clear()
+    yield
+    app.dependency_overrides.clear()
+
+
+def _member(*, role: str = "member", team_id: UUID | None = None) -> Member:
+    return Member(
+        id=uuid4(),
+        team_id=team_id or uuid4(),
+        login_id=f"{uuid4()}@salesluv.demo",
+        password_hash="unused",
+        display_name="합성 담당자",
+        role_code=role,
+        job_title="영업 담당자",
+        active=True,
+    )
+
+
+def _company(team_id: UUID) -> CustomerCompany:
+    return CustomerCompany(
+        id=uuid4(),
+        team_id=team_id,
+        name="합성 고객사",
+        region_code="seoul",
+        created_at=NOW,
+    )
+
+
+def _contact(owner: Member, company: CustomerCompany) -> CustomerContact:
+    return CustomerContact(
+        id=uuid4(),
+        company_id=company.id,
+        owner_member_id=owner.id,
+        name="합성 고객",
+        department="구매팀",
+        job_title="팀장",
+        email=None,
+        phone="010-0000-0000",
+        status_code="contracted",
+        source_code=None,
+        memo=None,
+        registered_at=NOW,
+    )
+
+
+def _request(
+    assignee: Member,
+    contact: CustomerContact,
+    *,
+    status_code: str = "in_progress",
+) -> SupportRequest:
+    return SupportRequest(
+        id=uuid4(),
+        team_id=assignee.team_id,
+        customer_contact_id=contact.id,
+        assignee_member_id=assignee.id,
+        title="합성 문의",
+        body="합성 문의 본문",
+        is_urgent=True,
+        status_code=status_code,
+        registered_at=NOW,
+    )
+
+
+def _support_response(request: SupportRequest, responder: Member) -> SupportResponse:
+    return SupportResponse(
+        id=uuid4(),
+        request_id=request.id,
+        responder_member_id=responder.id,
+        body="합성 답변",
+        responded_at=NOW,
+    )
+
+
+def _row(
+    request: SupportRequest,
+    contact: CustomerContact,
+    company: CustomerCompany,
+    assignee: Member,
+):
+    return request, contact.name, company.id, company.name, assignee.display_name
+
+
+def _client(db: _Db, member: Member) -> TestClient:
+    async def override_db():
+        yield db
+
+    async def override_member():
+        return member
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_member] = override_member
+    return TestClient(app)
+
+
+def _payload(contact: CustomerContact, **overrides):
+    values = {
+        "customer_contact_id": str(contact.id),
+        "title": " 합성 문의 ",
+        "body": " 합성 문의 본문 ",
+        "is_urgent": True,
+        "status_code": "in_progress",
+    }
+    return values | overrides
+
+
+def test_support_write_models_are_strict_and_allow_only_two_status_codes():
+    contact_id = uuid4()
+    parsed = SupportRequestCreate(
+        customer_contact_id=contact_id,
+        title=" 문의 ",
+        body=" 본문 ",
+        is_urgent=True,
+        status_code="completed",
+    )
+    assert parsed.title == "문의"
+    assert parsed.body == "본문"
+    assert SupportRequestPageParams(status_code=["in_progress", "completed"])
+
+    invalid_payloads = (
+        {"body": " "},
+        {"status_code": "처리중"},
+        {"is_urgent": 1},
+        {"unknown": "value"},
+    )
+    for invalid in invalid_payloads:
+        with pytest.raises(ValidationError):
+            SupportRequestCreate(
+                **{
+                    "customer_contact_id": contact_id,
+                    "title": "문의",
+                    "body": "본문",
+                    "is_urgent": True,
+                    "status_code": "in_progress",
+                }
+                | invalid
+            )
+    with pytest.raises(ValidationError):
+        SupportResponseCreate(body=" ")
+    with pytest.raises(ValidationError):
+        SupportTransition(expected_status_code="in_progress", status_code="done")
+
+
+def test_member_list_and_detail_are_scoped_and_include_response_history():
+    member = _member()
+    company = _company(member.team_id)
+    contact = _contact(member, company)
+    request = _request(member, contact)
+    response_item = _support_response(request, member)
+    list_db = _Db(
+        _Result(scalar=1),
+        _Result(rows=[_row(request, contact, company, member)]),
+        _Result(rows=[(response_item, member.display_name)]),
+    )
+
+    with _client(list_db, member) as client:
+        response = client.get(
+            "/api/support-requests",
+            params=[("q", " 합성 "), ("status_code", "in_progress")],
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "items": [
+            {
+                "id": str(request.id),
+                "customer_contact_id": str(contact.id),
+                "customer_contact_name": contact.name,
+                "customer_company_id": str(company.id),
+                "customer_company_name": company.name,
+                "assignee_member_id": str(member.id),
+                "assignee_display_name": member.display_name,
+                "title": request.title,
+                "body": request.body,
+                "is_urgent": True,
+                "status_code": "in_progress",
+                "registered_at": "2026-08-17T18:00:00+09:00",
+                "responses": [
+                    {
+                        "id": str(response_item.id),
+                        "request_id": str(request.id),
+                        "responder_member_id": str(member.id),
+                        "responder_display_name": member.display_name,
+                        "body": response_item.body,
+                        "responded_at": "2026-08-17T18:00:00+09:00",
+                    }
+                ],
+            }
+        ],
+        "skip": 0,
+        "limit": 30,
+        "total": 1,
+        "has_more": False,
+        "next_skip": None,
+    }
+    for statement in list_db.statements[:2]:
+        assert member.id in statement.compile().params.values()
+        assert member.team_id in statement.compile().params.values()
+        assert "%합성%" in statement.compile().params.values()
+    assert member.team_id in list_db.statements[2].compile().params.values()
+
+    detail_db = _Db(
+        _Result(rows=[_row(request, contact, company, member)]),
+        _Result(rows=[(response_item, member.display_name)]),
+    )
+    with _client(detail_db, member) as client:
+        detail = client.get(f"/api/support-requests/{request.id}")
+    assert detail.status_code == 200
+    assert detail.json()["responses"][0]["body"] == response_item.body
+
+
+def test_manager_reads_team_request_without_member_self_filter():
+    manager = _member(role="manager")
+    assignee = _member(team_id=manager.team_id)
+    company = _company(manager.team_id)
+    contact = _contact(assignee, company)
+    request = _request(assignee, contact)
+    db = _Db(
+        _Result(scalar=1),
+        _Result(rows=[_row(request, contact, company, assignee)]),
+        _Result(rows=[]),
+    )
+
+    with _client(db, manager) as client:
+        response = client.get("/api/support-requests")
+
+    assert response.status_code == 200
+    assert response.json()["items"][0]["assignee_member_id"] == str(assignee.id)
+    assert manager.id not in db.statements[0].compile().params.values()
+
+
+def test_create_uses_visible_contact_and_current_member_as_assignee():
+    member = _member()
+    company = _company(member.team_id)
+    contact = _contact(member, company)
+    db = _Db(_Result(rows=[(contact, company)]))
+
+    with _client(db, member) as client:
+        response = client.post(
+            "/api/support-requests",
+            headers={"Origin": ORIGIN},
+            json=_payload(contact, status_code="completed"),
+        )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["assignee_member_id"] == str(member.id)
+    assert data["status_code"] == "completed"
+    assert data["title"] == "합성 문의"
+    assert data["responses"] == []
+    assert response.headers["location"] == f"/api/support-requests/{data['id']}"
+    created = db.added[0]
+    assert isinstance(created, SupportRequest)
+    assert created.team_id == member.team_id
+    assert created.assignee_member_id == member.id
+    assert member.id in db.statements[0].compile().params.values()
+    assert db.flush_count == db.commit_count == 1
+    assert db.rollback_count == 0
+
+    hidden_db = _Db(_Result(rows=[]))
+    with _client(hidden_db, member) as client:
+        hidden = client.post(
+            "/api/support-requests",
+            headers={"Origin": ORIGIN},
+            json=_payload(contact),
+        )
+    assert hidden.status_code == 404
+    assert hidden.json() == {"detail": "customer_contact_not_found"}
+    assert hidden_db.added == []
+    assert hidden_db.commit_count == 0
+    assert hidden_db.rollback_count == 1
+
+
+def test_transition_uses_stale_guard_and_rejects_noop():
+    member = _member()
+    company = _company(member.team_id)
+    contact = _contact(member, company)
+    request = _request(member, contact)
+    db = _Db(
+        _Result(scalar=request),
+        _Result(rows=[_row(request, contact, company, member)]),
+        _Result(rows=[]),
+    )
+
+    with _client(db, member) as client:
+        response = client.post(
+            f"/api/support-requests/{request.id}/transition",
+            headers={"Origin": ORIGIN},
+            json={"expected_status_code": "in_progress", "status_code": "completed"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["status_code"] == "completed"
+    assert "FOR UPDATE" in str(db.statements[0])
+    assert db.flush_count == db.commit_count == 1
+
+    for payload in (
+        {"expected_status_code": "completed", "status_code": "in_progress"},
+        {"expected_status_code": "in_progress", "status_code": "in_progress"},
+    ):
+        current = _request(member, contact)
+        stale_db = _Db(_Result(scalar=current))
+        with _client(stale_db, member) as client:
+            stale = client.post(
+                f"/api/support-requests/{current.id}/transition",
+                headers={"Origin": ORIGIN},
+                json=payload,
+            )
+        assert stale.status_code == 409
+        assert stale.json() == {"detail": "invalid_state_transition"}
+        assert stale_db.flush_count == stale_db.commit_count == 0
+        assert stale_db.rollback_count == 1
+
+
+def test_response_creation_uses_current_member_and_hides_invisible_request():
+    manager = _member(role="manager")
+    assignee = _member(team_id=manager.team_id)
+    company = _company(manager.team_id)
+    contact = _contact(assignee, company)
+    request = _request(assignee, contact)
+    db = _Db(_Result(scalar=request))
+
+    with _client(db, manager) as client:
+        response = client.post(
+            f"/api/support-requests/{request.id}/responses",
+            headers={"Origin": ORIGIN},
+            json={"body": " 합성 처리 답변 "},
+        )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["request_id"] == str(request.id)
+    assert data["responder_member_id"] == str(manager.id)
+    assert data["responder_display_name"] == manager.display_name
+    assert data["body"] == "합성 처리 답변"
+    assert data["responded_at"] == "2026-08-17T18:00:00+09:00"
+    assert response.headers["location"].endswith(f"/responses/{data['id']}")
+    assert isinstance(db.added[0], SupportResponse)
+    assert db.flush_count == db.commit_count == 1
+
+    hidden_db = _Db(_Result(scalar=None))
+    with _client(hidden_db, manager) as client:
+        hidden = client.post(
+            f"/api/support-requests/{uuid4()}/responses",
+            headers={"Origin": ORIGIN},
+            json={"body": "합성 답변"},
+        )
+    assert hidden.status_code == 404
+    assert hidden.json() == {"detail": "support_request_not_found"}
+    assert hidden_db.added == []
+    assert hidden_db.rollback_count == 1

--- a/frontend/src/components/layout/Topbar/Topbar.tsx
+++ b/frontend/src/components/layout/Topbar/Topbar.tsx
@@ -32,6 +32,8 @@ export default function Topbar() {
   const pageLabel = findNavLabel(pathname) ?? '페이지를 찾을 수 없음'
   const isVisits = pathname === ROUTES.VISITS || pathname.startsWith(`${ROUTES.VISITS}/`)
   const isOrders = pathname === ROUTES.ORDERS || pathname.startsWith(`${ROUTES.ORDERS}/`)
+  const isComplaints =
+    pathname === ROUTES.COMPLAINTS || pathname.startsWith(`${ROUTES.COMPLAINTS}/`)
 
   return (
     <header className={styles.topbar}>
@@ -57,7 +59,8 @@ export default function Topbar() {
         pathname !== ROUTES.CUSTOMERS &&
         pathname !== ROUTES.CALENDAR &&
         !isVisits &&
-        !isOrders && (
+        !isOrders &&
+        !isComplaints && (
           <div className={styles.scope}>
             <ScopeSwitcher />
           </div>

--- a/frontend/src/pages/Complaints/Complaints.module.scss
+++ b/frontend/src/pages/Complaints/Complaints.module.scss
@@ -162,6 +162,14 @@
   }
 }
 
+.loadState {
+  display: flex;
+  align-items: center;
+  gap: var(--s3);
+  color: var(--muted);
+  font-size: 13px;
+}
+
 /* ---- 폰: 표 대신 카드 ---- */
 
 .cardList {
@@ -231,6 +239,65 @@
   dd {
     margin: 0;
     line-height: 1.6;
+  }
+}
+
+.responses {
+  display: grid;
+  gap: var(--s3);
+  margin-top: var(--s6);
+  padding-top: var(--s5);
+  border-top: 1px solid var(--line);
+
+  h3 {
+    color: var(--ink);
+    font-size: 14px;
+  }
+
+  ol {
+    display: grid;
+    gap: var(--s2);
+  }
+
+  li {
+    padding: var(--s3);
+    border-radius: var(--r-sm);
+    background: var(--surface-2);
+
+    div {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: var(--s2);
+      color: var(--ink-2);
+      font-size: 12px;
+    }
+
+    time {
+      color: var(--muted);
+    }
+
+    p {
+      margin-top: var(--s2);
+      color: var(--ink-2);
+      font-size: 13px;
+      line-height: 1.6;
+      white-space: pre-wrap;
+    }
+  }
+}
+
+.noResponses {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.responseForm {
+  @include form-field;
+  align-items: flex-start;
+
+  button {
+    align-self: flex-end;
   }
 }
 

--- a/frontend/src/pages/Complaints/Complaints.tsx
+++ b/frontend/src/pages/Complaints/Complaints.tsx
@@ -1,8 +1,3 @@
-// 고객불만관리. 대시보드 KPI 타일 'C/S 대응요청' 이 보여 주는 그 목록의 본화면입니다.
-// 목록은 shared/counters.ts 한 곳에 있어, 여기서 등록하거나 상태를 바꾸면 대시보드
-// 타일 숫자와 드로어 줄이 함께 바뀝니다.
-//
-// 조건은 주소에 둡니다(q·status). 걸러 둔 채로 링크를 건네면 받는 쪽도 같은 화면을 봅니다.
 import { useCallback, useDeferredValue, useMemo, useState } from 'react'
 import { useSearchParams } from 'react-router'
 
@@ -12,23 +7,30 @@ import { ComplaintIcon, PlusIcon, SearchIcon } from '@/components/icons'
 import SearchInput from '@/components/SearchInput'
 import Tabs, { type TabItem } from '@/components/Tabs'
 import { BP_DESKTOP } from '@/constants/breakpoints'
-import { addCsRequest, setCsState, useCsRequests } from '@/shared/counters'
-import type { ColumnTone, CsRequest, CsState } from '@/types'
 import useMediaQuery from '@/hooks/useMediaQuery'
-import { addDays, fmtDay, fmtDotShort, TODAY } from '@/utils/date'
+import type {
+  ColumnTone,
+  SupportRequestResponse,
+  SupportStatusCode,
+  SupportResponseResponse,
+} from '@/types'
+import { fmtDotShort } from '@/utils/date'
 
 import ComplaintFormModal from './components/ComplaintFormModal'
+import useSupportRequests from './useSupportRequests'
 
 import styles from './Complaints.module.scss'
 
-/** 상태 두 가지. 탭 순서와 배지 색이 여기에 묶여 있습니다. */
-const STATES: CsState[] = ['처리중', '처리완료']
+const STATES: { code: SupportStatusCode; label: string; tone: ColumnTone }[] = [
+  { code: 'in_progress', label: '처리중', tone: 'blue' },
+  { code: 'completed', label: '처리완료', tone: 'green' },
+]
 
-/** 탭 앞 색 점. 목록 배지와 같은 색을 씁니다. */
-const TONE_OF: Record<CsState, ColumnTone> = { 처리중: 'blue', 처리완료: 'green' }
+const STATUS_LABEL: Record<SupportStatusCode, string> = {
+  in_progress: '처리중',
+  completed: '처리완료',
+}
 
-// 표가 화면보다 넓으면 이 폭 그대로, 좁으면 이 폭의 비율로 늘어납니다(table-layout: fixed).
-// 남는 자리는 잘리면 아쉬운 '내용'이 가져가고 상태·날짜는 좁게 붙잡아 둡니다.
 const COLUMNS = [
   { id: 'org', header: '회사', width: 150 },
   { id: 'owner', header: '담당자', width: 90 },
@@ -38,25 +40,44 @@ const COLUMNS = [
   { id: 'created', header: '등록날짜', width: 104 },
 ]
 
-/** 접수한 날. agoOff 가 오늘로부터 며칠 전인지를 들고 있습니다. */
-const createdAt = (c: CsRequest) => addDays(TODAY, c.agoOff)
+const dateOf = (value: string) => new Date(value)
+
+const dateTime = new Intl.DateTimeFormat('ko-KR', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+})
 
 export default function Complaints() {
-  const complaints = useCsRequests()
-
   const [params, setParams] = useSearchParams()
   const query = params.get('q') ?? ''
   const status = params.get('status') ?? ''
-
-  // 타이핑 중에도 입력이 밀리지 않도록 목록 계산만 한 박자 늦춥니다.
   const deferredQuery = useDeferredValue(query)
 
   const [openId, setOpenId] = useState<string | null>(null)
   const [adding, setAdding] = useState(false)
-
   const isDesktop = useMediaQuery(`(min-width: ${BP_DESKTOP}px)`)
 
-  // 기본값은 쿼리에서 지웁니다. 주소를 복사했을 때 조건이 그대로 살아나되 짧게 남습니다.
+  const {
+    requests,
+    contacts,
+    loading,
+    error,
+    reload,
+    detail,
+    detailLoading,
+    detailError,
+    reloadDetail,
+    pendingKey,
+    mutationError,
+    clearMutationError,
+    createRequest,
+    transition,
+    addResponse,
+  } = useSupportRequests(openId)
+
   const setParam = useCallback(
     (key: string, value: string) => {
       const next = new URLSearchParams(params)
@@ -67,17 +88,28 @@ export default function Complaints() {
     [params, setParams],
   )
 
-  // 상태를 뺀 나머지 조건까지만 거른 목록입니다. 탭의 건수를 여기서 셉니다.
   const beforeStatus = useMemo(() => {
     const needle = deferredQuery.trim().toLowerCase()
-    if (needle === '') return complaints
-    return complaints.filter((c) =>
-      [c.issue, c.org, c.owner, c.note].join(' ').toLowerCase().includes(needle),
+    if (needle === '') return requests
+    return requests.filter((request) =>
+      [
+        request.title,
+        request.body,
+        request.customer_company_name,
+        request.customer_contact_name,
+        request.assignee_display_name,
+      ]
+        .join(' ')
+        .toLowerCase()
+        .includes(needle),
     )
-  }, [complaints, deferredQuery])
+  }, [requests, deferredQuery])
 
   const rows = useMemo(
-    () => (status === '' ? beforeStatus : beforeStatus.filter((c) => c.state === status)),
+    () =>
+      status === ''
+        ? beforeStatus
+        : beforeStatus.filter((request) => request.status_code === status),
     [beforeStatus, status],
   )
 
@@ -85,24 +117,26 @@ export default function Complaints() {
     () => [
       { value: '', label: '전체', count: beforeStatus.length },
       ...STATES.map((state) => ({
-        value: state,
-        label: state,
-        count: beforeStatus.filter((c) => c.state === state).length,
-        tone: TONE_OF[state],
+        value: state.code,
+        label: state.label,
+        count: beforeStatus.filter((request) => request.status_code === state.code).length,
+        tone: state.tone,
       })),
     ],
     [beforeStatus],
   )
 
-  // 객체가 아니라 id 를 들고 목록에서 찾습니다. 상태를 바꾸면 새 객체가 되므로
-  // 열어 둔 드로어가 바뀐 값을 그대로 받습니다.
-  const open = openId ? complaints.find((c) => c.id === openId) : undefined
-
+  const summary = openId === null ? undefined : requests.find((request) => request.id === openId)
+  const open = detail?.id === openId ? detail : summary
   const isFiltered = query.trim() !== '' || status !== ''
 
+  const closeDrawer = useCallback(() => {
+    setOpenId(null)
+    clearMutationError()
+  }, [clearMutationError])
+
   return (
-    <section className={styles.page}>
-      {/* Topbar 빵부스러기가 이미 화면 이름을 말하므로 제목은 읽어 주기만 합니다. */}
+    <section className={styles.page} aria-busy={loading}>
       <h1 className="sr-only">고객불만관리</h1>
 
       <div className={styles.toolbar}>
@@ -115,7 +149,7 @@ export default function Complaints() {
         />
 
         <div className={styles.actions}>
-          <Button onClick={() => setAdding(true)}>
+          <Button disabled={loading} onClick={() => setAdding(true)}>
             <PlusIcon width={15} height={15} />
             불만 등록
           </Button>
@@ -129,7 +163,18 @@ export default function Complaints() {
         onChange={(next) => setParam('status', next)}
       />
 
-      {rows.length === 0 ? (
+      {error ? (
+        <div className={styles.loadState} role="alert">
+          <p>{error}</p>
+          <Button variant="outline" onClick={reload}>
+            다시 시도
+          </Button>
+        </div>
+      ) : loading && requests.length === 0 ? (
+        <p className={styles.loadState} role="status">
+          고객불만 목록을 불러오는 중입니다.
+        </p>
+      ) : rows.length === 0 ? (
         <div className={styles.card}>
           <div className={styles.empty}>
             {isFiltered ? (
@@ -150,60 +195,59 @@ export default function Complaints() {
           </div>
         </div>
       ) : isDesktop ? (
-        // 표와 카드는 마크업 자체가 다릅니다. CSS 로는 한쪽을 숨기는 것밖에 못 해
-        // 폰에서도 여섯 열짜리 DOM 을 그대로 들고 있게 됩니다.
         <div className={styles.card}>
           <div className={styles.scroller}>
             <table
               className={styles.table}
-              style={{ width: COLUMNS.reduce((sum, col) => sum + col.width, 0) }}
+              style={{ width: COLUMNS.reduce((sum, column) => sum + column.width, 0) }}
             >
               <caption className="sr-only">고객불만 목록. 줄을 누르면 상세가 열립니다.</caption>
-
               <colgroup>
-                {COLUMNS.map((col) => (
-                  <col key={col.id} style={{ width: col.width }} />
+                {COLUMNS.map((column) => (
+                  <col key={column.id} style={{ width: column.width }} />
                 ))}
               </colgroup>
-
               <thead>
                 <tr>
-                  {COLUMNS.map((col) => (
-                    <th key={col.id} scope="col">
-                      {col.header}
+                  {COLUMNS.map((column) => (
+                    <th key={column.id} scope="col">
+                      {column.header}
                     </th>
                   ))}
                 </tr>
               </thead>
-
               <tbody>
-                {rows.map((c) => (
-                  <tr key={c.id} className={styles.clickable} onClick={() => setOpenId(c.id)}>
-                    <td title={c.org}>
-                      {/* 줄 전체를 누르지만 tr 은 키보드로 못 잡습니다. 첫 칸이
-                          그 손잡이이고, 하는 일은 줄을 누른 것과 같습니다. */}
+                {rows.map((request) => (
+                  <tr
+                    key={request.id}
+                    className={styles.clickable}
+                    onClick={() => setOpenId(request.id)}
+                  >
+                    <td title={request.customer_company_name}>
                       <button
                         type="button"
                         className={styles.openButton}
                         onClick={(event) => {
                           event.stopPropagation()
-                          setOpenId(c.id)
+                          setOpenId(request.id)
                         }}
                       >
-                        {c.org}
+                        {request.customer_company_name}
                       </button>
                     </td>
-                    <td title={c.owner}>{c.owner}</td>
-                    <td className={styles.issue} title={c.issue}>
-                      {c.issue}
+                    <td title={request.assignee_display_name}>{request.assignee_display_name}</td>
+                    <td className={styles.issue} title={request.title}>
+                      {request.title}
                     </td>
-                    <td className={styles.note} title={c.note}>
-                      {c.note}
+                    <td className={styles.note} title={request.body}>
+                      {request.body}
                     </td>
                     <td>
-                      <StateBadge state={c.state} />
+                      <StateBadge state={request.status_code} />
                     </td>
-                    <td className={`${styles.date} tnum`}>{fmtDotShort(createdAt(c))}</td>
+                    <td className={`${styles.date} tnum`}>
+                      {fmtDotShort(dateOf(request.registered_at))}
+                    </td>
                   </tr>
                 ))}
               </tbody>
@@ -212,20 +256,23 @@ export default function Complaints() {
         </div>
       ) : (
         <ul className={styles.cardList}>
-          {rows.map((c) => (
-            <li key={c.id} className={styles.miniCard} onClick={() => setOpenId(c.id)}>
-              {/* 표와 같은 순서로 읽힙니다 — 회사·담당자 다음에 제목·내용. */}
+          {rows.map((request) => (
+            <li key={request.id} className={styles.miniCard} onClick={() => setOpenId(request.id)}>
               <div className={styles.miniHead}>
-                <button type="button" className={styles.openButton} onClick={() => setOpenId(c.id)}>
-                  {c.org}
+                <button
+                  type="button"
+                  className={styles.openButton}
+                  onClick={() => setOpenId(request.id)}
+                >
+                  {request.customer_company_name}
                 </button>
-                <StateBadge state={c.state} />
+                <StateBadge state={request.status_code} />
               </div>
-              <p className={styles.miniIssue}>{c.issue}</p>
-              <p className={styles.miniNote}>{c.note}</p>
+              <p className={styles.miniIssue}>{request.title}</p>
+              <p className={styles.miniNote}>{request.body}</p>
               <div className={styles.miniMeta}>
-                <span>{c.owner}</span>
-                <span className="tnum">{fmtDotShort(createdAt(c))}</span>
+                <span>{request.assignee_display_name}</span>
+                <span className="tnum">{fmtDotShort(dateOf(request.registered_at))}</span>
               </div>
             </li>
           ))}
@@ -234,56 +281,95 @@ export default function Complaints() {
 
       {open && (
         <Drawer
-          title={open.issue}
-          sub={open.org}
-          onClose={() => setOpenId(null)}
+          title={open.title}
+          sub={`${open.customer_company_name} · ${open.customer_contact_name}`}
+          onClose={closeDrawer}
           meta={
             <>
-              <StateBadge state={open.state} />
-              {open.urgent && <i className={`${styles.badge} ${styles.risk}`}>긴급</i>}
+              <StateBadge state={open.status_code} />
+              {open.is_urgent && <i className={`${styles.badge} ${styles.risk}`}>긴급</i>}
             </>
           }
           footer={
-            open.state === '처리중' ? (
-              <Button onClick={() => setCsState(open.id, '처리완료')}>처리완료로 변경</Button>
-            ) : (
-              <Button variant="outline" onClick={() => setCsState(open.id, '처리중')}>
-                처리중으로 되돌리기
+            detail?.id === open.id ? (
+              <Button
+                variant={detail.status_code === 'in_progress' ? 'primary' : 'outline'}
+                disabled={pendingKey !== null}
+                onClick={() =>
+                  void transition(
+                    detail,
+                    detail.status_code === 'in_progress' ? 'completed' : 'in_progress',
+                  )
+                }
+              >
+                {pendingKey === `transition:${open.id}`
+                  ? '변경 중…'
+                  : detail.status_code === 'in_progress'
+                    ? '처리완료로 변경'
+                    : '처리중으로 되돌리기'}
               </Button>
-            )
+            ) : undefined
           }
         >
-          <dl className={styles.rows}>
-            {/* 화면에서 등록한 건에는 접수자가 없습니다. 있는 값만 늘어놓습니다. */}
-            {(
-              [
-                ['회사', open.org],
-                ['담당자', open.owner],
-                ['접수자', open.who],
-                ['물품명', open.product],
-                ['등록날짜', `${fmtDay(createdAt(open))} · ${open.ago}`],
-                ['내용', open.note],
-              ] as [string, string][]
-            )
-              .filter(([, value]) => value !== '')
-              .map(([label, value]) => (
-                <div key={label}>
-                  <dt>{label}</dt>
-                  <dd>{value}</dd>
+          {detailError ? (
+            <div className={styles.loadState} role="alert">
+              <p>{detailError}</p>
+              <Button variant="outline" onClick={reloadDetail}>
+                다시 시도
+              </Button>
+            </div>
+          ) : detailLoading || detail?.id !== open.id ? (
+            <p className={styles.loadState} role="status">
+              상세 내용을 불러오는 중입니다.
+            </p>
+          ) : (
+            <>
+              <dl className={styles.rows}>
+                <div>
+                  <dt>회사</dt>
+                  <dd>{detail.customer_company_name}</dd>
                 </div>
-              ))}
-          </dl>
+                <div>
+                  <dt>고객 담당자</dt>
+                  <dd>{detail.customer_contact_name}</dd>
+                </div>
+                <div>
+                  <dt>처리 담당자</dt>
+                  <dd>{detail.assignee_display_name}</dd>
+                </div>
+                <div>
+                  <dt>등록일시</dt>
+                  <dd>{dateTime.format(dateOf(detail.registered_at))}</dd>
+                </div>
+                <div>
+                  <dt>내용</dt>
+                  <dd>{detail.body}</dd>
+                </div>
+              </dl>
+
+              <ResponseHistory
+                key={detail.id}
+                request={detail}
+                pending={pendingKey === `response:${detail.id}`}
+                error={mutationError}
+                onClearError={clearMutationError}
+                onSubmit={(body) => addResponse(detail.id, body)}
+              />
+            </>
+          )}
         </Drawer>
       )}
 
       {adding && (
         <ComplaintFormModal
+          contacts={contacts}
           onClose={() => setAdding(false)}
-          onSubmit={(draft) => {
-            const created = addCsRequest(draft)
+          onSubmit={async (payload) => {
+            const created = await createRequest(payload)
             setAdding(false)
-            // 방금 등록한 건이 걸러져 보이지 않으면 저장됐는지 알 수 없습니다.
-            if (status !== '' && status !== created.state) setParam('status', created.state)
+            if (status !== '' && status !== created.status_code) {
+              setParam('status', created.status_code)
+            }
           }}
         />
       )}
@@ -291,10 +377,92 @@ export default function Complaints() {
   )
 }
 
-function StateBadge({ state }: { state: CsState }) {
+function StateBadge({ state }: { state: SupportStatusCode }) {
   return (
-    <i className={`${styles.badge} ${state === '처리완료' ? styles.done : styles.working}`}>
-      {state}
+    <i className={`${styles.badge} ${state === 'completed' ? styles.done : styles.working}`}>
+      {STATUS_LABEL[state]}
     </i>
+  )
+}
+
+interface ResponseHistoryProps {
+  request: SupportRequestResponse
+  pending: boolean
+  error: string | null
+  onClearError: () => void
+  onSubmit: (body: string) => Promise<boolean>
+}
+
+function ResponseHistory({
+  request,
+  pending,
+  error,
+  onClearError,
+  onSubmit,
+}: ResponseHistoryProps) {
+  const [body, setBody] = useState('')
+  const [bodyError, setBodyError] = useState<string | null>(null)
+
+  const submit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    const value = body.trim()
+    if (value === '') {
+      setBodyError('답변 내용을 입력하세요.')
+      return
+    }
+
+    if (await onSubmit(value)) setBody('')
+  }
+
+  return (
+    <section className={styles.responses}>
+      <h3>답변 이력</h3>
+      {request.responses.length === 0 ? (
+        <p className={styles.noResponses}>등록된 답변이 없습니다.</p>
+      ) : (
+        <ol>
+          {request.responses.map((response: SupportResponseResponse) => (
+            <li key={response.id}>
+              <div>
+                <strong>{response.responder_display_name}</strong>
+                <time dateTime={response.responded_at}>
+                  {dateTime.format(dateOf(response.responded_at))}
+                </time>
+              </div>
+              <p>{response.body}</p>
+            </li>
+          ))}
+        </ol>
+      )}
+
+      <form className={styles.responseForm} onSubmit={submit}>
+        <label htmlFor={`response-${request.id}`}>답변 추가</label>
+        <textarea
+          id={`response-${request.id}`}
+          rows={4}
+          maxLength={5_000}
+          value={body}
+          disabled={pending}
+          onChange={(event) => {
+            setBody(event.target.value)
+            setBodyError(null)
+            onClearError()
+          }}
+        />
+        {bodyError && (
+          <p className={styles.error} role="alert">
+            {bodyError}
+          </p>
+        )}
+        {error && (
+          <p className={styles.error} role="alert">
+            {error}
+          </p>
+        )}
+        <Button type="submit" disabled={pending}>
+          {pending ? '등록 중…' : '답변 등록'}
+        </Button>
+      </form>
+    </section>
   )
 }

--- a/frontend/src/pages/Complaints/components/ComplaintFormModal.tsx
+++ b/frontend/src/pages/Complaints/components/ComplaintFormModal.tsx
@@ -1,138 +1,175 @@
-// 불만 등록. 받는 값은 다섯 개뿐입니다 — 제목·회사·담당자·내용·상태.
-// 접수자·제품처럼 시드에만 있는 칸은 비워 두고, 목록과 드로어가 그 칸을 그리지 않습니다.
 import { useState, type ReactNode } from 'react'
 
-import { useCurrentUser } from '@/auth/sessionContext'
 import Button from '@/components/Button'
 import Modal from '@/components/Modal'
-import type { CsDraft } from '@/shared/counters'
-import type { CsState } from '@/types'
+import type { SupportRequestCreateRequest, SupportStatusCode } from '@/types'
+
+import { type ContactOption, mutationErrorMessage } from '../useSupportRequests'
 
 import styles from '../Complaints.module.scss'
 
-const STATES: CsState[] = ['처리중', '처리완료']
+const STATES: { code: SupportStatusCode; label: string }[] = [
+  { code: 'in_progress', label: '처리중' },
+  { code: 'completed', label: '처리완료' },
+]
 
 interface Props {
+  contacts: ContactOption[]
   onClose: () => void
-  onSubmit: (draft: CsDraft) => void
+  onSubmit: (payload: SupportRequestCreateRequest) => Promise<void>
 }
 
-type Errors = Partial<Record<'issue' | 'org' | 'owner', string>>
+type Errors = Partial<Record<'contact' | 'title' | 'body', string>>
 
-export default function ComplaintFormModal({ onClose, onSubmit }: Props) {
-  const { profile } = useCurrentUser()
-
-  const [issue, setIssue] = useState('')
-  const [org, setOrg] = useState('')
-  // 담당 영업은 보통 접수한 본인입니다. 비어 있으면 목록에서 담당자 칸이 빕니다.
-  const [owner, setOwner] = useState(profile.name)
-  const [product, setProduct] = useState('')
-  const [note, setNote] = useState('')
-  const [state, setState] = useState<CsState>('처리중')
+export default function ComplaintFormModal({ contacts, onClose, onSubmit }: Props) {
+  const [contactId, setContactId] = useState('')
+  const [title, setTitle] = useState('')
+  const [body, setBody] = useState('')
+  const [statusCode, setStatusCode] = useState<SupportStatusCode>('in_progress')
   const [urgent, setUrgent] = useState(false)
   const [errors, setErrors] = useState<Errors>({})
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
 
-  const submit = () => {
+  const submit = async () => {
+    if (submitting) return
+
     const found: Errors = {}
-    if (issue.trim() === '') found.issue = '제목을 입력하세요.'
-    if (org.trim() === '') found.org = '회사를 입력하세요.'
-    if (owner.trim() === '') found.owner = '담당자를 입력하세요.'
+    if (contactId === '') found.contact = '고객 담당자를 선택하세요.'
+    if (title.trim() === '') found.title = '제목을 입력하세요.'
+    if (body.trim() === '') found.body = '내용을 입력하세요.'
     setErrors(found)
     if (Object.keys(found).length > 0) return
 
-    onSubmit({
-      issue: issue.trim(),
-      org: org.trim(),
-      owner: owner.trim(),
-      product: product.trim(),
-      note: note.trim(),
-      state,
-      urgent,
-    })
+    setSubmitting(true)
+    setSubmitError(null)
+    try {
+      await onSubmit({
+        customer_contact_id: contactId,
+        title: title.trim(),
+        body: body.trim(),
+        is_urgent: urgent,
+        status_code: statusCode,
+      })
+    } catch (caught: unknown) {
+      setSubmitError(mutationErrorMessage(caught, '고객불만을 등록'))
+      setSubmitting(false)
+    }
+  }
+
+  const close = () => {
+    if (!submitting) onClose()
   }
 
   return (
     <Modal
       title="불만 등록"
-      onClose={onClose}
+      onClose={close}
       onSubmit={submit}
       footer={
         <>
-          <Button type="button" variant="outline" onClick={onClose}>
+          <Button type="button" variant="outline" disabled={submitting} onClick={close}>
             취소
           </Button>
-          <Button type="submit">불만 등록</Button>
+          <Button type="submit" disabled={submitting || contacts.length === 0}>
+            {submitting ? '등록 중…' : '불만 등록'}
+          </Button>
         </>
       }
     >
-      {/* 칸 순서는 목록의 열 순서와 같습니다 — 회사·담당자·제목·물품명·상태·내용. */}
-      <div className={styles.grid}>
-        <Field label="회사" required error={errors.org}>
-          <input value={org} placeholder="회사 이름" onChange={(e) => setOrg(e.target.value)} />
-        </Field>
-
-        <Field label="담당자" required error={errors.owner}>
-          <input value={owner} onChange={(e) => setOwner(e.target.value)} />
-        </Field>
-
-        <Field label="제목" required error={errors.issue} wide>
-          <input
-            value={issue}
-            placeholder="부팅 시 화면 깜빡임"
-            onChange={(e) => setIssue(e.target.value)}
-          />
-        </Field>
-
-        <Field label="물품명" wide>
-          <input
-            value={product}
-            placeholder="CardioView X7"
-            onChange={(e) => setProduct(e.target.value)}
-          />
-        </Field>
-
-        <Field label="상태">
-          <select value={state} onChange={(e) => setState(e.target.value as CsState)}>
-            {STATES.map((option) => (
-              <option key={option} value={option}>
-                {option}
+      <div className={styles.grid} aria-busy={submitting}>
+        <Field label="고객 담당자" required error={errors.contact} wide>
+          <select
+            value={contactId}
+            disabled={submitting || contacts.length === 0}
+            onChange={(event) => {
+              setContactId(event.target.value)
+              setErrors((previous) => ({ ...previous, contact: undefined }))
+            }}
+          >
+            <option value="">
+              {contacts.length === 0 ? '등록된 고객 담당자가 없습니다' : '고객 담당자 선택'}
+            </option>
+            {contacts.map((contact) => (
+              <option key={contact.id} value={contact.id}>
+                {contact.label}
               </option>
             ))}
           </select>
         </Field>
 
-        {/* 대시보드 C/S 타일이 이 값을 '긴급 N건' 으로 셉니다.
-            fieldset/legend 는 flex 안에서 브라우저마다 다르게 자리를 잡아 옆 칸과 높이가
-            어긋납니다. 다른 칸과 같은 마크업을 쓰고 그룹 역할만 role 로 알립니다. */}
+        <Field label="제목" required error={errors.title} wide>
+          <input
+            value={title}
+            maxLength={254}
+            disabled={submitting}
+            placeholder="요청 내용을 요약해 주세요"
+            onChange={(event) => {
+              setTitle(event.target.value)
+              setErrors((previous) => ({ ...previous, title: undefined }))
+            }}
+          />
+        </Field>
+
+        <Field label="상태">
+          <select
+            value={statusCode}
+            disabled={submitting}
+            onChange={(event) => setStatusCode(event.target.value as SupportStatusCode)}
+          >
+            {STATES.map((state) => (
+              <option key={state.code} value={state.code}>
+                {state.label}
+              </option>
+            ))}
+          </select>
+        </Field>
+
         <div className={styles.field}>
           <span className={styles.label}>긴급도</span>
           <div className={styles.tags} role="radiogroup" aria-label="긴급도">
-            {/* 라디오 두 개를 태그 모양으로 입힙니다. 고른 것만 색이 차고,
-                긴급은 목록에 붙을 배지와 같은 주황입니다. 기본은 보통입니다. */}
             <label className={styles.tag}>
               <input
                 type="radio"
                 name="urgent"
                 checked={!urgent}
+                disabled={submitting}
                 onChange={() => setUrgent(false)}
               />
               <span>보통</span>
             </label>
             <label className={`${styles.tag} ${styles.urgentTag}`}>
-              <input type="radio" name="urgent" checked={urgent} onChange={() => setUrgent(true)} />
+              <input
+                type="radio"
+                name="urgent"
+                checked={urgent}
+                disabled={submitting}
+                onChange={() => setUrgent(true)}
+              />
               <span>긴급</span>
             </label>
           </div>
         </div>
 
-        <Field label="내용" wide>
+        <Field label="내용" required error={errors.body} wide>
           <textarea
-            rows={4}
-            value={note}
-            placeholder="접수한 내용과 처리 상황"
-            onChange={(e) => setNote(e.target.value)}
+            rows={5}
+            value={body}
+            maxLength={5_000}
+            disabled={submitting}
+            placeholder="접수한 내용을 입력해 주세요"
+            onChange={(event) => {
+              setBody(event.target.value)
+              setErrors((previous) => ({ ...previous, body: undefined }))
+            }}
           />
         </Field>
+
+        {submitError && (
+          <p className={`${styles.error} ${styles.isWide}`} role="alert">
+            {submitError}
+          </p>
+        )}
       </div>
     </Modal>
   )

--- a/frontend/src/pages/Complaints/useSupportRequests.ts
+++ b/frontend/src/pages/Complaints/useSupportRequests.ts
@@ -1,0 +1,211 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { isAxiosError } from 'axios'
+
+import { client } from '@/api/client'
+import type {
+  CustomerContactResponse,
+  PageResponse,
+  SupportRequestCreateRequest,
+  SupportRequestResponse,
+  SupportResponseResponse,
+  SupportStatusCode,
+  SupportTransitionRequest,
+} from '@/types'
+
+const PAGE_LIMIT = 100
+
+export interface ContactOption {
+  id: string
+  label: string
+}
+
+async function fetchAll<T>(path: string, signal: AbortSignal): Promise<T[]> {
+  // ponytail: 탭 건수는 전건 기준입니다. 데이터가 커지면 서버 집계 API로 바꿉니다.
+  const items: T[] = []
+  let skip = 0
+
+  while (!signal.aborted) {
+    const { data } = await client.get<PageResponse<T>>(path, {
+      params: { skip, limit: PAGE_LIMIT },
+      signal,
+    })
+    items.push(...data.items)
+    if (!data.has_more || data.next_skip === null) break
+    if (data.next_skip <= skip) throw new Error('invalid_pagination')
+    skip = data.next_skip
+  }
+
+  return items
+}
+
+function loadErrorMessage(error: unknown, detail = false): string {
+  if (!isAxiosError(error)) return `고객불만 ${detail ? '상세를' : '목록을'} 불러오지 못했습니다.`
+  if (error.response?.status === 401) return '로그인이 만료되었습니다. 다시 로그인해 주세요.'
+  if (error.response?.status === 403) return '고객불만을 조회할 권한이 없습니다.'
+  if (error.response?.status === 404) return '고객불만을 찾을 수 없습니다.'
+  if (error.response?.status === 422) return '조회 조건을 처리하지 못했습니다.'
+  return '서버에 연결할 수 없습니다. 잠시 후 다시 시도해 주세요.'
+}
+
+export function mutationErrorMessage(error: unknown, action: string): string {
+  if (!isAxiosError(error)) return `${action}하지 못했습니다.`
+  if (error.response?.status === 401) return '로그인이 만료되었습니다. 다시 로그인해 주세요.'
+  if (error.response?.status === 403) return `${action}할 권한이 없습니다.`
+  if (error.response?.status === 404)
+    return '고객불만을 찾을 수 없습니다. 목록을 새로고침해 주세요.'
+  if (error.response?.status === 409)
+    return '다른 변경이 먼저 반영되었습니다. 새로고침한 뒤 다시 시도해 주세요.'
+  if (error.response?.status === 422) return '입력한 내용을 확인해 주세요.'
+  return '서버에 연결할 수 없습니다. 잠시 후 다시 시도해 주세요.'
+}
+
+export default function useSupportRequests(openId: string | null) {
+  const [requests, setRequests] = useState<SupportRequestResponse[]>([])
+  const [contacts, setContacts] = useState<ContactOption[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [reloadKey, setReloadKey] = useState(0)
+
+  const [detail, setDetail] = useState<SupportRequestResponse | null>(null)
+  const [detailLoading, setDetailLoading] = useState(false)
+  const [detailError, setDetailError] = useState<string | null>(null)
+  const [detailReloadKey, setDetailReloadKey] = useState(0)
+
+  const [pendingKey, setPendingKey] = useState<string | null>(null)
+  const pendingRef = useRef(false)
+  const [mutationError, setMutationError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    setLoading(true)
+    setError(null)
+
+    void Promise.all([
+      fetchAll<SupportRequestResponse>('/support-requests', controller.signal),
+      fetchAll<CustomerContactResponse>('/customer-contacts', controller.signal),
+    ])
+      .then(([requestItems, contactItems]) => {
+        if (controller.signal.aborted) return
+        setRequests(requestItems)
+        setContacts(
+          contactItems.map((contact) => ({
+            id: contact.id,
+            label: `${contact.company_name} · ${contact.name}`,
+          })),
+        )
+      })
+      .catch((caught: unknown) => {
+        if (!controller.signal.aborted) setError(loadErrorMessage(caught))
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false)
+      })
+
+    return () => controller.abort()
+  }, [reloadKey])
+
+  useEffect(() => {
+    setDetail(null)
+    setDetailError(null)
+    if (openId === null) {
+      setDetailLoading(false)
+      return
+    }
+
+    const controller = new AbortController()
+    setDetailLoading(true)
+    void client
+      .get<SupportRequestResponse>(`/support-requests/${openId}`, { signal: controller.signal })
+      .then(({ data }) => {
+        if (!controller.signal.aborted) setDetail(data)
+      })
+      .catch((caught: unknown) => {
+        if (!controller.signal.aborted) setDetailError(loadErrorMessage(caught, true))
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setDetailLoading(false)
+      })
+
+    return () => controller.abort()
+  }, [openId, detailReloadKey])
+
+  const createRequest = useCallback(async (payload: SupportRequestCreateRequest) => {
+    const { data } = await client.post<SupportRequestResponse>('/support-requests', payload)
+    setRequests((previous) => [data, ...previous])
+    return data
+  }, [])
+
+  const transition = useCallback(
+    async (request: SupportRequestResponse, statusCode: SupportStatusCode) => {
+      if (pendingRef.current) return false
+      pendingRef.current = true
+      setPendingKey(`transition:${request.id}`)
+      setMutationError(null)
+
+      try {
+        const payload: SupportTransitionRequest = {
+          expected_status_code: request.status_code,
+          status_code: statusCode,
+        }
+        const { data } = await client.post<SupportRequestResponse>(
+          `/support-requests/${request.id}/transition`,
+          payload,
+        )
+        setRequests((previous) => previous.map((item) => (item.id === data.id ? data : item)))
+        setDetail(data)
+        return true
+      } catch (caught: unknown) {
+        setMutationError(mutationErrorMessage(caught, '상태를 변경'))
+        return false
+      } finally {
+        pendingRef.current = false
+        setPendingKey(null)
+      }
+    },
+    [],
+  )
+
+  const addResponse = useCallback(async (requestId: string, body: string) => {
+    if (pendingRef.current) return false
+    pendingRef.current = true
+    setPendingKey(`response:${requestId}`)
+    setMutationError(null)
+
+    try {
+      const { data } = await client.post<SupportResponseResponse>(
+        `/support-requests/${requestId}/responses`,
+        { body },
+      )
+      setDetail((previous) =>
+        previous?.id === requestId
+          ? { ...previous, responses: [...previous.responses, data] }
+          : previous,
+      )
+      return true
+    } catch (caught: unknown) {
+      setMutationError(mutationErrorMessage(caught, '답변을 등록'))
+      return false
+    } finally {
+      pendingRef.current = false
+      setPendingKey(null)
+    }
+  }, [])
+
+  return {
+    requests,
+    contacts,
+    loading,
+    error,
+    reload: () => setReloadKey((value) => value + 1),
+    detail,
+    detailLoading,
+    detailError,
+    reloadDetail: () => setDetailReloadKey((value) => value + 1),
+    pendingKey,
+    mutationError,
+    clearMutationError: () => setMutationError(null),
+    createRequest,
+    transition,
+    addResponse,
+  }
+}

--- a/frontend/src/types/counters.ts
+++ b/frontend/src/types/counters.ts
@@ -29,6 +29,46 @@ export interface CsRequest {
   note: string
 }
 
+export type SupportStatusCode = 'in_progress' | 'completed'
+
+export interface SupportResponseResponse {
+  id: string
+  request_id: string
+  responder_member_id: string
+  responder_display_name: string
+  body: string
+  responded_at: string
+}
+
+export interface SupportRequestResponse {
+  id: string
+  customer_contact_id: string
+  customer_contact_name: string
+  customer_company_id: string
+  customer_company_name: string
+  assignee_member_id: string
+  assignee_display_name: string
+  title: string
+  body: string
+  is_urgent: boolean
+  status_code: SupportStatusCode
+  registered_at: string
+  responses: SupportResponseResponse[]
+}
+
+export interface SupportRequestCreateRequest {
+  customer_contact_id: string
+  title: string
+  body: string
+  is_urgent: boolean
+  status_code: SupportStatusCode
+}
+
+export interface SupportTransitionRequest {
+  expected_status_code: SupportStatusCode
+  status_code: SupportStatusCode
+}
+
 export interface Renewal {
   /** 담당 영업 */
   owner: string


### PR DESCRIPTION
## 변경 요약

- C/S 요청 목록·상세·등록·상태 전이·답변 API를 추가했습니다.
- 팀원 본인 담당/팀장 같은 팀 범위와 고객 담당자 팀 경계를 적용했습니다.
- `/complaints`를 실제 API와 연결하고 기존 Dashboard 목업은 보존했습니다.
- filled 데모팀에 정확히 연결되는 합성 C/S 3건만 반복 가능하게 준비하고 empty 팀은 건드리지 않습니다.

## 검증

- `cd backend && uv run ruff check .`
- `cd backend && uv run ruff format --check .`
- `cd backend && uv run pytest -q` — 67 passed
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run format:check`
- `cd frontend && npm run build`
- 실제 개발 Supabase에서 seed 2회 실행 후 filled 3건, empty 0건 확인
- 실제 브라우저에서 등록 → 답변 → 처리완료 → 새로고침 저장 확인 후 검증 데이터 삭제

## 영향 및 주의 사항

- 기존 C/S 목업은 Dashboard가 계속 사용하므로 삭제하지 않았습니다.
- C/S 수정·삭제·담당자 재배정 API는 이번 범위에 포함하지 않았습니다.
- 기존 Vite 번들 크기 경고와 Starlette TestClient deprecation warning만 남아 있습니다.