### PR TITLE
일정 완료·다시 열기 API 추가

### DIFF
--- a/backend/app/api/activities.py
+++ b/backend/app/api/activities.py
@@ -602,3 +602,52 @@ async def delete_activity(
     except Exception:
         await db.rollback()
         raise
+
+
+@router.post("/activities/{activity_id}/complete", response_model=ActivityRead)
+async def complete_activity(
+    activity_id: UUID,
+    member: CurrentMember,
+    db: DbSession,
+):
+    try:
+        activity = await _locked_activity(db, member, activity_id)
+        if activity.completed_at is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="already_completed",
+            )
+        now = datetime.now(UTC)
+        activity.completed_at = now
+        activity.updated_at = now
+        await db.flush()
+        read = _activity_read(*await _activity_row(db, member, activity_id))
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return read
+
+
+@router.post("/activities/{activity_id}/reopen", response_model=ActivityRead)
+async def reopen_activity(
+    activity_id: UUID,
+    member: CurrentMember,
+    db: DbSession,
+):
+    try:
+        activity = await _locked_activity(db, member, activity_id)
+        if activity.completed_at is None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="not_completed",
+            )
+        activity.completed_at = None
+        activity.updated_at = datetime.now(UTC)
+        await db.flush()
+        read = _activity_read(*await _activity_row(db, member, activity_id))
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return read

--- a/backend/tests/test_activities.py
+++ b/backend/tests/test_activities.py
@@ -703,3 +703,87 @@ def test_write_failure_rolls_back_transaction():
 
     assert db.commit_count == 0
     assert db.rollback_count == 1
+
+
+def test_patch_cannot_set_completed_at():
+    """완료 여부는 전용 endpoint 로만 바꾼다. 일반 PATCH 는 받지 않는다."""
+    with pytest.raises(ValidationError):
+        ActivityPatch(completed_at="2026-08-17T10:00:00+09:00")
+
+
+def test_complete_and_reopen_toggle_completed_at():
+    member = _member()
+    activity = _activity(member)
+
+    complete_db = _Db(
+        _Result(scalar=activity),
+        _Result(rows=[_row(activity, member)]),
+    )
+    with _client(complete_db, member) as client:
+        completed = client.post(
+            f"/api/activities/{activity.id}/complete",
+            headers={"Origin": ORIGIN},
+        )
+    assert completed.status_code == 200
+    assert completed.json()["completed_at"] is not None
+    assert activity.completed_at is not None
+    assert activity.updated_at == activity.completed_at
+    assert "FOR UPDATE" in str(complete_db.statements[0])
+    assert complete_db.flush_count == complete_db.commit_count == 1
+
+    reopen_db = _Db(
+        _Result(scalar=activity),
+        _Result(rows=[_row(activity, member)]),
+    )
+    with _client(reopen_db, member) as client:
+        reopened = client.post(
+            f"/api/activities/{activity.id}/reopen",
+            headers={"Origin": ORIGIN},
+        )
+    assert reopened.status_code == 200
+    assert reopened.json()["completed_at"] is None
+    assert activity.completed_at is None
+    assert reopen_db.flush_count == reopen_db.commit_count == 1
+
+
+def test_complete_and_reopen_reject_repeated_state():
+    member = _member()
+    done = _activity(member)
+    done.completed_at = NOW
+
+    repeat_db = _Db(_Result(scalar=done))
+    with _client(repeat_db, member) as client:
+        repeated = client.post(
+            f"/api/activities/{done.id}/complete",
+            headers={"Origin": ORIGIN},
+        )
+    assert repeated.status_code == 409
+    assert repeated.json() == {"detail": "already_completed"}
+    assert repeat_db.commit_count == 0
+    assert repeat_db.rollback_count == 1
+
+    open_activity = _activity(member)
+    reopen_db = _Db(_Result(scalar=open_activity))
+    with _client(reopen_db, member) as client:
+        reopened = client.post(
+            f"/api/activities/{open_activity.id}/reopen",
+            headers={"Origin": ORIGIN},
+        )
+    assert reopened.status_code == 409
+    assert reopened.json() == {"detail": "not_completed"}
+    assert reopen_db.commit_count == 0
+    assert reopen_db.rollback_count == 1
+
+
+def test_complete_hides_other_scope_activity():
+    member = _member()
+    hidden_db = _Db(_Result(scalar=None))
+    with _client(hidden_db, member) as client:
+        hidden = client.post(
+            f"/api/activities/{uuid4()}/complete",
+            headers={"Origin": ORIGIN},
+        )
+    assert hidden.status_code == 404
+    assert hidden.json() == {"detail": "activity_not_found"}
+    assert hidden_db.commit_count == 0
+    assert hidden_db.rollback_count == 1

--- a/docs/technical/backend/api-conventions.md
+++ b/docs/technical/backend/api-conventions.md
@@ -288,6 +288,15 @@ GET /api/activities?owner_member_id=9f64618b-8ed8-4aed-9560-78b25228dbe5&owner_m
 | 발주 이동 | `POST /api/orders/{purchase_order_id}/move` | `expected_stage_code`, 목표 `stage_code` |
 | C/S | `GET/POST /api/support-requests`, `GET /api/support-requests/{request_id}` | 목록은 `q,status_code,skip,limit`; 상태 `in_progress|completed` |
 | C/S 전이·답변 | `POST /api/support-requests/{request_id}/transition`, `POST /api/support-requests/{request_id}/responses` | expected 상태 비교; 답변 생성 `201` |
+| 일정 완료 | `POST /api/activities/{activity_id}/complete`, `POST /api/activities/{activity_id}/reopen` | 본문 없음; 완료 시각은 서버가 정함 |
+
+### 일정 완료 처리
+
+- 완료 여부는 `completed_at` 하나로 표현한다. 완료면 시각이 있고 아니면 `null`이다.
+- 완료 시각은 서버가 정하므로 두 endpoint 모두 요청 본문을 받지 않는다.
+- 일반 `PATCH /api/activities/{activity_id}`로는 `completed_at`을 바꿀 수 없다. 보내면 `422`다.
+- 이미 완료된 일정의 완료 요청은 `409 already_completed`, 완료되지 않은 일정의 재개 요청은 `409 not_completed`다.
+- 조회 범위와 잠금 규칙은 일정 상세·수정과 같다.
 
 ### 영업 딜의 화면 필터와 상태 전이
 


### PR DESCRIPTION
## 변경 요약

- 일정 완료 여부를 바꾸는 전용 endpoint 두 개를 추가합니다.
  - `POST /api/activities/{activity_id}/complete`
  - `POST /api/activities/{activity_id}/reopen`
- 완료 시각은 서버가 정하므로 두 endpoint 모두 요청 본문을 받지 않습니다.
- 일반 `PATCH`로는 `completed_at`을 바꿀 수 없게 두어 상태 전이 경로를 하나로 유지합니다. `ActivityPatch`는 건드리지 않았습니다.
- 이미 완료된 일정의 완료 요청은 `409 already_completed`, 완료되지 않은 일정의 재개 요청은 `409 not_completed`입니다.
- 조회·잠금은 기존 `_locked_activity`(FOR UPDATE)와 `_activity_row`를 그대로 사용해 팀·담당자 범위 규칙이 목록·상세와 같습니다.
- `api-conventions.md` 17절에 구현 목록과 완료 처리 규칙을 함께 반영합니다.

## 검증

| 검사 | 결과 |
|---|---|
| `uv run ruff check .` | All checks passed |
| `uv run ruff format --check .` | 52 files already formatted |
| `uv run pytest -q` | 74 passed (기존 70 → +4) |
| `git diff --check` | 문제 없음 |

개발 Supabase 실제 데이터로 확인한 결과입니다. 실행 후 원래 상태로 되돌렸습니다.

```
complete           -> 200  completed_at=2026-08-18T00:58:48+09:00
complete 재요청     -> 409  already_completed
reopen             -> 200  completed_at=null
reopen 재요청       -> 409  not_completed
PATCH completed_at -> 422  extra_forbidden
최종 상태 원상복구 확인
```

## 영향 및 주의 사항

- 백엔드만 변경합니다. 프론트 연결은 후속 작업입니다.
- Calendar는 이미 `completed_at`을 읽고 있어(`done: activity.completed_at !== null`) 읽기 경로는 그대로 동작합니다.
- Dashboard는 아직 `shared/agenda`의 목업 ID를 사용하므로 이 API에 연결하지 않았습니다. 목업 ID 제거 후 별도 PR에서 잇습니다.

## 관련 이슈

- 없음