### PR TITLE
보고서 초안 LLM 호출 추가

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -35,3 +35,12 @@ DEMO_PASSWORD=
 # 스키마 변경은 backend/sql/ 의 SQL 을 Supabase SQL Editor 에서 실행한다.
 # 관리 작업에는 앱 연결 문자열 대신 direct 연결을 사용한다 (backend/sql/README.md 참고).
 DATABASE_URL=
+
+# LLM (보고서 초안 생성)
+#
+# API key 는 서버 프로세스 안에서만 사용하고 브라우저로 내려보내지 않는다.
+# 세 값이 모두 있어야 초안 생성이 열리고, 하나라도 비면 503 으로 막는다.
+LLM_API_URL=
+LLM_API_KEY=
+LLM_MODEL=
+LLM_TIMEOUT_SECONDS=30

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 from app.api import (
     activities,
+    agent_runs,
     auth,
     customers,
     health,
@@ -22,3 +23,4 @@ api_router.include_router(orders.router)
 api_router.include_router(support.router)
 api_router.include_router(reports.router)
 api_router.include_router(notices.router)
+api_router.include_router(agent_runs.router)

--- a/backend/app/api/agent_runs.py
+++ b/backend/app/api/agent_runs.py
@@ -1,0 +1,249 @@
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+from zoneinfo import ZoneInfo
+
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Response, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import CurrentMember, DbSession
+from app.core.config import settings
+from app.db.session import get_sessionmaker
+from app.models.agent import AgentRun
+from app.models.content import Report
+from app.models.workspace import Member
+from app.schemas.agent_runs import (
+    AgentRunCreate,
+    AgentRunRead,
+    ReportDraftOutput,
+)
+from app.services.llm import LLMError, generate_structured
+
+router = APIRouter(tags=["agent-runs"])
+
+_SEOUL = ZoneInfo("Asia/Seoul")
+
+# 프롬프트를 고치면 올린다. 실행 이력이 어떤 프롬프트로 나왔는지 되짚기 위해서다.
+PROMPT_VERSION = "report_writing.v1"
+RETRY_AFTER_SECONDS = 2
+
+_INSTRUCTIONS = (
+    "너는 한국어 영업 보고서 초안을 쓰는 도우미다. "
+    "주어진 양식 항목과 근거 자료만 사용하고 없는 사실을 지어내지 마라. "
+    "각 항목마다 field_id 와 value 를 채우고, 근거가 없으면 value 를 빈 문자열로 둬라. "
+    "JSON 만 출력한다."
+)
+
+
+def _seoul(value: datetime | None) -> datetime | None:
+    return None if value is None else value.astimezone(_SEOUL)
+
+
+def _run_read(run: AgentRun) -> AgentRunRead:
+    return AgentRunRead(
+        id=run.id,
+        agent_code=run.agent_code,
+        trigger_code=run.trigger_code,
+        status_code=run.status_code,
+        llm_model_name=run.llm_model_name,
+        prompt_version=run.prompt_version,
+        requested_by_member_id=run.requested_by_member_id,
+        source_refs=run.source_refs,
+        output_snapshot=run.output_snapshot,
+        evidence=run.evidence,
+        error_message=run.error_message,
+        started_at=_seoul(run.started_at),
+        finished_at=_seoul(run.finished_at),
+    )
+
+
+def _scope(member: Member):
+    """실행 이력은 같은 팀 안에서 요청자 본인 것만 본다."""
+    conditions = [AgentRun.team_id == member.team_id]
+    if member.role_code == "member":
+        conditions.append(AgentRun.requested_by_member_id == member.id)
+    return conditions
+
+
+async def _draft_source(db: AsyncSession, member: Member, report_id: UUID) -> Report:
+    """초안을 붙일 보고서. 남의 보고서와 제출된 보고서는 대상이 아니다."""
+    conditions = [
+        Report.id == report_id,
+        Report.team_id == member.team_id,
+    ]
+    if member.role_code == "member":
+        conditions.append(Report.author_member_id == member.id)
+    report = (await db.execute(select(Report).where(*conditions))).scalar_one_or_none()
+    if report is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="report_not_found",
+        )
+    if report.status_code != "draft":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="report_not_editable",
+        )
+    return report
+
+
+def _input_snapshot(report: Report, guidance: str | None) -> dict:
+    """실행에 실제로 쓴 값만 남긴다. 원문 전체를 복제하지 않는다."""
+    return {
+        "report_kind": report.report_kind,
+        "report_date": report.report_date.isoformat(),
+        "template_snapshot": report.template_snapshot,
+        "content": report.content,
+        "transcript": report.transcript,
+        "guidance": guidance,
+    }
+
+
+def _prompt_input(snapshot: dict) -> str:
+    lines = [
+        f"보고서 종류: {snapshot['report_kind']}",
+        f"보고 일자: {snapshot['report_date']}",
+        f"양식: {snapshot['template_snapshot']}",
+        f"현재 작성값: {snapshot['content']}",
+    ]
+    if snapshot.get("transcript"):
+        lines.append(f"미팅 기록: {snapshot['transcript']}")
+    if snapshot.get("guidance"):
+        lines.append(f"작성자 요청: {snapshot['guidance']}")
+    return "\n".join(lines)
+
+
+async def _execute(run_id: UUID) -> None:
+    """백그라운드 실행. 요청 세션이 닫힌 뒤라 자체 세션을 쓴다.
+
+    실패해도 업무 데이터는 건드리지 않고 실행 이력에만 남긴다.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        run = (
+            await session.execute(select(AgentRun).where(AgentRun.id == run_id))
+        ).scalar_one_or_none()
+        if run is None or run.status_code != "queued":
+            return
+        run.status_code = "running"
+        run.started_at = datetime.now(UTC)
+        await session.commit()
+
+    output: ReportDraftOutput | None = None
+    error: str | None = None
+    try:
+        async with sessionmaker() as session:
+            snapshot = (
+                await session.execute(select(AgentRun.input_snapshot).where(AgentRun.id == run_id))
+            ).scalar_one()
+        output = await generate_structured(
+            instructions=_INSTRUCTIONS,
+            input_text=_prompt_input(snapshot),
+            schema=ReportDraftOutput,
+            schema_name="report_draft",
+        )
+    except LLMError as caught:
+        error = str(caught)
+    except Exception:
+        # 공급자 예외 원문에 URL 이나 key 가 섞일 수 있어 코드만 남긴다.
+        error = "llm_unexpected_error"
+
+    async with sessionmaker() as session:
+        run = (
+            await session.execute(select(AgentRun).where(AgentRun.id == run_id))
+        ).scalar_one_or_none()
+        if run is None:
+            return
+        run.finished_at = datetime.now(UTC)
+        if output is None:
+            run.status_code = "failed"
+            run.error_message = error
+        else:
+            run.status_code = "completed"
+            # 제안일 뿐이다. 사람이 확인해 보고서에 반영하기 전에는 report 를 고치지 않는다.
+            run.output_snapshot = output.model_dump()
+            run.evidence = {"prompt_version": PROMPT_VERSION, "summary": output.summary}
+        await session.commit()
+
+
+@router.post(
+    "/agent-runs",
+    response_model=AgentRunRead,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def create_agent_run(
+    payload: AgentRunCreate,
+    response: Response,
+    background: BackgroundTasks,
+    member: CurrentMember,
+    db: DbSession,
+) -> AgentRunRead:
+    if not settings.llm_configured:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="llm_not_configured",
+        )
+
+    existing = (
+        await db.execute(
+            select(AgentRun).where(
+                AgentRun.requested_by_member_id == member.id,
+                AgentRun.idempotency_key == payload.idempotency_key,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        response.headers["Location"] = f"/api/agent-runs/{existing.id}"
+        response.headers["Retry-After"] = str(RETRY_AFTER_SECONDS)
+        return _run_read(existing)
+
+    try:
+        report = await _draft_source(db, member, payload.report_id)
+        run = AgentRun(
+            id=uuid4(),
+            team_id=member.team_id,
+            parent_run_id=None,
+            requested_by_member_id=member.id,
+            agent_code=payload.agent_code,
+            trigger_code="user",
+            idempotency_key=payload.idempotency_key,
+            status_code="queued",
+            llm_model_name=settings.llm_model,
+            prompt_version=PROMPT_VERSION,
+            source_refs={"report_id": str(report.id)},
+            input_snapshot=_input_snapshot(report, payload.guidance),
+            output_snapshot=None,
+            evidence=None,
+            error_message=None,
+            started_at=None,
+            finished_at=None,
+        )
+        db.add(run)
+        await db.flush()
+        read = _run_read(run)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+
+    background.add_task(_execute, run.id)
+    response.headers["Location"] = f"/api/agent-runs/{run.id}"
+    response.headers["Retry-After"] = str(RETRY_AFTER_SECONDS)
+    return read
+
+
+@router.get("/agent-runs/{agent_run_id}", response_model=AgentRunRead)
+async def get_agent_run(
+    agent_run_id: UUID,
+    member: CurrentMember,
+    db: DbSession,
+) -> AgentRunRead:
+    run = (
+        await db.execute(select(AgentRun).where(AgentRun.id == agent_run_id, *_scope(member)))
+    ).scalar_one_or_none()
+    if run is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="agent_run_not_found",
+        )
+    return _run_read(run)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -42,6 +42,17 @@ class Settings(BaseSettings):
     demo_empty_member2_login_id: str = ""
     demo_password: SecretStr = SecretStr("")
 
+    # LLM 공급자. API key 는 서버 프로세스 안에서만 쓰고 응답이나 로그에 남기지 않는다.
+    llm_api_url: str = ""
+    llm_api_key: SecretStr = SecretStr("")
+    llm_model: str = ""
+    llm_timeout_seconds: float = Field(default=30.0, gt=0, le=300)
+
+    @property
+    def llm_configured(self) -> bool:
+        """LLM 호출에 필요한 값이 모두 있는지. 없으면 기능을 503 으로 막는다."""
+        return bool(self.llm_api_url and self.llm_api_key.get_secret_value() and self.llm_model)
+
     @property
     def cors_origin_list(self) -> list[str]:
         return [origin.strip() for origin in self.cors_origins.split(",") if origin.strip()]

--- a/backend/app/schemas/agent_runs.py
+++ b/backend/app/schemas/agent_runs.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+from typing import Annotated, Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+
+# 이번 범위에서 사람이 시작할 수 있는 실행은 보고서 초안 하나다.
+AgentCode = Literal["report_writing"]
+AgentStatus = Literal["queued", "running", "completed", "failed"]
+
+Guidance = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=2_000),
+]
+
+
+class AgentRunCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    agent_code: AgentCode
+    report_id: UUID
+    # 같은 키로 다시 보내면 새 실행을 만들지 않고 기존 실행을 돌려준다.
+    idempotency_key: UUID
+    guidance: Guidance | None = None
+
+
+class ReportDraftField(BaseModel):
+    """양식 항목 하나에 대한 제안. field_id 는 template_snapshot 의 항목 id 다."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    field_id: str = Field(min_length=1, max_length=128)
+    value: str = Field(max_length=5_000)
+
+
+class ReportDraftOutput(BaseModel):
+    """LLM 이 돌려줘야 하는 구조. 검증에 실패하면 실행을 failed 로 남긴다."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    fields: list[ReportDraftField] = Field(max_length=50)
+    summary: str = Field(default="", max_length=2_000)
+
+
+class AgentRunRead(BaseModel):
+    id: UUID
+    agent_code: str
+    trigger_code: str
+    status_code: AgentStatus
+    llm_model_name: str
+    prompt_version: str
+    requested_by_member_id: UUID | None
+    source_refs: dict[str, Any]
+    output_snapshot: dict[str, Any] | None
+    evidence: dict[str, Any] | None
+    error_message: str | None
+    started_at: datetime | None
+    finished_at: datetime | None

--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -1,0 +1,105 @@
+"""LLM 공급자 호출 경계.
+
+지금은 공급자 HTTP 호출 하나만 둔다. 나중에 멀티에이전트를 붙일 때
+호출부는 그대로 두고 이 모듈만 교체한다.
+
+API key 는 서버 환경변수에서만 읽고 응답이나 로그에 남기지 않는다.
+"""
+
+import json
+from typing import Any
+
+import httpx
+from pydantic import BaseModel, ValidationError
+
+from app.core.config import settings
+
+
+class LLMError(Exception):
+    """공급자 호출이나 구조화 출력 검증이 실패했다. 메시지에 비밀값을 담지 않는다."""
+
+
+class LLMNotConfigured(LLMError):
+    """LLM_API_URL, LLM_API_KEY, LLM_MODEL 중 빠진 값이 있다."""
+
+
+def _extract_text(payload: dict[str, Any]) -> str:
+    """공급자 응답에서 모델이 쓴 본문만 꺼낸다."""
+    text = payload.get("output_text")
+    if isinstance(text, str) and text.strip():
+        return text
+
+    chunks: list[str] = []
+    for item in payload.get("output") or ():
+        if not isinstance(item, dict):
+            continue
+        for part in item.get("content") or ():
+            if isinstance(part, dict) and isinstance(part.get("text"), str):
+                chunks.append(part["text"])
+    if chunks:
+        return "".join(chunks)
+
+    # Chat Completions 형태로 응답하는 공급자도 받아 준다.
+    for choice in payload.get("choices") or ():
+        if isinstance(choice, dict):
+            message = choice.get("message")
+            if isinstance(message, dict) and isinstance(message.get("content"), str):
+                return message["content"]
+
+    raise LLMError("empty_llm_output")
+
+
+async def generate_structured[Schema: BaseModel](
+    *,
+    instructions: str,
+    input_text: str,
+    schema: type[Schema],
+    schema_name: str,
+) -> Schema:
+    """구조화 출력 하나를 받아 Pydantic 으로 검증해 돌려준다."""
+    if not settings.llm_configured:
+        raise LLMNotConfigured("llm_not_configured")
+
+    body = {
+        "model": settings.llm_model,
+        "input": [
+            {"role": "system", "content": instructions},
+            {"role": "user", "content": input_text},
+        ],
+        "text": {
+            "format": {
+                "type": "json_schema",
+                "name": schema_name,
+                "schema": schema.model_json_schema(),
+                "strict": False,
+            }
+        },
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=settings.llm_timeout_seconds) as client:
+            response = await client.post(
+                settings.llm_api_url,
+                headers={
+                    "Authorization": f"Bearer {settings.llm_api_key.get_secret_value()}",
+                    "Content-Type": "application/json",
+                },
+                json=body,
+            )
+    except httpx.HTTPError as error:
+        # 공급자 URL 과 key 가 메시지에 섞이지 않도록 예외 종류만 남긴다.
+        raise LLMError(f"llm_request_failed:{type(error).__name__}") from error
+
+    if response.status_code >= 400:
+        raise LLMError(f"llm_provider_error:{response.status_code}")
+
+    try:
+        payload = response.json()
+    except ValueError as error:
+        raise LLMError("llm_response_not_json") from error
+
+    text = _extract_text(payload)
+    try:
+        return schema.model_validate(json.loads(text))
+    except (ValueError, ValidationError) as error:
+        raise LLMError("llm_output_schema_mismatch") from error

--- a/backend/tests/test_agent_runs.py
+++ b/backend/tests/test_agent_runs.py
@@ -1,0 +1,367 @@
+import json
+from datetime import UTC, date, datetime
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from app.api import agent_runs
+from app.api.deps import get_current_member
+from app.core.config import settings
+from app.db.session import get_db
+from app.main import app
+from app.models.agent import AgentRun
+from app.models.content import Report
+from app.models.workspace import Member
+from app.schemas.agent_runs import AgentRunCreate, ReportDraftOutput
+from app.services import llm
+
+ORIGIN = settings.cors_origin_list[0]
+NOW = datetime(2026, 8, 17, 9, tzinfo=UTC)
+TEMPLATE = {"fields": [{"id": "summary", "label": "요약"}]}
+_MISSING = object()
+
+
+class _Secret:
+    """SecretStr 대체. 값이 메시지에 새는지 보려고 일부러 눈에 띄는 문자열을 쓴다."""
+
+    def __init__(self, value: str):
+        self._value = value
+
+    def get_secret_value(self) -> str:
+        return self._value
+
+
+class _Result:
+    def __init__(self, *, scalar=_MISSING):
+        self.scalar = scalar
+
+    def scalar_one(self):
+        assert self.scalar is not _MISSING
+        return self.scalar
+
+    def scalar_one_or_none(self):
+        assert self.scalar is not _MISSING
+        return self.scalar
+
+
+class _Db:
+    def __init__(self, *results: _Result):
+        self.results = list(results)
+        self.statements = []
+        self.added = []
+        self.commit_count = 0
+        self.rollback_count = 0
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        assert self.results, "예상보다 많은 쿼리가 실행되었습니다."
+        return self.results.pop(0)
+
+    def add(self, value):
+        self.added.append(value)
+
+    async def flush(self):
+        pass
+
+    async def commit(self):
+        self.commit_count += 1
+
+    async def rollback(self):
+        self.rollback_count += 1
+
+
+@pytest.fixture(autouse=True)
+def reset_dependency_overrides():
+    app.dependency_overrides.clear()
+    yield
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def llm_ready(monkeypatch):
+    monkeypatch.setattr(settings, "llm_api_url", "https://provider.invalid/v1/responses")
+    monkeypatch.setattr(settings, "llm_model", "test-model")
+    monkeypatch.setattr(settings, "llm_api_key", _Secret("super-secret-key"))
+    monkeypatch.setattr(type(settings), "llm_configured", property(lambda self: True))
+    yield
+
+
+@pytest.fixture
+def llm_missing(monkeypatch):
+    """개발 .env 에 LLM 값이 있어도 미설정 상태를 강제한다."""
+    monkeypatch.setattr(type(settings), "llm_configured", property(lambda self: False))
+    yield
+
+
+def _member(*, role: str = "member") -> Member:
+    return Member(
+        id=uuid4(),
+        team_id=uuid4(),
+        login_id=f"{uuid4()}@salesluv.demo",
+        password_hash="unused",
+        display_name="합성 영업 담당자",
+        role_code=role,
+        job_title="영업 담당자",
+        active=True,
+    )
+
+
+def _report(member: Member, *, status_code: str = "draft") -> Report:
+    return Report(
+        id=uuid4(),
+        team_id=member.team_id,
+        author_member_id=member.id,
+        recipient_member_id=None,
+        template_snapshot=TEMPLATE,
+        source_activity_id=None,
+        report_kind="daily",
+        report_date=date(2026, 8, 17),
+        period_start=None,
+        period_end=None,
+        status_code=status_code,
+        content={"summary": ""},
+        transcript=None,
+        source_snapshot=None,
+        ai_evidence=None,
+        note=None,
+        reviewed_by_member_id=None,
+        reviewed_at=None,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _run(member: Member, *, status_code: str = "queued", key: UUID | None = None) -> AgentRun:
+    return AgentRun(
+        id=uuid4(),
+        team_id=member.team_id,
+        parent_run_id=None,
+        requested_by_member_id=member.id,
+        agent_code="report_writing",
+        trigger_code="user",
+        idempotency_key=key or uuid4(),
+        status_code=status_code,
+        llm_model_name="test-model",
+        prompt_version=agent_runs.PROMPT_VERSION,
+        source_refs={"report_id": str(uuid4())},
+        input_snapshot={},
+        output_snapshot=None,
+        evidence=None,
+        error_message=None,
+        started_at=None,
+        finished_at=None,
+    )
+
+
+def _client(db: _Db, member: Member) -> TestClient:
+    async def override_db():
+        yield db
+
+    async def override_member():
+        return member
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_member] = override_member
+    return TestClient(app)
+
+
+def test_agent_run_request_rejects_unsafe_values():
+    report_id = uuid4()
+    key = uuid4()
+    with pytest.raises(ValidationError):
+        # 이번 범위에 없는 agent 는 받지 않는다.
+        AgentRunCreate(agent_code="meeting_analysis", report_id=report_id, idempotency_key=key)
+    with pytest.raises(ValidationError):
+        # 상태와 팀은 요청으로 정할 수 없다.
+        AgentRunCreate(
+            agent_code="report_writing",
+            report_id=report_id,
+            idempotency_key=key,
+            status_code="completed",
+        )
+    with pytest.raises(ValidationError):
+        # idempotency_key 는 필수다.
+        AgentRunCreate(agent_code="report_writing", report_id=report_id)
+
+
+def test_llm_not_configured_returns_503(llm_missing):
+    member = _member()
+    db = _Db()
+    with _client(db, member) as client:
+        response = client.post(
+            "/api/agent-runs",
+            headers={"Origin": ORIGIN},
+            json={
+                "agent_code": "report_writing",
+                "report_id": str(uuid4()),
+                "idempotency_key": str(uuid4()),
+            },
+        )
+    assert response.status_code == 503
+    assert response.json() == {"detail": "llm_not_configured"}
+    assert db.commit_count == 0
+
+
+def test_accepted_run_is_queued_and_does_not_touch_report(llm_ready, monkeypatch):
+    # TestClient 는 응답 뒤 백그라운드 작업을 실제로 돌린다. 실행 자체는 별도로 검증하고
+    # 여기서는 예약 여부만 본다. 그대로 두면 실제 DB 엔진에 붙어 다른 테스트를 오염시킨다.
+    scheduled: list[UUID] = []
+
+    async def _fake_execute(run_id: UUID) -> None:
+        scheduled.append(run_id)
+
+    monkeypatch.setattr(agent_runs, "_execute", _fake_execute)
+
+    member = _member()
+    report = _report(member)
+    db = _Db(_Result(scalar=None), _Result(scalar=report))
+
+    with _client(db, member) as client:
+        response = client.post(
+            "/api/agent-runs",
+            headers={"Origin": ORIGIN},
+            json={
+                "agent_code": "report_writing",
+                "report_id": str(report.id),
+                "idempotency_key": str(uuid4()),
+            },
+        )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["status_code"] == "queued"
+    assert body["output_snapshot"] is None
+    assert response.headers["Location"] == f"/api/agent-runs/{body['id']}"
+    assert response.headers["Retry-After"] == str(agent_runs.RETRY_AFTER_SECONDS)
+
+    # 사람이 확인하기 전에는 보고서를 고치지 않는다.
+    assert report.content == {"summary": ""}
+    assert report.status_code == "draft"
+    assert db.commit_count == 1
+    assert scheduled == [UUID(body["id"])]
+
+
+def test_same_idempotency_key_returns_existing_run(llm_ready):
+    member = _member()
+    key = uuid4()
+    existing = _run(member, status_code="running", key=key)
+    db = _Db(_Result(scalar=existing))
+
+    with _client(db, member) as client:
+        response = client.post(
+            "/api/agent-runs",
+            headers={"Origin": ORIGIN},
+            json={
+                "agent_code": "report_writing",
+                "report_id": str(uuid4()),
+                "idempotency_key": str(key),
+            },
+        )
+
+    assert response.status_code == 202
+    assert response.json()["id"] == str(existing.id)
+    assert response.json()["status_code"] == "running"
+    # 새 실행을 만들지 않았다.
+    assert db.added == []
+    assert db.commit_count == 0
+
+
+def test_submitted_report_cannot_be_drafted(llm_ready):
+    member = _member()
+    submitted = _report(member, status_code="submitted")
+    db = _Db(_Result(scalar=None), _Result(scalar=submitted))
+
+    with _client(db, member) as client:
+        response = client.post(
+            "/api/agent-runs",
+            headers={"Origin": ORIGIN},
+            json={
+                "agent_code": "report_writing",
+                "report_id": str(submitted.id),
+                "idempotency_key": str(uuid4()),
+            },
+        )
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "report_not_editable"}
+    assert db.rollback_count == 1
+
+
+def test_member_cannot_read_other_requesters_run():
+    member = _member()
+    db = _Db(_Result(scalar=None))
+    with _client(db, member) as client:
+        response = client.get(f"/api/agent-runs/{uuid4()}")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "agent_run_not_found"}
+    sql = str(db.statements[0])
+    assert "agent_run.requested_by_member_id" in sql
+    assert "agent_run.team_id" in sql
+
+
+@pytest.mark.anyio
+async def test_provider_errors_never_leak_url_or_key(llm_ready, monkeypatch):
+    class _FailingClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def post(self, *args, **kwargs):
+            raise httpx.ConnectError("https://provider.invalid 로 붙지 못함")
+
+    monkeypatch.setattr(llm.httpx, "AsyncClient", _FailingClient)
+
+    with pytest.raises(llm.LLMError) as caught:
+        await llm.generate_structured(
+            instructions="x",
+            input_text="y",
+            schema=ReportDraftOutput,
+            schema_name="report_draft",
+        )
+
+    message = str(caught.value)
+    assert "super-secret-key" not in message
+    assert "provider.invalid" not in message
+    assert message == "llm_request_failed:ConnectError"
+
+
+@pytest.mark.anyio
+async def test_schema_mismatch_is_rejected(llm_ready, monkeypatch):
+    class _Response:
+        status_code = 200
+
+        def json(self):
+            # fields 가 요구 형태가 아니다.
+            return {"output_text": json.dumps({"fields": [{"wrong": 1}]})}
+
+    class _Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def post(self, *args, **kwargs):
+            return _Response()
+
+    monkeypatch.setattr(llm.httpx, "AsyncClient", _Client)
+
+    with pytest.raises(llm.LLMError, match="llm_output_schema_mismatch"):
+        await llm.generate_structured(
+            instructions="x",
+            input_text="y",
+            schema=ReportDraftOutput,
+            schema_name="report_draft",
+        )

--- a/docs/technical/backend/api-conventions.md
+++ b/docs/technical/backend/api-conventions.md
@@ -292,6 +292,7 @@ GET /api/activities?owner_member_id=9f64618b-8ed8-4aed-9560-78b25228dbe5&owner_m
 | 보고서 | `GET/POST /api/reports`, `GET/PATCH/DELETE /api/reports/{report_id}` | 목록은 `q,report_kind,status_code,start_date,end_date,author_member_id,skip,limit` |
 | 보고서 제출 | `POST /api/reports/{report_id}/submit` | `expected_status_code` 비교; `draft`만 제출 가능 |
 | 공지·지시 | `GET /api/notices`, `GET /api/notices/{notice_id}` | 목록은 `scope,q,published_from,published_to,skip,limit` |
+| 보고서 초안 실행 | `POST /api/agent-runs`, `GET /api/agent-runs/{agent_run_id}` | `202` + `Location` + `Retry-After`; polling 으로 상태 확인 |
 
 ### 일정 완료 처리
 
@@ -320,6 +321,18 @@ GET /api/activities?owner_member_id=9f64618b-8ed8-4aed-9560-78b25228dbe5&owner_m
 - 다른 사람에게 온 지시는 팀장에게도 보이지 않는다.
 - `image_storage_key`는 내부 저장소 주소라 응답하지 않고 `image_alt`만 내보낸다.
 - 각 `scope`의 전체 건수는 페이지 응답의 `total`로 얻는다.
+
+### 보고서 초안 실행
+
+- 현재 사람이 시작할 수 있는 `agent_code`는 `report_writing` 하나다. 멀티에이전트는 아직 없다.
+- `LLM_API_URL`, `LLM_API_KEY`, `LLM_MODEL` 중 하나라도 비면 `503 llm_not_configured`다.
+- 대상 보고서는 조회 가능한 `draft`여야 한다. 제출된 보고서는 `409 report_not_editable`이다.
+- 시작은 `202`와 `Location`, `Retry-After`를 반환하고 클라이언트는 `GET /api/agent-runs/{agent_run_id}`로 polling한다.
+- `idempotency_key`는 필수다. 같은 요청자가 같은 키로 다시 보내면 새 실행을 만들지 않고 기존 실행을 돌려준다.
+- 결과는 제안일 뿐이다. `output_snapshot`에만 남고 `report.content`는 사람이 `PATCH /api/reports/{report_id}`로 확정하기 전까지 바뀌지 않는다.
+- 실행이 실패해도 조회는 `200`이고 `status_code=failed`와 안전한 오류 코드를 반환한다.
+- 오류 코드에는 공급자 URL과 API key를 넣지 않는다. `llm_request_failed:<예외종류>`, `llm_provider_error:<상태>`, `llm_output_schema_mismatch` 형태만 쓴다.
+- 실행 이력은 같은 팀 안에서 요청자 본인 것만 조회한다.
 
 ### 영업 딜의 화면 필터와 상태 전이
 


### PR DESCRIPTION
## 변경 요약

에이전트가 들어갈 자리를 **일반 LLM 호출 하나**로 채웁니다. 멀티에이전트는 아직 만들지 않습니다.

- `POST /api/agent-runs` — `202` + `Location` + `Retry-After`
- `GET /api/agent-runs/{agent_run_id}` — polling

구조:

- `app/services/llm.py`가 공급자 호출 경계입니다. 나중에 에이전트를 붙일 때 **이 모듈만 교체**하면 되도록 호출부와 분리했습니다.
- `config.py`에 `llm_api_url`, `llm_api_key`(SecretStr), `llm_model`, `llm_timeout_seconds`를 추가하고 `.env.example`에 예시 키를 넣었습니다.

규칙:

- 세 값 중 하나라도 비면 `503 llm_not_configured`
- 대상은 조회 가능한 `draft` 보고서만. 제출된 보고서는 `409 report_not_editable`
- `idempotency_key` 필수. 같은 요청자가 같은 키로 다시 보내면 새 실행을 만들지 않고 기존 실행 반환
- 구조화 출력은 `ReportDraftOutput`으로 검증하고 어긋나면 `failed`로 기록
- **결과는 제안일 뿐입니다.** `output_snapshot`에만 남고 사람이 `PATCH /api/reports/{id}`로 확정하기 전까지 `report.content`는 바뀌지 않습니다.
- 오류 메시지에 공급자 URL과 API key를 넣지 않습니다. `llm_request_failed:<예외종류>`, `llm_provider_error:<상태>`, `llm_output_schema_mismatch`만 사용합니다.
- 실행 이력은 같은 팀 안에서 요청자 본인 것만 조회합니다.

## 검증

| 검사 | 결과 |
|---|---|
| `uv run ruff check .` | All checks passed |
| `uv run ruff format --check .` | 63 files already formatted |
| `uv run pytest -q` | 95 passed (기존 87 → +8) |
| `git diff --check` | 문제 없음 |

테스트가 확인하는 것:

- LLM 미설정 시 `503`
- 성공 시 `202`/`queued`이고 **보고서가 변경되지 않음**
- 같은 `idempotency_key` 재요청 시 새 실행을 만들지 않음
- 제출된 보고서는 `409`
- 다른 요청자의 실행은 `404`
- **공급자 예외 메시지에 API key와 URL이 새지 않음**
- 스키마 불일치 출력은 거부

개발 DB 실제 흐름(공급자 호출만 가짜로 대체, 데이터는 삭제):

```
보고서 생성        -> 201
초안 요청          -> 202 queued  Location=/api/agent-runs/...  Retry-After=2
같은 키 재요청      -> 202 같은 실행 반환
polling            -> 200 completed, output_snapshot/evidence 기록됨
보고서 content     -> {"summary": ""} 그대로 (자동 반영 안 됨)
```

## 영향 및 주의 사항

- 백엔드만 변경합니다. 프론트 연결은 후속 작업입니다.
- 실행은 FastAPI `BackgroundTasks`로 돌립니다. worker queue와 SSE/WebSocket은 도입하지 않았습니다. 규약 14절의 polling 방식만 씁니다.
- 실제 공급자 응답으로는 검증하지 못했습니다. 서비스 경계를 가짜로 대체해 확인했습니다.
- 새 테이블이나 migration은 없습니다. 기존 `agent_run`을 사용합니다.
- OCR/STT, 딜 승산 모델, 멀티에이전트 orchestration은 범위 밖입니다.

## 관련 이슈

- 없음