### PR TITLE
개발 Supabase의 0005 적용과 seed 재실행 기록

### DIFF
--- a/backend/sql/README.md
+++ b/backend/sql/README.md
@@ -47,6 +47,13 @@ SQL은 `0001 → 0002 → 0003 → 0004 → 0005` 순서로 적용합니다. `00
 | 2026-08-17 | 개발 Supabase `public` | `scripts/seed_demo_auth.py` 2팀·6계정 | Session Pooler | 성공 |
 | 2026-08-17 | 개발 Supabase `public` | `scripts/seed_demo_customers.py` 고객사 6개·담당자 32명 | Session Pooler | 성공 |
 | 2026-08-17 | 개발 Supabase `public` | `scripts/seed_demo_activities.py` 상품 3개·일정 12건 | Session Pooler | 성공 |
+| 2026-08-18 | 개발 Supabase `public` | `20260817_0005_sales_deal_names.sql` | Session Pooler | 성공 |
+| 2026-08-18 | 개발 Supabase `public` | `scripts/seed_demo_auth.py` 2팀·6계정 | Session Pooler | 성공 |
+| 2026-08-18 | 개발 Supabase `public` | `scripts/seed_demo_customers.py` 고객사 6개·담당자 32명 | Session Pooler | 성공 |
+| 2026-08-18 | 개발 Supabase `public` | `scripts/seed_demo_activities.py` 상품 3개·일정 12건 | Session Pooler | 성공 |
+| 2026-08-18 | 개발 Supabase `public` | `scripts/seed_demo_sales_deals.py` 딜 61건 | Session Pooler | 성공 |
+| 2026-08-18 | 개발 Supabase `public` | `scripts/seed_demo_orders.py` 발주 2건·품목 2건 | Session Pooler | 성공 |
+| 2026-08-18 | 개발 Supabase `public` | `scripts/seed_demo_support.py` C/S 요청 3건 | Session Pooler | 성공 |
 
 ## 개발 로그인 계정
 


### PR DESCRIPTION
## 변경 요약

- 개발 Supabase `public` 스키마에 `20260817_0005_sales_deal_names.sql`을 적용하고 그 결과를 `backend/sql/README.md` 적용 이력에 남깁니다.
- 이어서 실행한 데모 seed 6종의 결과도 함께 기록합니다.

## 검증

적용 후 원격 DB를 읽기 전용으로 대조한 결과입니다.

| 항목 | 기대 | 실제 |
|---|---|---|
| 테이블 | 26 | 26 |
| 컬럼 | 266 | 266 |
| FK 제약조건 | 64 | 64 |
| FK 컬럼 요소 | 65 | 65 |
| RLS | 26/26 | 26/26 |

- `sales_deal`, `sales_pipeline` 생성 확인
- `contract` 제거 확인
- `agent_run.llm_model_name` 추가 확인
- ORM 26테이블과 원격 26테이블의 컬럼 집합 100% 일치 확인
- seed 결과: 데모팀 activity 12 / sales_deal 61 / purchase_order 2 / support_request 3 / customer_company 6, 첫 세팅팀 업무 데이터 0건

문서만 변경하므로 코드 검사 대상이 없습니다.

## 영향 및 주의 사항

- 원격 DB 변경은 이미 적용되었고 이 PR은 그 기록만 남깁니다.
- 원격 `member`가 8명입니다. 목표는 6명이지만 `demo-roster-rep-4`(15건), `demo-roster-rep-5`(9건)에 연결된 데이터가 있어 삭제하지 않았습니다. 처리 방침은 별도 판단이 필요합니다.

## 관련 이슈

- 없음
