### PR TITLE
공지와 개인 지시 조회 API 추가

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,6 +1,15 @@
 from fastapi import APIRouter
 
-from app.api import activities, auth, customers, health, orders, sales_deals, support
+from app.api import (
+    activities,
+    auth,
+    customers,
+    health,
+    notices,
+    orders,
+    sales_deals,
+    support,
+)
 
 api_router = APIRouter()
 api_router.include_router(health.router)
@@ -10,3 +19,4 @@ api_router.include_router(activities.router)
 api_router.include_router(sales_deals.router)
 api_router.include_router(orders.router)
 api_router.include_router(support.router)
+api_router.include_router(notices.router)

--- a/backend/app/api/notices.py
+++ b/backend/app/api/notices.py
@@ -1,0 +1,138 @@
+from datetime import datetime
+from typing import Annotated
+from uuid import UUID
+from zoneinfo import ZoneInfo
+
+from fastapi import APIRouter, HTTPException, Query, status
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from app.api.deps import CurrentMember, DbSession
+from app.models.workspace import Member, Notice
+from app.schemas.notices import NoticePage, NoticePageParams, NoticeRead
+
+router = APIRouter(tags=["notices"])
+
+_SEOUL = ZoneInfo("Asia/Seoul")
+_author = aliased(Member)
+
+
+def _contains(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return f"%{escaped}%"
+
+
+def _seoul(value: datetime | None) -> datetime | None:
+    return None if value is None else value.astimezone(_SEOUL)
+
+
+def _joined_select(*entities):
+    return (
+        select(*entities).select_from(Notice).join(_author, Notice.author_member_id == _author.id)
+    )
+
+
+def _scope(member: Member, requested: str | None):
+    """공지는 팀 전체가 보고 지시는 수신자 본인만 본다. 담당자 범위와 무관하다."""
+    conditions = [
+        Notice.team_id == member.team_id,
+        _author.team_id == member.team_id,
+        _author.role_code.in_(("member", "manager")),
+    ]
+    if requested == "team":
+        conditions.append(Notice.recipient_member_id.is_(None))
+    elif requested == "personal":
+        conditions.append(Notice.recipient_member_id == member.id)
+    else:
+        conditions.append(
+            or_(
+                Notice.recipient_member_id.is_(None),
+                Notice.recipient_member_id == member.id,
+            )
+        )
+    return conditions
+
+
+def _notice_read(notice: Notice, author_display_name: str) -> NoticeRead:
+    return NoticeRead(
+        id=notice.id,
+        scope="team" if notice.recipient_member_id is None else "personal",
+        author_member_id=notice.author_member_id,
+        author_display_name=author_display_name,
+        recipient_member_id=notice.recipient_member_id,
+        tag=notice.tag,
+        title=notice.title,
+        body=notice.body,
+        image_alt=notice.image_alt,
+        published_at=_seoul(notice.published_at),
+        due_at=_seoul(notice.due_at),
+        due_text=notice.due_text,
+    )
+
+
+async def _notice_row(db: AsyncSession, member: Member, notice_id: UUID):
+    result = await db.execute(
+        _joined_select(Notice, _author.display_name).where(
+            Notice.id == notice_id, *_scope(member, None)
+        )
+    )
+    row = result.one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="notice_not_found",
+        )
+    return row
+
+
+@router.get("/notices", response_model=NoticePage)
+async def list_notices(
+    page: Annotated[NoticePageParams, Query()],
+    member: CurrentMember,
+    db: DbSession,
+) -> NoticePage:
+    scope = _scope(member, page.scope)
+    if page.published_from is not None:
+        scope.append(Notice.published_at >= page.published_from)
+    if page.published_to is not None:
+        scope.append(Notice.published_at <= page.published_to)
+    if page.q is not None:
+        pattern = _contains(page.q)
+        scope.append(
+            or_(
+                Notice.title.ilike(pattern, escape="\\"),
+                Notice.body.ilike(pattern, escape="\\"),
+                Notice.tag.ilike(pattern, escape="\\"),
+                _author.display_name.ilike(pattern, escape="\\"),
+            )
+        )
+
+    total_result = await db.execute(_joined_select(func.count(Notice.id)).where(*scope))
+    total = total_result.scalar_one()
+    rows_result = await db.execute(
+        _joined_select(Notice, _author.display_name)
+        .where(*scope)
+        .order_by(Notice.published_at.desc(), Notice.id)
+        .offset(page.skip)
+        .limit(page.limit)
+    )
+    items = [_notice_read(*row) for row in rows_result.all()]
+    has_more = page.skip + len(items) < total
+    return NoticePage(
+        items=items,
+        skip=page.skip,
+        limit=page.limit,
+        total=total,
+        has_more=has_more,
+        next_skip=page.skip + len(items) if has_more else None,
+    )
+
+
+@router.get("/notices/{notice_id}", response_model=NoticeRead)
+async def get_notice(
+    notice_id: UUID,
+    member: CurrentMember,
+    db: DbSession,
+) -> NoticeRead:
+    return _notice_read(*await _notice_row(db, member, notice_id))

--- a/backend/app/schemas/notices.py
+++ b/backend/app/schemas/notices.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+from typing import Annotated, Literal, Self
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
+
+SearchQuery = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=100),
+]
+
+# team 은 수신자가 없는 팀 공지, personal 은 로그인한 사람에게 온 지시다.
+NoticeScope = Literal["team", "personal"]
+
+
+class NoticeRead(BaseModel):
+    id: UUID
+    scope: NoticeScope
+    author_member_id: UUID
+    author_display_name: str
+    recipient_member_id: UUID | None
+    tag: str | None
+    title: str
+    body: str
+    # image_storage_key 는 내부 저장소 주소라 응답하지 않는다. 대체 텍스트만 내보낸다.
+    image_alt: str | None
+    published_at: datetime
+    due_at: datetime | None
+    due_text: str | None
+
+
+class NoticePage(BaseModel):
+    items: list[NoticeRead]
+    skip: int
+    limit: int
+    total: int
+    has_more: bool
+    next_skip: int | None
+
+
+class NoticePageParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    scope: NoticeScope | None = None
+    q: SearchQuery | None = None
+    published_from: datetime | None = None
+    published_to: datetime | None = None
+    skip: int = Field(default=0, ge=0, le=9_223_372_036_854_775_807)
+    limit: int = Field(default=30, ge=1, le=100)
+
+    @model_validator(mode="after")
+    def _validate(self) -> Self:
+        if self.published_from is not None and self.published_to is not None:
+            if self.published_to < self.published_from:
+                raise ValueError("invalid_notice_range")
+        return self

--- a/backend/tests/test_notices.py
+++ b/backend/tests/test_notices.py
@@ -1,0 +1,175 @@
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from app.api.deps import get_current_member
+from app.db.session import get_db
+from app.main import app
+from app.models.workspace import Member, Notice
+from app.schemas.notices import NoticePageParams
+
+NOW = datetime(2026, 8, 17, 9, tzinfo=UTC)
+_MISSING = object()
+
+
+class _Result:
+    def __init__(self, *, scalar=_MISSING, rows=None):
+        self.scalar = scalar
+        self.rows = [] if rows is None else rows
+
+    def scalar_one(self):
+        assert self.scalar is not _MISSING
+        return self.scalar
+
+    def one_or_none(self):
+        assert len(self.rows) <= 1
+        return self.rows[0] if self.rows else None
+
+    def all(self):
+        return self.rows
+
+
+class _Db:
+    def __init__(self, *results: _Result):
+        self.results = list(results)
+        self.statements = []
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        assert self.results, "예상보다 많은 쿼리가 실행되었습니다."
+        return self.results.pop(0)
+
+
+@pytest.fixture(autouse=True)
+def reset_dependency_overrides():
+    app.dependency_overrides.clear()
+    yield
+    app.dependency_overrides.clear()
+
+
+def _member(*, role: str = "member", team_id: UUID | None = None) -> Member:
+    return Member(
+        id=uuid4(),
+        team_id=team_id or uuid4(),
+        login_id=f"{uuid4()}@salesluv.demo",
+        password_hash="unused",
+        display_name="합성 영업 담당자",
+        role_code=role,
+        job_title="영업 담당자",
+        active=True,
+    )
+
+
+def _notice(author: Member, *, recipient_id: UUID | None = None) -> Notice:
+    return Notice(
+        id=uuid4(),
+        team_id=author.team_id,
+        author_member_id=author.id,
+        recipient_member_id=recipient_id,
+        tag="공지",
+        title="합성 공지",
+        body="합성 본문",
+        image_storage_key="team/secret-object-key.png",
+        image_alt="합성 이미지",
+        published_at=NOW,
+        due_at=None,
+        due_text=None,
+    )
+
+
+def _client(db: _Db, member: Member) -> TestClient:
+    async def override_db():
+        yield db
+
+    async def override_member():
+        return member
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_member] = override_member
+    return TestClient(app)
+
+
+def test_notice_page_params_reject_unsafe_values():
+    with pytest.raises(ValidationError):
+        NoticePageParams(scope="everyone")
+    with pytest.raises(ValidationError):
+        NoticePageParams(
+            published_from="2026-08-17T00:00:00+09:00",
+            published_to="2026-08-10T00:00:00+09:00",
+        )
+    with pytest.raises(ValidationError):
+        NoticePageParams(limit=101)
+    with pytest.raises(ValidationError):
+        NoticePageParams(recipient_member_id=str(uuid4()))
+
+
+def test_storage_key_is_never_exposed():
+    member = _member()
+    notice = _notice(member)
+    db = _Db(_Result(rows=[(notice, member.display_name)]))
+
+    with _client(db, member) as client:
+        response = client.get(f"/api/notices/{notice.id}")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "image_storage_key" not in body
+    assert notice.image_storage_key not in response.text
+    assert body["image_alt"] == "합성 이미지"
+
+
+def test_scope_splits_team_notice_and_personal_directive():
+    member = _member()
+    team_notice = _notice(member)
+    personal = _notice(member, recipient_id=member.id)
+
+    team_db = _Db(_Result(scalar=1), _Result(rows=[(team_notice, member.display_name)]))
+    with _client(team_db, member) as client:
+        team = client.get("/api/notices?scope=team")
+    assert team.status_code == 200
+    assert team.json()["items"][0]["scope"] == "team"
+    assert team.json()["items"][0]["recipient_member_id"] is None
+    assert "public.notice.recipient_member_id IS NULL" in str(team_db.statements[0])
+
+    personal_db = _Db(_Result(scalar=1), _Result(rows=[(personal, member.display_name)]))
+    with _client(personal_db, member) as client:
+        mine = client.get("/api/notices?scope=personal")
+    assert mine.status_code == 200
+    assert mine.json()["items"][0]["scope"] == "personal"
+    assert mine.json()["items"][0]["recipient_member_id"] == str(member.id)
+
+    sql = str(personal_db.statements[0])
+    assert "public.notice.recipient_member_id =" in sql
+    assert member.id in personal_db.statements[0].compile().params.values()
+
+
+def test_default_scope_hides_other_members_directive():
+    member = _member()
+    db = _Db(_Result(scalar=0), _Result(rows=[]))
+
+    with _client(db, member) as client:
+        response = client.get("/api/notices")
+
+    assert response.status_code == 200
+    assert response.json()["items"] == []
+    assert response.json()["total"] == 0
+
+    sql = str(db.statements[0])
+    # 팀 공지이거나 내가 수신자인 지시만 보인다.
+    assert "public.notice.recipient_member_id IS NULL OR public.notice.recipient_member_id =" in sql
+    assert "public.notice.team_id =" in sql
+
+
+def test_other_team_notice_is_hidden():
+    member = _member()
+    db = _Db(_Result(rows=[]))
+
+    with _client(db, member) as client:
+        response = client.get(f"/api/notices/{uuid4()}")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "notice_not_found"}
+    assert member.team_id in db.statements[0].compile().params.values()

--- a/docs/technical/backend/api-conventions.md
+++ b/docs/technical/backend/api-conventions.md
@@ -288,6 +288,17 @@ GET /api/activities?owner_member_id=9f64618b-8ed8-4aed-9560-78b25228dbe5&owner_m
 | 발주 이동 | `POST /api/orders/{purchase_order_id}/move` | `expected_stage_code`, 목표 `stage_code` |
 | C/S | `GET/POST /api/support-requests`, `GET /api/support-requests/{request_id}` | 목록은 `q,status_code,skip,limit`; 상태 `in_progress|completed` |
 | C/S 전이·답변 | `POST /api/support-requests/{request_id}/transition`, `POST /api/support-requests/{request_id}/responses` | expected 상태 비교; 답변 생성 `201` |
+| 공지·지시 | `GET /api/notices`, `GET /api/notices/{notice_id}` | 목록은 `scope,q,published_from,published_to,skip,limit` |
+
+### 공지와 개인 지시의 조회 범위
+
+- `notice.recipient_member_id`가 NULL이면 팀 공지, 값이 있으면 그 사람에게 온 개인 지시다.
+- 응답의 `scope`가 `team`과 `personal`을 구분해 주므로 프론트가 `recipient_member_id`로 다시 판정하지 않는다.
+- 담당자 범위와 무관하다. 팀 공지는 같은 팀 전체가 보고 개인 지시는 수신자 본인만 본다.
+- `scope`를 생략하면 팀 공지와 본인 수신 지시를 함께 조회한다.
+- 다른 사람에게 온 지시는 팀장에게도 보이지 않는다.
+- `image_storage_key`는 내부 저장소 주소라 응답하지 않고 `image_alt`만 내보낸다.
+- 각 `scope`의 전체 건수는 페이지 응답의 `total`로 얻는다.
 
 ### 영업 딜의 화면 필터와 상태 전이
 


### PR DESCRIPTION
## 변경 요약

대시보드의 공지·지시 영역이 쓸 조회 endpoint를 추가합니다.

- `GET /api/notices`
- `GET /api/notices/{notice_id}`

규칙:

- `notice.recipient_member_id`가 NULL이면 팀 공지, 값이 있으면 개인 지시입니다.
- 응답의 `scope`가 `team`/`personal`을 구분해 주므로 프론트가 `recipient_member_id`로 다시 판정하지 않습니다.
- 담당자 범위와 무관합니다. 팀 공지는 같은 팀 전체가, 개인 지시는 수신자 본인만 봅니다. 다른 사람에게 온 지시는 팀장에게도 보이지 않습니다.
- `scope`를 생략하면 팀 공지와 본인 수신 지시를 함께 조회합니다.
- `image_storage_key`는 내부 저장소 주소라 응답 모델에서 제외하고 `image_alt`만 내보냅니다. (규약 13절)
- 각 `scope`의 전체 건수는 페이지 응답의 `total`로 얻습니다.

## 검증

| 검사 | 결과 |
|---|---|
| `uv run ruff check .` | All checks passed |
| `uv run ruff format --check .` | 55 files already formatted |
| `uv run pytest -q` | 75 passed (기존 70 → +5) |
| `git diff --check` | 문제 없음 |

테스트가 확인하는 것:

- `image_storage_key`가 응답 본문 어디에도 나타나지 않음
- `scope=team`이 `recipient_member_id IS NULL`로, `scope=personal`이 본인 ID로 필터링
- `scope` 생략 시 팀 공지 + 본인 지시만
- 다른 팀 공지는 `404 notice_not_found`
- `scope` 오타, 뒤집힌 날짜 범위, `limit=101`, 미지원 Query는 `422`

원격 `notice` 테이블은 현재 0건이라 실제 데이터 스모크 테스트는 하지 못했습니다. seed가 없어 조회 결과가 빈 페이지로만 나옵니다.

## 영향 및 주의 사항

- 백엔드만 변경합니다. Dashboard 연결은 후속 작업입니다.
- 공지 작성·수정은 팀장 기능이라 이번 범위에서 제외했습니다. 조회만 추가합니다.
- 새 테이블이나 migration은 없습니다. 기존 `notice`를 사용합니다.
- 이미지 다운로드 경로는 Supabase Storage 연동과 함께 별도로 다룹니다.

## 관련 이슈

- 없음