### PR TITLE
보고서 작성·수정·제출 API 추가

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api import activities, auth, customers, health, orders, sales_deals, support
+from app.api import activities, auth, customers, health, orders, reports, sales_deals, support
 
 api_router = APIRouter()
 api_router.include_router(health.router)
@@ -10,3 +10,4 @@ api_router.include_router(activities.router)
 api_router.include_router(sales_deals.router)
 api_router.include_router(orders.router)
 api_router.include_router(support.router)
+api_router.include_router(reports.router)

--- a/backend/app/api/reports.py
+++ b/backend/app/api/reports.py
@@ -1,0 +1,469 @@
+from datetime import UTC, datetime
+from typing import Annotated
+from uuid import UUID, uuid4
+from zoneinfo import ZoneInfo
+
+from fastapi import APIRouter, HTTPException, Query, Response, status
+from sqlalchemy import delete, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from app.api.deps import CurrentMember, DbSession
+from app.models.content import Report, ReportActivity
+from app.models.crm import Activity
+from app.models.workspace import Member
+from app.schemas.reports import (
+    ReportActivityRead,
+    ReportCreate,
+    ReportPage,
+    ReportPageParams,
+    ReportPatch,
+    ReportRead,
+    ReportSubmit,
+)
+
+router = APIRouter(tags=["reports"])
+
+_SEOUL = ZoneInfo("Asia/Seoul")
+_author = aliased(Member)
+_recipient = aliased(Member)
+
+# 제출한 보고서는 팀원이 더 고치지 않는다. 검토 결과는 팀장 기능에서 다룬다.
+_EDITABLE_STATUS = "draft"
+
+
+def _contains(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return f"%{escaped}%"
+
+
+def _seoul(value: datetime | None) -> datetime | None:
+    return None if value is None else value.astimezone(_SEOUL)
+
+
+def _joined_select(*entities):
+    return (
+        select(*entities)
+        .select_from(Report)
+        .join(_author, Report.author_member_id == _author.id)
+        .outerjoin(_recipient, Report.recipient_member_id == _recipient.id)
+    )
+
+
+def _scope(member: Member, author_ids: tuple[UUID, ...] | None = None):
+    conditions = [
+        Report.team_id == member.team_id,
+        _author.team_id == member.team_id,
+        _author.active.is_(True),
+        _author.role_code.in_(("member", "manager")),
+        or_(
+            Report.recipient_member_id.is_(None),
+            _recipient.team_id == member.team_id,
+        ),
+    ]
+    if member.role_code == "member":
+        conditions.append(Report.author_member_id == member.id)
+    elif author_ids is not None:
+        conditions.append(Report.author_member_id.in_(author_ids))
+    return conditions
+
+
+def _read_entities():
+    return (Report, _author.display_name, _recipient.display_name)
+
+
+def _report_read(
+    report: Report,
+    author_display_name: str,
+    recipient_display_name: str | None,
+    activities: list[ReportActivityRead],
+) -> ReportRead:
+    return ReportRead(
+        id=report.id,
+        team_id=report.team_id,
+        author_member_id=report.author_member_id,
+        author_display_name=author_display_name,
+        recipient_member_id=report.recipient_member_id,
+        recipient_display_name=recipient_display_name,
+        source_activity_id=report.source_activity_id,
+        report_kind=report.report_kind,
+        report_date=report.report_date,
+        period_start=report.period_start,
+        period_end=report.period_end,
+        status_code=report.status_code,
+        template_snapshot=report.template_snapshot,
+        content=report.content,
+        transcript=report.transcript,
+        source_snapshot=report.source_snapshot,
+        ai_evidence=report.ai_evidence,
+        note=report.note,
+        reviewed_by_member_id=report.reviewed_by_member_id,
+        reviewed_at=_seoul(report.reviewed_at),
+        activities=activities,
+        created_at=_seoul(report.created_at),
+        updated_at=_seoul(report.updated_at),
+    )
+
+
+async def _author_filter(
+    db: AsyncSession,
+    member: Member,
+    requested: list[UUID] | None,
+) -> tuple[UUID, ...] | None:
+    if requested is None:
+        return None
+    if member.role_code != "manager":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="scope_not_allowed",
+        )
+    author_ids = tuple(dict.fromkeys(requested))
+    result = await db.execute(
+        select(Member.id).where(
+            Member.id.in_(author_ids),
+            Member.team_id == member.team_id,
+            Member.active.is_(True),
+            Member.role_code.in_(("member", "manager")),
+        )
+    )
+    if set(result.scalars().all()) != set(author_ids):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="scope_not_allowed",
+        )
+    return author_ids
+
+
+async def _visible_activity_ids(
+    db: AsyncSession,
+    member: Member,
+    activity_ids: list[UUID],
+) -> tuple[UUID, ...]:
+    """보고서에 묶을 일정이 모두 같은 팀의 접근 가능한 일정인지 확인한다."""
+    if not activity_ids:
+        return ()
+    unique = tuple(dict.fromkeys(activity_ids))
+    conditions = [
+        Activity.id.in_(unique),
+        Activity.team_id == member.team_id,
+        Activity.deleted_at.is_(None),
+    ]
+    if member.role_code == "member":
+        conditions.append(Activity.owner_member_id == member.id)
+    result = await db.execute(select(Activity.id).where(*conditions))
+    if set(result.scalars().all()) != set(unique):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="activity_not_found",
+        )
+    return unique
+
+
+async def _visible_recipient(db: AsyncSession, member: Member, recipient_id: UUID) -> Member:
+    result = await db.execute(
+        select(Member).where(
+            Member.id == recipient_id,
+            Member.team_id == member.team_id,
+            Member.active.is_(True),
+            Member.role_code.in_(("member", "manager")),
+        )
+    )
+    recipient = result.scalar_one_or_none()
+    if recipient is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="recipient_not_found",
+        )
+    return recipient
+
+
+async def _activities_by_report_ids(
+    db: AsyncSession,
+    report_ids: list[UUID],
+) -> dict[UUID, list[ReportActivityRead]]:
+    grouped: dict[UUID, list[ReportActivityRead]] = {report_id: [] for report_id in report_ids}
+    if not report_ids:
+        return grouped
+    result = await db.execute(
+        select(
+            ReportActivity.report_id,
+            Activity.id,
+            Activity.title,
+            Activity.activity_type,
+            Activity.starts_at,
+        )
+        .join(Activity, ReportActivity.activity_id == Activity.id)
+        .where(ReportActivity.report_id.in_(report_ids))
+        .order_by(Activity.starts_at, Activity.id)
+    )
+    for report_id, activity_id, title, activity_type, starts_at in result.all():
+        grouped[report_id].append(
+            ReportActivityRead(
+                activity_id=activity_id,
+                title=title,
+                activity_type=activity_type,
+                starts_at=_seoul(starts_at),
+            )
+        )
+    return grouped
+
+
+async def _report_row(db: AsyncSession, member: Member, report_id: UUID):
+    result = await db.execute(
+        _joined_select(*_read_entities()).where(Report.id == report_id, *_scope(member))
+    )
+    row = result.one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="report_not_found",
+        )
+    return row
+
+
+async def _locked_report(db: AsyncSession, member: Member, report_id: UUID) -> Report:
+    conditions = [
+        Report.id == report_id,
+        Report.team_id == member.team_id,
+        Member.team_id == member.team_id,
+        Member.active.is_(True),
+        Member.role_code.in_(("member", "manager")),
+    ]
+    if member.role_code == "member":
+        conditions.append(Report.author_member_id == member.id)
+    result = await db.execute(
+        select(Report)
+        .join(Member, Report.author_member_id == Member.id)
+        .where(*conditions)
+        .with_for_update(of=Report)
+    )
+    report = result.scalar_one_or_none()
+    if report is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="report_not_found",
+        )
+    return report
+
+
+async def _replace_report_activities(
+    db: AsyncSession,
+    report_id: UUID,
+    activity_ids: tuple[UUID, ...],
+) -> None:
+    await db.execute(delete(ReportActivity).where(ReportActivity.report_id == report_id))
+    for activity_id in activity_ids:
+        db.add(ReportActivity(report_id=report_id, activity_id=activity_id))
+
+
+async def _detail(db: AsyncSession, member: Member, report_id: UUID) -> ReportRead:
+    row = await _report_row(db, member, report_id)
+    activities = await _activities_by_report_ids(db, [report_id])
+    return _report_read(*row, activities[report_id])
+
+
+@router.get("/reports", response_model=ReportPage)
+async def list_reports(
+    page: Annotated[ReportPageParams, Query()],
+    member: CurrentMember,
+    db: DbSession,
+) -> ReportPage:
+    author_ids = await _author_filter(db, member, page.author_member_id)
+    scope = _scope(member, author_ids)
+    if page.report_kind is not None:
+        scope.append(Report.report_kind.in_(tuple(dict.fromkeys(page.report_kind))))
+    if page.status_code is not None:
+        scope.append(Report.status_code.in_(tuple(dict.fromkeys(page.status_code))))
+    if page.start_date is not None:
+        scope.append(Report.report_date >= page.start_date)
+    if page.end_date is not None:
+        scope.append(Report.report_date <= page.end_date)
+    if page.q is not None:
+        pattern = _contains(page.q)
+        scope.append(
+            or_(
+                Report.note.ilike(pattern, escape="\\"),
+                Report.transcript.ilike(pattern, escape="\\"),
+                _author.display_name.ilike(pattern, escape="\\"),
+            )
+        )
+
+    total_result = await db.execute(_joined_select(func.count(Report.id)).where(*scope))
+    total = total_result.scalar_one()
+    rows_result = await db.execute(
+        _joined_select(*_read_entities())
+        .where(*scope)
+        .order_by(Report.report_date.desc(), Report.created_at.desc(), Report.id)
+        .offset(page.skip)
+        .limit(page.limit)
+    )
+    rows = rows_result.all()
+    activity_map = await _activities_by_report_ids(db, [row[0].id for row in rows])
+    items = [_report_read(*row, activity_map[row[0].id]) for row in rows]
+    has_more = page.skip + len(items) < total
+    return ReportPage(
+        items=items,
+        skip=page.skip,
+        limit=page.limit,
+        total=total,
+        has_more=has_more,
+        next_skip=page.skip + len(items) if has_more else None,
+    )
+
+
+@router.get("/reports/{report_id}", response_model=ReportRead)
+async def get_report(
+    report_id: UUID,
+    member: CurrentMember,
+    db: DbSession,
+) -> ReportRead:
+    return await _detail(db, member, report_id)
+
+
+@router.post("/reports", response_model=ReportRead, status_code=status.HTTP_201_CREATED)
+async def create_report(
+    payload: ReportCreate,
+    response: Response,
+    member: CurrentMember,
+    db: DbSession,
+) -> ReportRead:
+    try:
+        recipient = (
+            None
+            if payload.recipient_member_id is None
+            else await _visible_recipient(db, member, payload.recipient_member_id)
+        )
+        if payload.source_activity_id is not None:
+            await _visible_activity_ids(db, member, [payload.source_activity_id])
+        activity_ids = await _visible_activity_ids(db, member, payload.activity_ids)
+
+        report = Report(
+            id=uuid4(),
+            team_id=member.team_id,
+            author_member_id=member.id,
+            recipient_member_id=None if recipient is None else recipient.id,
+            template_snapshot=payload.template_snapshot,
+            source_activity_id=payload.source_activity_id,
+            report_kind=payload.report_kind,
+            report_date=payload.report_date,
+            period_start=payload.period_start,
+            period_end=payload.period_end,
+            # 작성은 언제나 draft 로 시작한다. 제출은 별도 endpoint 를 거친다.
+            status_code=_EDITABLE_STATUS,
+            content=payload.content,
+            transcript=payload.transcript,
+            source_snapshot=None,
+            ai_evidence=None,
+            note=payload.note,
+            reviewed_by_member_id=None,
+            reviewed_at=None,
+        )
+        db.add(report)
+        for activity_id in activity_ids:
+            db.add(ReportActivity(report_id=report.id, activity_id=activity_id))
+        await db.flush()
+        read = await _detail(db, member, report.id)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    response.headers["Location"] = f"/api/reports/{report.id}"
+    return read
+
+
+@router.patch("/reports/{report_id}", response_model=ReportRead)
+async def update_report(
+    report_id: UUID,
+    payload: ReportPatch,
+    member: CurrentMember,
+    db: DbSession,
+) -> ReportRead:
+    try:
+        report = await _locked_report(db, member, report_id)
+        if report.status_code != _EDITABLE_STATUS:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="report_not_editable",
+            )
+
+        values = payload.model_dump(exclude_unset=True)
+        activity_ids = values.pop("activity_ids", None)
+
+        if "recipient_member_id" in values and values["recipient_member_id"] is not None:
+            await _visible_recipient(db, member, values["recipient_member_id"])
+
+        period_start = values.get("period_start", report.period_start)
+        period_end = values.get("period_end", report.period_end)
+        if period_start is not None and period_end is not None and period_end < period_start:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="invalid_report_period",
+            )
+
+        for field_name, value in values.items():
+            setattr(report, field_name, value)
+        report.updated_at = datetime.now(UTC)
+
+        if activity_ids is not None:
+            visible = await _visible_activity_ids(db, member, activity_ids)
+            await _replace_report_activities(db, report.id, visible)
+
+        await db.flush()
+        read = await _detail(db, member, report_id)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return read
+
+
+@router.post("/reports/{report_id}/submit", response_model=ReportRead)
+async def submit_report(
+    report_id: UUID,
+    payload: ReportSubmit,
+    member: CurrentMember,
+    db: DbSession,
+) -> ReportRead:
+    try:
+        report = await _locked_report(db, member, report_id)
+        if report.status_code != payload.expected_status_code:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="invalid_state_transition",
+            )
+        if report.status_code != _EDITABLE_STATUS:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="invalid_state_transition",
+            )
+        report.status_code = "submitted"
+        report.updated_at = datetime.now(UTC)
+        await db.flush()
+        read = await _detail(db, member, report_id)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return read
+
+
+@router.delete("/reports/{report_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_report(
+    report_id: UUID,
+    member: CurrentMember,
+    db: DbSession,
+) -> None:
+    try:
+        report = await _locked_report(db, member, report_id)
+        if report.status_code != _EDITABLE_STATUS:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="report_not_editable",
+            )
+        # report 에는 deleted_at 이 없다. 묶인 일정은 report_activity 의 FK CASCADE 가 지운다.
+        await db.delete(report)
+        await db.flush()
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise

--- a/backend/app/schemas/reports.py
+++ b/backend/app/schemas/reports.py
@@ -1,0 +1,160 @@
+from datetime import date, datetime
+from typing import Annotated, Any, Literal, Self
+from uuid import UUID
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    model_validator,
+)
+
+Text = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=254),
+]
+LongText = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=5_000),
+]
+Transcript = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=50_000),
+]
+SearchQuery = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=100),
+]
+
+# 미팅보고서는 일정 하나에 붙고, 나머지는 기간을 덮습니다.
+ReportKind = Literal["meeting", "daily", "weekly", "monthly"]
+# 팀원이 다루는 범위는 draft 와 submitted 두 개다. 검토 결과 값은 조회로만 나온다.
+ReportStatus = Literal["draft", "submitted", "approved", "rejected"]
+WritableStatus = Literal["draft", "submitted"]
+
+_PERIOD_KINDS = ("weekly", "monthly")
+
+
+class _WriteModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+def _check_period(kind: ReportKind, start: date | None, end: date | None) -> None:
+    if kind == "meeting":
+        return
+    if kind in _PERIOD_KINDS and (start is None or end is None):
+        raise ValueError("period_required")
+    if start is not None and end is not None and end < start:
+        raise ValueError("invalid_report_period")
+
+
+class ReportCreate(_WriteModel):
+    report_kind: ReportKind
+    report_date: date
+    period_start: date | None = None
+    period_end: date | None = None
+    source_activity_id: UUID | None = None
+    recipient_member_id: UUID | None = None
+    template_snapshot: dict[str, Any]
+    content: dict[str, Any]
+    transcript: Transcript | None = None
+    note: LongText | None = None
+    activity_ids: list[UUID] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _validate(self) -> Self:
+        _check_period(self.report_kind, self.period_start, self.period_end)
+        # 미팅보고서는 근거 일정이 곧 보고 대상이라 반드시 있어야 합니다.
+        if self.report_kind == "meeting" and self.source_activity_id is None:
+            raise ValueError("source_activity_required")
+        if len(set(self.activity_ids)) != len(self.activity_ids):
+            raise ValueError("duplicate_activity_ids")
+        return self
+
+
+class ReportPatch(_WriteModel):
+    report_date: date | None = None
+    period_start: date | None = None
+    period_end: date | None = None
+    recipient_member_id: UUID | None = None
+    template_snapshot: dict[str, Any] | None = None
+    content: dict[str, Any] | None = None
+    transcript: Transcript | None = None
+    note: LongText | None = None
+    activity_ids: list[UUID] | None = None
+
+    @model_validator(mode="after")
+    def _validate(self) -> Self:
+        if self.period_start is not None and self.period_end is not None:
+            if self.period_end < self.period_start:
+                raise ValueError("invalid_report_period")
+        if self.activity_ids is not None and len(set(self.activity_ids)) != len(self.activity_ids):
+            raise ValueError("duplicate_activity_ids")
+        return self
+
+
+class ReportSubmit(_WriteModel):
+    expected_status_code: WritableStatus
+
+
+class ReportActivityRead(BaseModel):
+    activity_id: UUID
+    title: str
+    activity_type: str
+    starts_at: datetime
+
+
+class ReportRead(BaseModel):
+    id: UUID
+    team_id: UUID
+    author_member_id: UUID
+    author_display_name: str
+    recipient_member_id: UUID | None
+    recipient_display_name: str | None
+    source_activity_id: UUID | None
+    report_kind: ReportKind
+    report_date: date
+    period_start: date | None
+    period_end: date | None
+    status_code: ReportStatus
+    template_snapshot: dict[str, Any]
+    content: dict[str, Any]
+    transcript: str | None
+    source_snapshot: dict[str, Any] | None
+    ai_evidence: dict[str, Any] | None
+    note: str | None
+    reviewed_by_member_id: UUID | None
+    reviewed_at: datetime | None
+    activities: list[ReportActivityRead]
+    created_at: datetime
+    updated_at: datetime
+
+
+class ReportPage(BaseModel):
+    items: list[ReportRead]
+    skip: int
+    limit: int
+    total: int
+    has_more: bool
+    next_skip: int | None
+
+
+class ReportPageParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    q: SearchQuery | None = None
+    report_kind: list[ReportKind] | None = None
+    status_code: list[ReportStatus] | None = None
+    start_date: date | None = None
+    end_date: date | None = None
+    author_member_id: list[UUID] | None = None
+    skip: int = Field(default=0, ge=0, le=9_223_372_036_854_775_807)
+    limit: int = Field(default=30, ge=1, le=100)
+
+    @model_validator(mode="after")
+    def _validate(self) -> Self:
+        if self.start_date is not None and self.end_date is not None:
+            if self.end_date < self.start_date:
+                raise ValueError("invalid_report_range")
+        return self

--- a/backend/tests/test_reports.py
+++ b/backend/tests/test_reports.py
@@ -1,0 +1,437 @@
+from datetime import UTC, date, datetime
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from app.api.deps import get_current_member
+from app.core.config import settings
+from app.db.session import get_db
+from app.main import app
+from app.models.content import Report
+from app.models.crm import Activity
+from app.models.workspace import Member
+from app.schemas.reports import ReportCreate, ReportPageParams, ReportPatch
+
+ORIGIN = settings.cors_origin_list[0]
+NOW = datetime(2026, 8, 17, 9, tzinfo=UTC)
+START = datetime(2026, 8, 17, 1, tzinfo=UTC)
+TEMPLATE = {"fields": [{"id": "summary", "label": "요약"}]}
+CONTENT = {"summary": "합성 보고 내용"}
+_MISSING = object()
+
+
+class _Scalars:
+    def __init__(self, values):
+        self.values = values
+
+    def all(self):
+        return self.values
+
+
+class _Result:
+    def __init__(self, *, scalar=_MISSING, rows=None, scalar_values=None):
+        self.scalar = scalar
+        self.rows = [] if rows is None else rows
+        self.scalar_values = [] if scalar_values is None else scalar_values
+
+    def scalar_one(self):
+        assert self.scalar is not _MISSING
+        return self.scalar
+
+    def scalar_one_or_none(self):
+        assert self.scalar is not _MISSING
+        return self.scalar
+
+    def one_or_none(self):
+        assert len(self.rows) <= 1
+        return self.rows[0] if self.rows else None
+
+    def all(self):
+        return self.rows
+
+    def scalars(self):
+        return _Scalars(self.scalar_values)
+
+
+class _Db:
+    def __init__(self, *results: _Result, flush_error: Exception | None = None):
+        self.results = list(results)
+        self.flush_error = flush_error
+        self.statements = []
+        self.added = []
+        self.deleted = []
+        self.flush_count = 0
+        self.commit_count = 0
+        self.rollback_count = 0
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        assert self.results, "예상보다 많은 쿼리가 실행되었습니다."
+        return self.results.pop(0)
+
+    def add(self, value):
+        self.added.append(value)
+
+    async def delete(self, value):
+        self.deleted.append(value)
+
+    async def flush(self):
+        self.flush_count += 1
+        if self.flush_error is not None:
+            raise self.flush_error
+        for value in self.added:
+            if isinstance(value, Report):
+                value.created_at = value.created_at or NOW
+                value.updated_at = value.updated_at or NOW
+
+    async def commit(self):
+        self.commit_count += 1
+
+    async def rollback(self):
+        self.rollback_count += 1
+
+
+@pytest.fixture(autouse=True)
+def reset_dependency_overrides():
+    app.dependency_overrides.clear()
+    yield
+    app.dependency_overrides.clear()
+
+
+def _member(*, role: str = "member", team_id: UUID | None = None) -> Member:
+    return Member(
+        id=uuid4(),
+        team_id=team_id or uuid4(),
+        login_id=f"{uuid4()}@salesluv.demo",
+        password_hash="unused",
+        display_name="합성 영업 담당자",
+        role_code=role,
+        job_title="영업 담당자",
+        active=True,
+    )
+
+
+def _report(member: Member, *, kind: str = "daily", status_code: str = "draft") -> Report:
+    return Report(
+        id=uuid4(),
+        team_id=member.team_id,
+        author_member_id=member.id,
+        recipient_member_id=None,
+        template_snapshot=TEMPLATE,
+        source_activity_id=None,
+        report_kind=kind,
+        report_date=date(2026, 8, 17),
+        period_start=None,
+        period_end=None,
+        status_code=status_code,
+        content=CONTENT,
+        transcript=None,
+        source_snapshot=None,
+        ai_evidence=None,
+        note=None,
+        reviewed_by_member_id=None,
+        reviewed_at=None,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _activity(member: Member) -> Activity:
+    return Activity(
+        id=uuid4(),
+        team_id=member.team_id,
+        owner_member_id=member.id,
+        customer_contact_id=None,
+        end_user_contact_id=None,
+        activity_type="meeting",
+        activity_category_id=uuid4(),
+        title="합성 미팅",
+        starts_at=START,
+        ends_at=None,
+        all_day=False,
+        due_at=None,
+        location=None,
+        activity_action_tag_id=None,
+        completed_at=None,
+        note=None,
+        deleted_at=None,
+        created_at=NOW,
+        updated_at=NOW,
+        product_id=None,
+        sales_deal_id=None,
+        purchase_order_id=None,
+    )
+
+
+def _row(report: Report, author: Member, recipient_display_name: str | None = None):
+    return (report, author.display_name, recipient_display_name)
+
+
+def _client(db: _Db, member: Member) -> TestClient:
+    async def override_db():
+        yield db
+
+    async def override_member():
+        return member
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_member] = override_member
+    return TestClient(app)
+
+
+def test_report_request_rejects_unsafe_values():
+    """기간·근거 규칙과 중복 일정은 스키마에서 막는다."""
+    with pytest.raises(ValidationError):
+        # 주간 보고는 기간이 필요하다.
+        ReportCreate(
+            report_kind="weekly",
+            report_date="2026-08-17",
+            template_snapshot=TEMPLATE,
+            content=CONTENT,
+        )
+
+    with pytest.raises(ValidationError):
+        # 끝이 시작보다 빠를 수 없다.
+        ReportCreate(
+            report_kind="weekly",
+            report_date="2026-08-17",
+            period_start="2026-08-17",
+            period_end="2026-08-10",
+            template_snapshot=TEMPLATE,
+            content=CONTENT,
+        )
+
+    with pytest.raises(ValidationError):
+        # 미팅보고서는 근거 일정이 있어야 한다.
+        ReportCreate(
+            report_kind="meeting",
+            report_date="2026-08-17",
+            template_snapshot=TEMPLATE,
+            content=CONTENT,
+        )
+
+    duplicated = uuid4()
+    with pytest.raises(ValidationError):
+        ReportCreate(
+            report_kind="daily",
+            report_date="2026-08-17",
+            template_snapshot=TEMPLATE,
+            content=CONTENT,
+            activity_ids=[duplicated, duplicated],
+        )
+
+    # 상태와 작성자는 요청으로 정하지 않는다.
+    with pytest.raises(ValidationError):
+        ReportCreate(
+            report_kind="daily",
+            report_date="2026-08-17",
+            template_snapshot=TEMPLATE,
+            content=CONTENT,
+            status_code="submitted",
+        )
+    with pytest.raises(ValidationError):
+        ReportCreate(
+            report_kind="daily",
+            report_date="2026-08-17",
+            template_snapshot=TEMPLATE,
+            content=CONTENT,
+            author_member_id=str(uuid4()),
+        )
+
+    assert ReportPatch(note=None).model_dump(exclude_unset=True) == {"note": None}
+    with pytest.raises(ValidationError):
+        ReportPageParams(start_date="2026-08-17", end_date="2026-08-10")
+
+
+class _CreateDb(_Db):
+    """생성한 Report 를 그대로 상세 조회 응답으로 돌려준다."""
+
+    def __init__(self, author: Member):
+        super().__init__()
+        self.author = author
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        report = next(value for value in self.added if isinstance(value, Report))
+        # 상세 조회는 _report_row, _activities_by_report_ids 순서로 두 번 실행된다.
+        if len(self.statements) == 1:
+            return _Result(rows=[_row(report, self.author)])
+        return _Result(rows=[])
+
+
+def test_create_starts_as_draft_and_ignores_client_status():
+    member = _member()
+    db = _CreateDb(member)
+
+    with _client(db, member) as client:
+        response = client.post(
+            "/api/reports",
+            headers={"Origin": ORIGIN},
+            json={
+                "report_kind": "daily",
+                "report_date": "2026-08-17",
+                "template_snapshot": TEMPLATE,
+                "content": CONTENT,
+            },
+        )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["status_code"] == "draft"
+    assert body["author_member_id"] == str(member.id)
+    assert body["team_id"] == str(member.team_id)
+    assert body["activities"] == []
+    assert response.headers["Location"] == f"/api/reports/{body['id']}"
+    assert db.flush_count == db.commit_count == 1
+
+
+def test_submitted_report_is_not_editable_or_deletable():
+    member = _member()
+
+    submitted = _report(member, status_code="submitted")
+    patch_db = _Db(_Result(scalar=submitted))
+    with _client(patch_db, member) as client:
+        patched = client.patch(
+            f"/api/reports/{submitted.id}",
+            headers={"Origin": ORIGIN},
+            json={"content": {"summary": "고치기"}},
+        )
+    assert patched.status_code == 409
+    assert patched.json() == {"detail": "report_not_editable"}
+    assert patch_db.commit_count == 0
+    assert patch_db.rollback_count == 1
+
+    delete_db = _Db(_Result(scalar=submitted))
+    with _client(delete_db, member) as client:
+        removed = client.delete(
+            f"/api/reports/{submitted.id}",
+            headers={"Origin": ORIGIN},
+        )
+    assert removed.status_code == 409
+    assert removed.json() == {"detail": "report_not_editable"}
+    assert delete_db.deleted == []
+    assert delete_db.commit_count == 0
+
+
+def test_submit_moves_draft_and_rejects_stale_expectation():
+    member = _member()
+    report = _report(member)
+
+    submit_db = _Db(
+        _Result(scalar=report),
+        _Result(rows=[_row(report, member)]),
+        _Result(rows=[]),
+    )
+    with _client(submit_db, member) as client:
+        submitted = client.post(
+            f"/api/reports/{report.id}/submit",
+            headers={"Origin": ORIGIN},
+            json={"expected_status_code": "draft"},
+        )
+    assert submitted.status_code == 200
+    assert submitted.json()["status_code"] == "submitted"
+    assert report.status_code == "submitted"
+    assert "FOR UPDATE" in str(submit_db.statements[0])
+    assert submit_db.flush_count == submit_db.commit_count == 1
+
+    stale_db = _Db(_Result(scalar=report))
+    with _client(stale_db, member) as client:
+        stale = client.post(
+            f"/api/reports/{report.id}/submit",
+            headers={"Origin": ORIGIN},
+            json={"expected_status_code": "draft"},
+        )
+    assert stale.status_code == 409
+    assert stale.json() == {"detail": "invalid_state_transition"}
+    assert stale_db.commit_count == 0
+    assert stale_db.rollback_count == 1
+
+
+def test_member_scope_hides_other_authors_report():
+    member = _member()
+    hidden_db = _Db(_Result(rows=[]))
+    report_id = uuid4()
+    with _client(hidden_db, member) as client:
+        hidden = client.get(f"/api/reports/{report_id}")
+    assert hidden.status_code == 404
+    assert hidden.json() == {"detail": "report_not_found"}
+
+    sql = str(hidden_db.statements[0])
+    assert "report.author_member_id" in sql
+
+    locked_db = _Db(_Result(scalar=None))
+    with _client(locked_db, member) as client:
+        missing = client.post(
+            f"/api/reports/{report_id}/submit",
+            headers={"Origin": ORIGIN},
+            json={"expected_status_code": "draft"},
+        )
+    assert missing.status_code == 404
+    assert missing.json() == {"detail": "report_not_found"}
+    assert locked_db.rollback_count == 1
+
+
+def test_member_cannot_attach_another_owners_activity():
+    member = _member()
+    foreign = _activity(_member(team_id=member.team_id))
+
+    db = _Db(_Result(scalar_values=[]))
+    with _client(db, member) as client:
+        response = client.post(
+            "/api/reports",
+            headers={"Origin": ORIGIN},
+            json={
+                "report_kind": "daily",
+                "report_date": "2026-08-17",
+                "template_snapshot": TEMPLATE,
+                "content": CONTENT,
+                "activity_ids": [str(foreign.id)],
+            },
+        )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "activity_not_found"}
+    assert db.commit_count == 0
+    assert db.rollback_count == 1
+
+    sql = str(db.statements[0])
+    assert "activity.owner_member_id" in sql
+    assert "activity.deleted_at IS NULL" in sql
+
+
+def test_manager_author_filter_is_limited_to_same_team():
+    member = _member(role="member")
+    denied_db = _Db()
+    with _client(denied_db, member) as client:
+        denied = client.get(f"/api/reports?author_member_id={uuid4()}")
+    assert denied.status_code == 403
+    assert denied.json() == {"detail": "scope_not_allowed"}
+
+    manager = _member(role="manager")
+    unknown_db = _Db(_Result(scalar_values=[]))
+    with _client(unknown_db, manager) as client:
+        unknown = client.get(f"/api/reports?author_member_id={uuid4()}")
+    assert unknown.status_code == 403
+    assert unknown.json() == {"detail": "scope_not_allowed"}
+
+
+def test_write_failure_rolls_back_transaction():
+    member = _member()
+    db = _Db(flush_error=RuntimeError("synthetic failure"))
+
+    with _client(db, member) as client, pytest.raises(RuntimeError, match="synthetic failure"):
+        client.post(
+            "/api/reports",
+            headers={"Origin": ORIGIN},
+            json={
+                "report_kind": "daily",
+                "report_date": "2026-08-17",
+                "template_snapshot": TEMPLATE,
+                "content": CONTENT,
+            },
+        )
+
+    assert db.commit_count == 0
+    assert db.rollback_count == 1

--- a/docs/technical/backend/api-conventions.md
+++ b/docs/technical/backend/api-conventions.md
@@ -288,6 +288,19 @@ GET /api/activities?owner_member_id=9f64618b-8ed8-4aed-9560-78b25228dbe5&owner_m
 | 발주 이동 | `POST /api/orders/{purchase_order_id}/move` | `expected_stage_code`, 목표 `stage_code` |
 | C/S | `GET/POST /api/support-requests`, `GET /api/support-requests/{request_id}` | 목록은 `q,status_code,skip,limit`; 상태 `in_progress|completed` |
 | C/S 전이·답변 | `POST /api/support-requests/{request_id}/transition`, `POST /api/support-requests/{request_id}/responses` | expected 상태 비교; 답변 생성 `201` |
+| 보고서 | `GET/POST /api/reports`, `GET/PATCH/DELETE /api/reports/{report_id}` | 목록은 `q,report_kind,status_code,start_date,end_date,author_member_id,skip,limit` |
+| 보고서 제출 | `POST /api/reports/{report_id}/submit` | `expected_status_code` 비교; `draft`만 제출 가능 |
+
+### 보고서의 상태와 작성 범위
+
+- 보고서 종류는 `meeting`, `daily`, `weekly`, `monthly`다.
+- 상태는 `draft`, `submitted`, `approved`, `rejected`이며 현재 API가 만드는 값은 `draft`와 `submitted` 둘이다.
+- 생성은 항상 `draft`로 시작한다. 요청으로 `status_code`나 작성자를 정할 수 없다.
+- 수정과 삭제는 `draft`에서만 허용하고 그 밖의 상태는 `409 report_not_editable`이다.
+- `weekly`, `monthly`는 `period_start`와 `period_end`가 모두 필요하고 `period_end >= period_start`여야 한다.
+- `meeting`은 근거가 되는 `source_activity_id`가 필요하다.
+- `activity_ids`로 묶는 일정은 같은 팀에서 조회 가능한 일정만 허용하며 아니면 `404 activity_not_found`다.
+- 검토(`approved`, `rejected`)와 `reviewed_by_member_id` 설정은 팀장 기능이라 이번 범위에 없다.
 
 ### 영업 딜의 화면 필터와 상태 전이
 


### PR DESCRIPTION
## 변경 요약

미팅·일간·주간·월간 보고서를 팀원이 직접 작성하는 흐름을 연결합니다.

- `GET/POST /api/reports`
- `GET/PATCH/DELETE /api/reports/{report_id}`
- `POST /api/reports/{report_id}/submit`

규칙:

- 생성은 항상 `draft`로 시작합니다. 요청으로 `status_code`나 작성자를 정할 수 없습니다.
- 수정·삭제는 `draft`에서만 허용하고 그 밖의 상태는 `409 report_not_editable`입니다.
- 제출은 `expected_status_code`를 비교해 중복 제출과 경합을 막습니다.
- `weekly`, `monthly`는 `period_start`·`period_end`가 모두 필요하고 `period_end >= period_start`여야 합니다.
- `meeting`은 근거가 되는 `source_activity_id`가 필요합니다.
- `report_activity`로 묶는 일정은 같은 팀에서 조회 가능한 일정만 허용하며 아니면 `404 activity_not_found`입니다.
- 팀원은 본인 보고서만, 팀장은 같은 팀 보고서를 보며 `author_member_id` 범위 규칙은 일정과 같습니다.

기존 `support.py`, `activities.py`의 구조(`_joined_select`, `_scope`, `_locked_*`, try/rollback)를 그대로 따랐습니다.

## 검증

| 검사 | 결과 |
|---|---|
| `uv run ruff check .` | All checks passed |
| `uv run ruff format --check .` | 55 files already formatted |
| `uv run pytest -q` | 78 passed (기존 70 → +8) |
| `git diff --check` | 문제 없음 |

개발 Supabase 실제 데이터로 확인한 결과입니다. 만든 보고서는 삭제했습니다.

```
create              -> 201  status=draft activities=1
patch               -> 200  content 수정 반영
남의 일정 붙이기      -> 404  activity_not_found
list                -> 200  total=1
submit              -> 200  status=submitted
submit 재요청        -> 409  invalid_state_transition
제출 후 수정          -> 409  report_not_editable
정리 완료
```

## 영향 및 주의 사항

- 백엔드만 변경합니다. Meetings·Daily 화면 연결은 후속 작업입니다.
- 검토(`approved`, `rejected`)와 `reviewed_by_member_id` 설정은 팀장 기능이라 이번 범위에서 제외했습니다. 상태값 자체는 조회 모델에 남아 있습니다.
- AI 초안 생성은 이번 범위에 없습니다. `source_snapshot`, `ai_evidence`는 생성 시 `null`로 두고 조회로만 노출합니다.
- 새 테이블이나 migration은 없습니다. 기존 `report`, `report_activity`를 사용합니다.

## 관련 이슈

- 없음
