### PR TITLE
자료실 문서와 파일 업로드 API 추가

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,22 +8,6 @@ DEBUG=true
 # CORS (프론트 개발 서버 주소)
 CORS_ORIGINS=http://localhost:5173
 
-# 인증
-# SESSION_SECRET은 `openssl rand -hex 32` 등으로 생성한 32자 이상의 임의값을 사용한다.
-SESSION_SECRET=
-SESSION_TTL_SECONDS=28800
-LOGIN_MAX_ATTEMPTS=5
-LOGIN_WINDOW_SECONDS=60
-
-# 공유 개발 DB에 합성 로그인 계정을 넣을 때만 사용한다.
-DEMO_FILLED_MANAGER_LOGIN_ID=
-DEMO_FILLED_MEMBER_LOGIN_ID=
-DEMO_FILLED_MEMBER2_LOGIN_ID=
-DEMO_EMPTY_MANAGER_LOGIN_ID=
-DEMO_EMPTY_MEMBER_LOGIN_ID=
-DEMO_EMPTY_MEMBER2_LOGIN_ID=
-DEMO_PASSWORD=
-
 # DB (Supabase)
 #
 # Supabase 대시보드 > Project Settings > Database > Connection string 에서 복사.
@@ -35,12 +19,22 @@ DEMO_PASSWORD=
 # 스키마 변경은 backend/sql/ 의 SQL 을 Supabase SQL Editor 에서 실행한다.
 # 관리 작업에는 앱 연결 문자열 대신 direct 연결을 사용한다 (backend/sql/README.md 참고).
 DATABASE_URL=
+SESSION_SECRET=
 
-# LLM (보고서 초안 생성)
-#
-# API key 는 서버 프로세스 안에서만 사용하고 브라우저로 내려보내지 않는다.
-# 세 값이 모두 있어야 초안 생성이 열리고, 하나라도 비면 503 으로 막는다.
-LLM_API_URL=
+# Supabase Storage (자료실 파일)
+# Project Settings > API Keys > Secret keys 의 값. 서버에서만 쓰고 브라우저로 보내지 않는다.
+SUPABASE_SECRET_KEY=
+SUPABASE_STORAGE_BUCKET=salesluv-documents
+
+DEMO_FILLED_MANAGER_LOGIN_ID=
+DEMO_FILLED_MEMBER_LOGIN_ID=
+DEMO_FILLED_MEMBER2_LOGIN_ID=
+DEMO_EMPTY_MANAGER_LOGIN_ID=
+DEMO_EMPTY_MEMBER_LOGIN_ID=
+DEMO_EMPTY_MEMBER2_LOGIN_ID=
+DEMO_PASSWORD=
+
+LLM_API_URL=https://api.openai.com/v1/responses
 LLM_API_KEY=
-LLM_MODEL=
+LLM_MODEL=gpt-5.6-luna
 LLM_TIMEOUT_SECONDS=30

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -5,6 +5,7 @@ from app.api import (
     agent_runs,
     auth,
     customers,
+    documents,
     health,
     notices,
     orders,
@@ -24,3 +25,4 @@ api_router.include_router(support.router)
 api_router.include_router(reports.router)
 api_router.include_router(notices.router)
 api_router.include_router(agent_runs.router)
+api_router.include_router(documents.router)

--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -1,0 +1,455 @@
+from datetime import datetime
+from typing import Annotated
+from uuid import UUID, uuid4
+from zoneinfo import ZoneInfo
+
+from fastapi import APIRouter, File, Form, HTTPException, Query, Response, UploadFile, status
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from app.api.deps import CurrentMember, DbSession
+from app.core.config import settings
+from app.models.content import Document
+from app.models.content import File as FileRow
+from app.models.crm import CustomerCompany
+from app.models.sales import PurchaseOrder, SalesDeal
+from app.models.workspace import Member, Team
+from app.schemas.documents import (
+    DocumentCreate,
+    DocumentFileRead,
+    DocumentPage,
+    DocumentPageParams,
+    DocumentPatch,
+    DocumentRead,
+    DownloadRead,
+)
+from app.services import storage
+from app.services.storage import StorageError
+from app.services.upload_guard import UploadRejected, check_size, check_upload
+
+router = APIRouter(tags=["documents"])
+
+_SEOUL = ZoneInfo("Asia/Seoul")
+_creator = aliased(Member)
+_company = aliased(CustomerCompany)
+_uploader = aliased(Member)
+
+DOWNLOAD_EXPIRES_IN = 60
+
+
+def _contains(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return f"%{escaped}%"
+
+
+def _seoul(value: datetime) -> datetime:
+    return value.astimezone(_SEOUL)
+
+
+def _require_storage() -> None:
+    if not settings.storage_configured:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="storage_not_configured",
+        )
+
+
+def _joined_select(*entities):
+    return (
+        select(*entities)
+        .select_from(Document)
+        .join(_creator, Document.created_by_member_id == _creator.id)
+        .outerjoin(_company, Document.customer_company_id == _company.id)
+    )
+
+
+def _scope(member: Member, creator_ids: tuple[UUID, ...] | None = None):
+    """자료실은 팀 공유물이다. 팀원도 같은 팀 문서를 모두 본다."""
+    conditions = [
+        Document.team_id == member.team_id,
+        _creator.team_id == member.team_id,
+        or_(Document.customer_company_id.is_(None), _company.team_id == member.team_id),
+    ]
+    if creator_ids is not None:
+        conditions.append(Document.created_by_member_id.in_(creator_ids))
+    return conditions
+
+
+def _file_read(row: FileRow, uploader_display_name: str) -> DocumentFileRead:
+    return DocumentFileRead(
+        id=row.id,
+        version_no=row.version_no,
+        file_name=row.file_name,
+        media_type=row.media_type,
+        byte_size=row.byte_size,
+        processing_status=row.processing_status,
+        uploaded_by_member_id=row.uploaded_by_member_id,
+        uploaded_by_display_name=uploader_display_name,
+        note=row.note,
+        uploaded_at=_seoul(row.uploaded_at),
+    )
+
+
+def _document_read(
+    document: Document,
+    created_by_display_name: str,
+    company_name: str | None,
+    files: list[DocumentFileRead],
+) -> DocumentRead:
+    return DocumentRead(
+        id=document.id,
+        document_no=document.document_no,
+        category_code=document.category_code,
+        title=document.title,
+        description=document.description,
+        customer_company_id=document.customer_company_id,
+        customer_company_name=company_name,
+        sales_deal_id=document.sales_deal_id,
+        purchase_order_id=document.purchase_order_id,
+        tags=list(document.tags or ()),
+        created_by_member_id=document.created_by_member_id,
+        created_by_display_name=created_by_display_name,
+        created_at=_seoul(document.created_at),
+        files=files,
+        latest_version_no=max((f.version_no for f in files), default=None),
+    )
+
+
+async def _files_by_document_ids(
+    db: AsyncSession,
+    document_ids: list[UUID],
+) -> dict[UUID, list[DocumentFileRead]]:
+    grouped: dict[UUID, list[DocumentFileRead]] = {doc_id: [] for doc_id in document_ids}
+    if not document_ids:
+        return grouped
+    result = await db.execute(
+        select(FileRow, _uploader.display_name)
+        .join(_uploader, FileRow.uploaded_by_member_id == _uploader.id)
+        .where(FileRow.document_id.in_(document_ids))
+        .order_by(FileRow.version_no.desc())
+    )
+    for row, uploader_name in result.all():
+        grouped[row.document_id].append(_file_read(row, uploader_name))
+    return grouped
+
+
+async def _document_row(db: AsyncSession, member: Member, document_id: UUID):
+    result = await db.execute(
+        _joined_select(Document, _creator.display_name, _company.name).where(
+            Document.id == document_id, *_scope(member)
+        )
+    )
+    row = result.one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="document_not_found",
+        )
+    return row
+
+
+async def _detail(db: AsyncSession, member: Member, document_id: UUID) -> DocumentRead:
+    row = await _document_row(db, member, document_id)
+    files = await _files_by_document_ids(db, [document_id])
+    return _document_read(*row, files[document_id])
+
+
+async def _validate_links(db: AsyncSession, member: Member, values: dict) -> None:
+    """다른 팀 FK 를 붙이지 못하게 막는다. 존재 여부는 404 로 숨긴다."""
+    checks = (
+        ("customer_company_id", CustomerCompany, "customer_company_not_found"),
+        ("sales_deal_id", SalesDeal, "sales_deal_not_found"),
+        ("purchase_order_id", PurchaseOrder, "purchase_order_not_found"),
+    )
+    for field_name, model, detail in checks:
+        target_id = values.get(field_name)
+        if target_id is None:
+            continue
+        found = (
+            await db.execute(
+                select(model.id).where(model.id == target_id, model.team_id == member.team_id)
+            )
+        ).scalar_one_or_none()
+        if found is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail)
+
+
+async def _next_document_no(db: AsyncSession, member: Member, year: int) -> str:
+    team_result = await db.execute(
+        select(Team.id).where(Team.id == member.team_id).with_for_update(of=Team)
+    )
+    if team_result.scalar_one_or_none() is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="team_not_found")
+
+    prefix = f"SL-DC-{year}-"
+    numbers_result = await db.execute(
+        select(Document.document_no).where(
+            Document.team_id == member.team_id,
+            Document.document_no.like(f"{prefix}%"),
+        )
+    )
+    numbers = []
+    for document_no in numbers_result.scalars().all():
+        suffix = document_no.removeprefix(prefix)
+        if len(suffix) == 4 and suffix.isascii() and suffix.isdigit():
+            numbers.append(int(suffix))
+    next_number = max(numbers, default=0) + 1
+    if next_number > 9_999:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="document_number_exhausted",
+        )
+    return f"{prefix}{next_number:04d}"
+
+
+@router.get("/documents", response_model=DocumentPage)
+async def list_documents(
+    page: Annotated[DocumentPageParams, Query()],
+    member: CurrentMember,
+    db: DbSession,
+) -> DocumentPage:
+    creator_ids = (
+        None
+        if page.created_by_member_id is None
+        else tuple(dict.fromkeys(page.created_by_member_id))
+    )
+    scope = _scope(member, creator_ids)
+    if page.category_code is not None:
+        scope.append(Document.category_code.in_(tuple(dict.fromkeys(page.category_code))))
+    if page.customer_company_id is not None:
+        scope.append(Document.customer_company_id == page.customer_company_id)
+    if page.sales_deal_id is not None:
+        scope.append(Document.sales_deal_id == page.sales_deal_id)
+    if page.q is not None:
+        pattern = _contains(page.q)
+        scope.append(
+            or_(
+                Document.title.ilike(pattern, escape="\\"),
+                Document.description.ilike(pattern, escape="\\"),
+                Document.document_no.ilike(pattern, escape="\\"),
+                _company.name.ilike(pattern, escape="\\"),
+            )
+        )
+
+    total = (await db.execute(_joined_select(func.count(Document.id)).where(*scope))).scalar_one()
+    rows = (
+        await db.execute(
+            _joined_select(Document, _creator.display_name, _company.name)
+            .where(*scope)
+            .order_by(Document.created_at.desc(), Document.id)
+            .offset(page.skip)
+            .limit(page.limit)
+        )
+    ).all()
+    file_map = await _files_by_document_ids(db, [row[0].id for row in rows])
+    items = [_document_read(*row, file_map[row[0].id]) for row in rows]
+    has_more = page.skip + len(items) < total
+    return DocumentPage(
+        items=items,
+        skip=page.skip,
+        limit=page.limit,
+        total=total,
+        has_more=has_more,
+        next_skip=page.skip + len(items) if has_more else None,
+    )
+
+
+@router.get("/documents/{document_id}", response_model=DocumentRead)
+async def get_document(
+    document_id: UUID,
+    member: CurrentMember,
+    db: DbSession,
+) -> DocumentRead:
+    return await _detail(db, member, document_id)
+
+
+@router.post("/documents", response_model=DocumentRead, status_code=status.HTTP_201_CREATED)
+async def create_document(
+    payload: DocumentCreate,
+    response: Response,
+    member: CurrentMember,
+    db: DbSession,
+) -> DocumentRead:
+    try:
+        values = payload.model_dump()
+        await _validate_links(db, member, values)
+        document = Document(
+            id=uuid4(),
+            team_id=member.team_id,
+            created_by_member_id=member.id,
+            document_no=await _next_document_no(db, member, datetime.now(_SEOUL).year),
+            category_code=payload.category_code,
+            title=payload.title,
+            description=payload.description,
+            customer_company_id=payload.customer_company_id,
+            sales_deal_id=payload.sales_deal_id,
+            purchase_order_id=payload.purchase_order_id,
+            tags=payload.tags,
+        )
+        db.add(document)
+        await db.flush()
+        read = await _detail(db, member, document.id)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    response.headers["Location"] = f"/api/documents/{document.id}"
+    return read
+
+
+@router.patch("/documents/{document_id}", response_model=DocumentRead)
+async def update_document(
+    document_id: UUID,
+    payload: DocumentPatch,
+    member: CurrentMember,
+    db: DbSession,
+) -> DocumentRead:
+    try:
+        document = (
+            await db.execute(
+                select(Document)
+                .where(Document.id == document_id, Document.team_id == member.team_id)
+                .with_for_update(of=Document)
+            )
+        ).scalar_one_or_none()
+        if document is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="document_not_found",
+            )
+        values = payload.model_dump(exclude_unset=True)
+        await _validate_links(db, member, values)
+        for field_name, value in values.items():
+            setattr(document, field_name, value)
+        await db.flush()
+        read = await _detail(db, member, document_id)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return read
+
+
+@router.post(
+    "/documents/{document_id}/files",
+    response_model=DocumentFileRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def upload_document_file(
+    document_id: UUID,
+    member: CurrentMember,
+    db: DbSession,
+    upload: Annotated[UploadFile, File()],
+    note: Annotated[str | None, Form(max_length=5_000)] = None,
+) -> DocumentFileRead:
+    _require_storage()
+    content = await upload.read()
+
+    try:
+        check_size(len(content), settings.upload_max_bytes)
+        allowed = check_upload(
+            file_name=upload.filename or "",
+            declared_media_type=upload.content_type,
+            content=content,
+        )
+    except UploadRejected as rejected:
+        raise HTTPException(
+            status_code=rejected.status_code,
+            detail=rejected.detail,
+        ) from rejected
+
+    storage_key = storage.build_storage_key(member.team_id, allowed.extension)
+    try:
+        await storage.upload(
+            storage_key=storage_key,
+            content=content,
+            media_type=allowed.media_type,
+        )
+    except StorageError as error:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(error),
+        ) from error
+
+    try:
+        # 버전 번호는 서버가 트랜잭션 안에서 매긴다.
+        document = (
+            await db.execute(
+                select(Document)
+                .where(Document.id == document_id, Document.team_id == member.team_id)
+                .with_for_update(of=Document)
+            )
+        ).scalar_one_or_none()
+        if document is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="document_not_found",
+            )
+        current = (
+            await db.execute(
+                select(func.max(FileRow.version_no)).where(FileRow.document_id == document_id)
+            )
+        ).scalar_one()
+        row = FileRow(
+            id=uuid4(),
+            report_id=None,
+            document_id=document_id,
+            version_no=(current or 0) + 1,
+            file_name=(upload.filename or "").strip(),
+            storage_key=storage_key,
+            media_type=allowed.media_type,
+            byte_size=len(content),
+            processing_status="uploaded",
+            extracted_text=None,
+            uploaded_by_member_id=member.id,
+            note=note,
+        )
+        db.add(row)
+        await db.flush()
+        read = _file_read(row, member.display_name)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        # DB 기록이 실패하면 올린 객체를 지워 고아를 남기지 않는다.
+        await storage.remove(storage_key=storage_key)
+        raise
+    return read
+
+
+@router.get("/documents/{document_id}/files/{file_id}/download", response_model=DownloadRead)
+async def download_document_file(
+    document_id: UUID,
+    file_id: UUID,
+    member: CurrentMember,
+    db: DbSession,
+) -> DownloadRead:
+    _require_storage()
+    # 다운로드마다 팀 권한을 다시 검사한다.
+    await _document_row(db, member, document_id)
+    row = (
+        await db.execute(
+            select(FileRow).where(FileRow.id == file_id, FileRow.document_id == document_id)
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="file_not_found")
+
+    try:
+        url = await storage.signed_url(
+            storage_key=row.storage_key,
+            expires_in=DOWNLOAD_EXPIRES_IN,
+        )
+    except StorageError as error:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(error),
+        ) from error
+
+    return DownloadRead(
+        url=url,
+        expires_in=DOWNLOAD_EXPIRES_IN,
+        file_name=row.file_name,
+        media_type=row.media_type,
+        byte_size=row.byte_size,
+    )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -48,6 +48,31 @@ class Settings(BaseSettings):
     llm_model: str = ""
     llm_timeout_seconds: float = Field(default=30.0, gt=0, le=300)
 
+    # Supabase Storage. secret 키는 RLS 를 우회하므로 서버에서만 쓴다.
+    supabase_secret_key: SecretStr = SecretStr("")
+    supabase_storage_bucket: str = ""
+    # 보통은 DATABASE_URL 에서 뽑아 쓴다. 다른 호스트를 쓸 때만 채운다.
+    supabase_url: str = ""
+    upload_max_bytes: int = Field(default=50 * 1024 * 1024, gt=0, le=1024 * 1024 * 1024)
+
+    @property
+    def supabase_project_url(self) -> str:
+        """Storage REST 주소. DATABASE_URL 의 `postgres.<project_ref>` 에서 뽑는다."""
+        if self.supabase_url:
+            return self.supabase_url.rstrip("/")
+        user = urlsplit(self.database_url).username or ""
+        _, _, project_ref = user.partition(".")
+        return f"https://{project_ref}.supabase.co" if project_ref else ""
+
+    @property
+    def storage_configured(self) -> bool:
+        """업로드에 필요한 값이 모두 있는지. 없으면 기능을 503 으로 막는다."""
+        return bool(
+            self.supabase_project_url
+            and self.supabase_secret_key.get_secret_value()
+            and self.supabase_storage_bucket
+        )
+
     @property
     def llm_configured(self) -> bool:
         """LLM 호출에 필요한 값이 모두 있는지. 없으면 기능을 503 으로 막는다."""

--- a/backend/app/schemas/documents.py
+++ b/backend/app/schemas/documents.py
@@ -1,0 +1,118 @@
+from datetime import datetime
+from typing import Annotated, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+
+Text = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=254),
+]
+LongText = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=5_000),
+]
+SearchQuery = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=100),
+]
+OptionCode = Annotated[
+    str,
+    StringConstraints(
+        strip_whitespace=True,
+        strict=True,
+        min_length=1,
+        max_length=64,
+        pattern=r"^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$",
+    ),
+]
+
+ProcessingStatus = Literal["uploaded", "processing", "completed", "failed"]
+
+
+class _WriteModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class DocumentCreate(_WriteModel):
+    category_code: OptionCode
+    title: Text
+    description: LongText | None = None
+    customer_company_id: UUID | None = None
+    sales_deal_id: UUID | None = None
+    purchase_order_id: UUID | None = None
+    tags: list[Text] = Field(default_factory=list, max_length=20)
+
+
+class DocumentPatch(_WriteModel):
+    category_code: OptionCode | None = None
+    title: Text | None = None
+    description: LongText | None = None
+    customer_company_id: UUID | None = None
+    sales_deal_id: UUID | None = None
+    purchase_order_id: UUID | None = None
+    tags: list[Text] | None = Field(default=None, max_length=20)
+
+
+class DocumentFileRead(BaseModel):
+    """storage_key 는 내부 저장소 주소라 내보내지 않는다."""
+
+    id: UUID
+    version_no: int
+    file_name: str
+    media_type: str | None
+    byte_size: int
+    processing_status: ProcessingStatus
+    uploaded_by_member_id: UUID
+    uploaded_by_display_name: str
+    note: str | None
+    uploaded_at: datetime
+
+
+class DocumentRead(BaseModel):
+    id: UUID
+    document_no: str
+    category_code: str
+    title: str
+    description: str | None
+    customer_company_id: UUID | None
+    customer_company_name: str | None
+    sales_deal_id: UUID | None
+    purchase_order_id: UUID | None
+    tags: list[str]
+    created_by_member_id: UUID
+    created_by_display_name: str
+    created_at: datetime
+    files: list[DocumentFileRead]
+    latest_version_no: int | None
+
+
+class DocumentPage(BaseModel):
+    items: list[DocumentRead]
+    skip: int
+    limit: int
+    total: int
+    has_more: bool
+    next_skip: int | None
+
+
+class DocumentPageParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    q: SearchQuery | None = None
+    category_code: list[OptionCode] | None = None
+    customer_company_id: UUID | None = None
+    sales_deal_id: UUID | None = None
+    created_by_member_id: list[UUID] | None = None
+    skip: int = Field(default=0, ge=0, le=9_223_372_036_854_775_807)
+    limit: int = Field(default=30, ge=1, le=100)
+
+
+class DownloadRead(BaseModel):
+    """짧게 사는 다운로드 주소. 매 요청마다 권한을 다시 검사하고 발급한다."""
+
+    url: str
+    expires_in: int
+    file_name: str
+    media_type: str | None
+    byte_size: int

--- a/backend/app/services/storage.py
+++ b/backend/app/services/storage.py
@@ -1,0 +1,87 @@
+"""Supabase Storage 호출 경계.
+
+업로드와 서명 URL 발급 두 가지만 둔다. 저장소를 바꾸면 이 모듈만 교체한다.
+
+secret 키는 RLS 를 우회하므로 서버 프로세스 안에서만 쓰고 응답이나
+오류 메시지에 남기지 않는다. storage_key 도 클라이언트에 내보내지 않는다.
+"""
+
+from uuid import UUID, uuid4
+
+import httpx
+
+from app.core.config import settings
+
+
+class StorageError(Exception):
+    """저장소 호출이 실패했다. 메시지에 키나 내부 주소를 담지 않는다."""
+
+
+class StorageNotConfigured(StorageError):
+    """secret 키나 버킷 이름이 없다."""
+
+
+def build_storage_key(team_id: UUID, extension: str) -> str:
+    """저장 경로는 서버가 만든다. 원본 파일명을 경로에 쓰지 않는다."""
+    return f"{team_id}/{uuid4()}{extension}"
+
+
+def _endpoint(path: str) -> str:
+    return f"{settings.supabase_project_url}/storage/v1/{path}"
+
+
+def _headers() -> dict[str, str]:
+    key = settings.supabase_secret_key.get_secret_value()
+    return {"Authorization": f"Bearer {key}", "apikey": key}
+
+
+def _require_config() -> None:
+    if not settings.storage_configured:
+        raise StorageNotConfigured("storage_not_configured")
+
+
+async def upload(*, storage_key: str, content: bytes, media_type: str) -> None:
+    _require_config()
+    url = _endpoint(f"object/{settings.supabase_storage_bucket}/{storage_key}")
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                url,
+                headers={**_headers(), "Content-Type": media_type, "x-upsert": "false"},
+                content=content,
+            )
+    except httpx.HTTPError as error:
+        raise StorageError(f"storage_request_failed:{type(error).__name__}") from error
+    if response.status_code >= 400:
+        raise StorageError(f"storage_upload_failed:{response.status_code}")
+
+
+async def signed_url(*, storage_key: str, expires_in: int = 60) -> str:
+    """짧게 사는 다운로드 주소. 매 요청마다 권한을 확인한 뒤에만 부른다."""
+    _require_config()
+    url = _endpoint(f"object/sign/{settings.supabase_storage_bucket}/{storage_key}")
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(url, headers=_headers(), json={"expiresIn": expires_in})
+    except httpx.HTTPError as error:
+        raise StorageError(f"storage_request_failed:{type(error).__name__}") from error
+    if response.status_code >= 400:
+        raise StorageError(f"storage_sign_failed:{response.status_code}")
+
+    try:
+        signed = response.json()["signedURL"]
+    except (ValueError, KeyError, TypeError) as error:
+        raise StorageError("storage_sign_response_invalid") from error
+    return f"{settings.supabase_project_url}/storage/v1{signed}"
+
+
+async def remove(*, storage_key: str) -> None:
+    """업로드 뒤 DB 기록이 실패했을 때 되돌리기 위해 쓴다."""
+    _require_config()
+    url = _endpoint(f"object/{settings.supabase_storage_bucket}/{storage_key}")
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            await client.delete(url, headers=_headers())
+    except httpx.HTTPError:
+        # 정리 실패가 원래 오류를 덮지 않게 한다. 고아 객체는 남을 수 있다.
+        return

--- a/backend/app/services/upload_guard.py
+++ b/backend/app/services/upload_guard.py
@@ -1,0 +1,86 @@
+"""업로드 파일 검증.
+
+확장자, 선언된 MIME, 실제 파일 signature 를 함께 본다. 셋 중 하나라도
+어긋나면 거절한다. 단순화를 이유로 생략하지 않는다.
+"""
+
+from dataclasses import dataclass
+
+# 허용 형식만 둔다. 실행 가능한 형식과 압축 파일은 넣지 않는다.
+# (확장자, 선언 MIME 집합, signature 검사 함수)
+_PDF = "application/pdf"
+_PNG = "image/png"
+_JPEG = "image/jpeg"
+_DOCX = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+_XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+_PPTX = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+
+
+class UploadRejected(Exception):
+    """업로드를 받을 수 없다. detail 은 API 가 그대로 쓰는 안정적인 코드다."""
+
+    def __init__(self, detail: str, status_code: int):
+        super().__init__(detail)
+        self.detail = detail
+        self.status_code = status_code
+
+
+@dataclass(frozen=True)
+class AllowedType:
+    extension: str
+    media_type: str
+    # OOXML 은 전부 zip 이라 signature 만으로는 서로 구분되지 않는다.
+    magic: tuple[bytes, ...]
+
+
+_ALLOWED: tuple[AllowedType, ...] = (
+    AllowedType(".pdf", _PDF, (b"%PDF-",)),
+    AllowedType(".png", _PNG, (b"\x89PNG\r\n\x1a\n",)),
+    AllowedType(".jpg", _JPEG, (b"\xff\xd8\xff",)),
+    AllowedType(".jpeg", _JPEG, (b"\xff\xd8\xff",)),
+    AllowedType(".docx", _DOCX, (b"PK\x03\x04",)),
+    AllowedType(".xlsx", _XLSX, (b"PK\x03\x04",)),
+    AllowedType(".pptx", _PPTX, (b"PK\x03\x04",)),
+)
+
+_BY_EXTENSION = {allowed.extension: allowed for allowed in _ALLOWED}
+
+ALLOWED_EXTENSIONS = tuple(sorted(_BY_EXTENSION))
+
+
+def _extension_of(file_name: str) -> str:
+    name = file_name.strip().lower()
+    dot = name.rfind(".")
+    return name[dot:] if dot > 0 else ""
+
+
+def check_upload(*, file_name: str, declared_media_type: str | None, content: bytes) -> AllowedType:
+    """통과하면 확정된 형식을 돌려준다. 실패하면 UploadRejected 를 던진다."""
+    name = file_name.strip()
+    if not name or "/" in name or "\\" in name or name in {".", ".."}:
+        raise UploadRejected("invalid_file_name", 422)
+
+    allowed = _BY_EXTENSION.get(_extension_of(name))
+    if allowed is None:
+        raise UploadRejected("unsupported_file_extension", 415)
+
+    # 선언 MIME 은 클라이언트 값이라 신뢰하지 않고 확장자와 일치할 때만 받는다.
+    if declared_media_type is not None:
+        declared = declared_media_type.split(";")[0].strip().lower()
+        if declared and declared != allowed.media_type:
+            raise UploadRejected("media_type_mismatch", 415)
+
+    if not content:
+        raise UploadRejected("empty_file", 422)
+
+    if not any(content.startswith(magic) for magic in allowed.magic):
+        raise UploadRejected("file_signature_mismatch", 415)
+
+    return allowed
+
+
+def check_size(byte_size: int, limit: int) -> None:
+    if byte_size <= 0:
+        raise UploadRejected("empty_file", 422)
+    if byte_size > limit:
+        raise UploadRejected("file_too_large", 413)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
     "asyncpg>=0.31.0",
     "fastapi>=0.141.1",
     "pydantic-settings>=2.14.2",
+    "python-multipart>=0.0.32",
     "sqlalchemy[asyncio]>=2.0.51",
     "uvicorn[standard]>=0.52.1",
 ]

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -1,0 +1,277 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from app.api.deps import get_current_member
+from app.core.config import settings
+from app.db.session import get_db
+from app.main import app
+from app.models.content import Document
+from app.models.content import File as FileRow
+from app.models.workspace import Member
+from app.schemas.documents import DocumentCreate, DocumentPageParams
+from app.services import storage
+
+ORIGIN = settings.cors_origin_list[0]
+NOW = datetime(2026, 8, 17, 9, tzinfo=UTC)
+PDF = b"%PDF-1.7\ntest\n"
+_MISSING = object()
+
+
+class _Result:
+    def __init__(self, *, scalar=_MISSING, rows=None):
+        self.scalar = scalar
+        self.rows = [] if rows is None else rows
+
+    def scalar_one(self):
+        assert self.scalar is not _MISSING
+        return self.scalar
+
+    def scalar_one_or_none(self):
+        assert self.scalar is not _MISSING
+        return self.scalar
+
+    def one_or_none(self):
+        assert len(self.rows) <= 1
+        return self.rows[0] if self.rows else None
+
+    def all(self):
+        return self.rows
+
+
+class _Db:
+    def __init__(self, *results: _Result):
+        self.results = list(results)
+        self.statements = []
+        self.added = []
+        self.commit_count = 0
+        self.rollback_count = 0
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        assert self.results, "예상보다 많은 쿼리가 실행되었습니다."
+        return self.results.pop(0)
+
+    def add(self, value):
+        self.added.append(value)
+
+    async def flush(self):
+        for value in self.added:
+            if isinstance(value, FileRow) and value.uploaded_at is None:
+                value.uploaded_at = NOW
+
+    async def commit(self):
+        self.commit_count += 1
+
+    async def rollback(self):
+        self.rollback_count += 1
+
+
+@pytest.fixture(autouse=True)
+def reset_dependency_overrides():
+    app.dependency_overrides.clear()
+    yield
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def storage_ready(monkeypatch):
+    monkeypatch.setattr(type(settings), "storage_configured", property(lambda self: True))
+    yield
+
+
+@pytest.fixture
+def storage_missing(monkeypatch):
+    monkeypatch.setattr(type(settings), "storage_configured", property(lambda self: False))
+    yield
+
+
+def _member(*, role: str = "member") -> Member:
+    return Member(
+        id=uuid4(),
+        team_id=uuid4(),
+        login_id=f"{uuid4()}@salesluv.demo",
+        password_hash="unused",
+        display_name="합성 영업 담당자",
+        role_code=role,
+        job_title="영업 담당자",
+        active=True,
+    )
+
+
+def _document(member: Member) -> Document:
+    return Document(
+        id=uuid4(),
+        team_id=member.team_id,
+        created_by_member_id=member.id,
+        document_no="SL-DC-2026-0001",
+        category_code="proposal",
+        title="합성 자료",
+        description=None,
+        customer_company_id=None,
+        sales_deal_id=None,
+        purchase_order_id=None,
+        tags=[],
+        created_at=NOW,
+    )
+
+
+def _file(document: Document, member: Member) -> FileRow:
+    return FileRow(
+        id=uuid4(),
+        report_id=None,
+        document_id=document.id,
+        version_no=1,
+        file_name="제안서.pdf",
+        storage_key=f"{member.team_id}/secret-object-key.pdf",
+        media_type="application/pdf",
+        byte_size=len(PDF),
+        processing_status="uploaded",
+        extracted_text=None,
+        uploaded_by_member_id=member.id,
+        note=None,
+        uploaded_at=NOW,
+    )
+
+
+def _client(db: _Db, member: Member) -> TestClient:
+    async def override_db():
+        yield db
+
+    async def override_member():
+        return member
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_member] = override_member
+    return TestClient(app)
+
+
+def test_document_request_rejects_unsafe_values():
+    with pytest.raises(ValidationError):
+        # 업무 번호와 작성자는 요청으로 정할 수 없다.
+        DocumentCreate(category_code="proposal", title="a", document_no="SL-DC-2026-0001")
+    with pytest.raises(ValidationError):
+        DocumentCreate(category_code="Proposal", title="a")
+    with pytest.raises(ValidationError):
+        DocumentCreate(category_code="proposal", title="")
+    with pytest.raises(ValidationError):
+        DocumentPageParams(limit=101)
+
+
+def test_upload_requires_storage_configuration(storage_missing):
+    member = _member()
+    db = _Db()
+    with _client(db, member) as client:
+        response = client.post(
+            f"/api/documents/{uuid4()}/files",
+            headers={"Origin": ORIGIN},
+            files={"upload": ("a.pdf", PDF, "application/pdf")},
+        )
+    assert response.status_code == 503
+    assert response.json() == {"detail": "storage_not_configured"}
+
+
+@pytest.mark.parametrize(
+    ("file_name", "media_type", "content", "detail", "code"),
+    [
+        ("악성.pdf", "application/pdf", b"MZ\x90\x00", "file_signature_mismatch", 415),
+        ("a.zip", "application/zip", b"PK\x03\x04", "unsupported_file_extension", 415),
+        ("a.pdf", "image/png", PDF, "media_type_mismatch", 415),
+        ("a.pdf", "application/pdf", b"", "empty_file", 422),
+        ("../a.pdf", "application/pdf", PDF, "invalid_file_name", 422),
+    ],
+)
+def test_upload_rejects_bad_files_before_touching_storage(
+    storage_ready, monkeypatch, file_name, media_type, content, detail, code
+):
+    uploaded: list[str] = []
+
+    async def _never(**kwargs):
+        uploaded.append(kwargs["storage_key"])
+
+    monkeypatch.setattr(storage, "upload", _never)
+
+    member = _member()
+    db = _Db()
+    with _client(db, member) as client:
+        response = client.post(
+            f"/api/documents/{uuid4()}/files",
+            headers={"Origin": ORIGIN},
+            files={"upload": (file_name, content, media_type)},
+        )
+
+    assert response.status_code == code
+    assert response.json() == {"detail": detail}
+    # 검증 전에 저장소를 건드리지 않는다.
+    assert uploaded == []
+    assert db.commit_count == 0
+
+
+def test_upload_removes_object_when_db_write_fails(storage_ready, monkeypatch):
+    uploaded: list[str] = []
+    removed: list[str] = []
+
+    async def _upload(**kwargs):
+        uploaded.append(kwargs["storage_key"])
+
+    async def _remove(**kwargs):
+        removed.append(kwargs["storage_key"])
+
+    monkeypatch.setattr(storage, "upload", _upload)
+    monkeypatch.setattr(storage, "remove", _remove)
+
+    member = _member()
+    # 문서를 찾지 못해 404 로 끝난다.
+    db = _Db(_Result(scalar=None))
+    with _client(db, member) as client:
+        response = client.post(
+            f"/api/documents/{uuid4()}/files",
+            headers={"Origin": ORIGIN},
+            files={"upload": ("a.pdf", PDF, "application/pdf")},
+        )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "document_not_found"}
+    # 올린 객체를 지워 고아를 남기지 않는다.
+    assert uploaded == removed
+    assert len(removed) == 1
+    assert db.rollback_count == 1
+
+
+def test_download_never_exposes_storage_key(storage_ready, monkeypatch):
+    member = _member()
+    document = _document(member)
+    row = _file(document, member)
+
+    async def _signed(**kwargs):
+        return "https://example.invalid/storage/v1/object/sign/x?token=abc"
+
+    monkeypatch.setattr(storage, "signed_url", _signed)
+
+    db = _Db(
+        _Result(rows=[(document, member.display_name, None)]),
+        _Result(scalar=row),
+    )
+    with _client(db, member) as client:
+        response = client.get(
+            f"/api/documents/{document.id}/files/{row.id}/download",
+        )
+
+    assert response.status_code == 200
+    assert "storage_key" not in response.text
+    assert row.storage_key not in response.text
+    assert response.json()["expires_in"] == 60
+    assert response.json()["file_name"] == "제안서.pdf"
+
+
+def test_other_team_document_is_hidden():
+    member = _member()
+    db = _Db(_Result(rows=[]))
+    with _client(db, member) as client:
+        response = client.get(f"/api/documents/{uuid4()}")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "document_not_found"}
+    assert member.team_id in db.statements[0].compile().params.values()

--- a/backend/tests/test_upload_guard.py
+++ b/backend/tests/test_upload_guard.py
@@ -1,0 +1,85 @@
+import pytest
+
+from app.services.upload_guard import (
+    ALLOWED_EXTENSIONS,
+    UploadRejected,
+    check_size,
+    check_upload,
+)
+
+PDF = b"%PDF-1.7\n%\xe2\xe3\xcf\xd3\n"
+PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 8
+JPEG = b"\xff\xd8\xff\xe0" + b"\x00" * 8
+DOCX = b"PK\x03\x04" + b"\x00" * 8
+DOCX_TYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+
+
+def test_accepts_matching_extension_mime_and_signature():
+    result = check_upload(
+        file_name="제안서.pdf", declared_media_type="application/pdf", content=PDF
+    )
+    assert result.media_type == "application/pdf"
+
+    png = check_upload(file_name="a.PNG", declared_media_type=None, content=PNG)
+    assert png.extension == ".png"
+    assert check_upload(file_name="b.jpeg", declared_media_type="image/jpeg", content=JPEG)
+    assert check_upload(file_name="c.docx", declared_media_type=DOCX_TYPE, content=DOCX)
+    # charset 이 붙어도 앞부분만 본다.
+    assert check_upload(
+        file_name="d.pdf", declared_media_type="application/pdf; charset=binary", content=PDF
+    )
+
+
+def test_rejects_disguised_extension():
+    """확장자만 바꾼 실행 파일은 signature 에서 걸린다."""
+    with pytest.raises(UploadRejected) as caught:
+        check_upload(
+            file_name="악성.pdf", declared_media_type="application/pdf", content=b"MZ\x90\x00"
+        )
+    assert caught.value.detail == "file_signature_mismatch"
+    assert caught.value.status_code == 415
+
+
+def test_rejects_mime_that_contradicts_extension():
+    with pytest.raises(UploadRejected) as caught:
+        check_upload(file_name="a.pdf", declared_media_type="image/png", content=PDF)
+    assert caught.value.detail == "media_type_mismatch"
+    assert caught.value.status_code == 415
+
+
+def test_rejects_unsupported_and_executable_types():
+    for name in ("a.exe", "b.sh", "c.zip", "d.html", "e.svg", "noextension"):
+        with pytest.raises(UploadRejected) as caught:
+            check_upload(file_name=name, declared_media_type=None, content=PDF)
+        assert caught.value.detail == "unsupported_file_extension"
+        assert caught.value.status_code == 415
+
+    assert ".exe" not in ALLOWED_EXTENSIONS
+    assert ".zip" not in ALLOWED_EXTENSIONS
+    assert ".html" not in ALLOWED_EXTENSIONS
+
+
+def test_rejects_path_traversal_in_file_name():
+    for name in ("../../etc/passwd.pdf", "a/b.pdf", "a\\b.pdf", "..", "."):
+        with pytest.raises(UploadRejected) as caught:
+            check_upload(file_name=name, declared_media_type=None, content=PDF)
+        assert caught.value.detail in {"invalid_file_name", "unsupported_file_extension"}
+
+
+def test_rejects_empty_content():
+    with pytest.raises(UploadRejected) as caught:
+        check_upload(file_name="a.pdf", declared_media_type=None, content=b"")
+    assert caught.value.detail == "empty_file"
+    assert caught.value.status_code == 422
+
+
+def test_size_limit_uses_413():
+    check_size(10, 100)
+    with pytest.raises(UploadRejected) as caught:
+        check_size(101, 100)
+    assert caught.value.detail == "file_too_large"
+    assert caught.value.status_code == 413
+
+    with pytest.raises(UploadRejected) as caught:
+        check_size(0, 100)
+    assert caught.value.detail == "empty_file"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -72,6 +72,7 @@ dependencies = [
     { name = "asyncpg" },
     { name = "fastapi" },
     { name = "pydantic-settings" },
+    { name = "python-multipart" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -88,6 +89,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "fastapi", specifier = ">=0.141.1" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
+    { name = "python-multipart", specifier = ">=0.0.32" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.51" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.52.1" },
 ]
@@ -421,6 +423,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]

--- a/docs/technical/backend/api-conventions.md
+++ b/docs/technical/backend/api-conventions.md
@@ -293,6 +293,8 @@ GET /api/activities?owner_member_id=9f64618b-8ed8-4aed-9560-78b25228dbe5&owner_m
 | 보고서 제출 | `POST /api/reports/{report_id}/submit` | `expected_status_code` 비교; `draft`만 제출 가능 |
 | 공지·지시 | `GET /api/notices`, `GET /api/notices/{notice_id}` | 목록은 `scope,q,published_from,published_to,skip,limit` |
 | 보고서 초안 실행 | `POST /api/agent-runs`, `GET /api/agent-runs/{agent_run_id}` | `202` + `Location` + `Retry-After`; polling 으로 상태 확인 |
+| 자료실 | `GET/POST /api/documents`, `GET/PATCH /api/documents/{document_id}` | 목록은 `q,category_code,customer_company_id,sales_deal_id,created_by_member_id,skip,limit` |
+| 자료 파일 | `POST /api/documents/{document_id}/files`, `GET /api/documents/{document_id}/files/{file_id}/download` | `multipart/form-data` 업로드; 다운로드는 짧은 서명 URL |
 
 ### 일정 완료 처리
 
@@ -333,6 +335,21 @@ GET /api/activities?owner_member_id=9f64618b-8ed8-4aed-9560-78b25228dbe5&owner_m
 - 실행이 실패해도 조회는 `200`이고 `status_code=failed`와 안전한 오류 코드를 반환한다.
 - 오류 코드에는 공급자 URL과 API key를 넣지 않는다. `llm_request_failed:<예외종류>`, `llm_provider_error:<상태>`, `llm_output_schema_mismatch` 형태만 쓴다.
 - 실행 이력은 같은 팀 안에서 요청자 본인 것만 조회한다.
+
+### 자료실 업로드와 다운로드
+
+- 자료실은 팀 공유물이다. 같은 팀이면 팀원도 문서를 모두 조회한다.
+- 업로드는 `multipart/form-data`만 받는다. JSON base64 업로드는 없다.
+- 확장자, 선언 MIME, 실제 파일 signature 셋을 함께 검사한다. 하나라도 어긋나면 거절한다.
+- 허용 형식은 `.pdf`, `.png`, `.jpg`, `.jpeg`, `.docx`, `.xlsx`, `.pptx`다. 실행 파일과 압축 파일은 받지 않는다.
+- 형식 위반은 `415`, 크기 초과는 `413`, 빈 파일과 잘못된 파일명은 `422`다.
+- 저장 경로는 서버가 만든다. 원본 파일명을 경로에 쓰지 않고 표시용으로만 보관한다.
+- `storage_key`는 어떤 응답에도 넣지 않는다. 다운로드는 매 요청마다 팀 권한을 검사한 뒤 짧게 사는 서명 URL을 발급한다.
+- 버전 번호는 서버가 트랜잭션 안에서 매긴다. 같은 문서에 다시 올리면 `version_no`가 하나 올라간다.
+- 저장소에 올린 뒤 DB 기록이 실패하면 올린 객체를 지워 고아를 남기지 않는다.
+- 문서 번호는 서버가 `SL-DC-YYYY-####`로 생성한다.
+- Storage 설정이 없으면 업로드와 다운로드를 `503 storage_not_configured`로 막는다.
+- OCR과 텍스트 추출은 아직 없다. `processing_status`는 업로드 시 `uploaded`로 둔다.
 
 ### 영업 딜의 화면 필터와 상태 전이
 


### PR DESCRIPTION
## 변경 요약

Supabase Storage로 자료실 파일을 올리고 내려받는 흐름을 연결합니다.

- `GET/POST /api/documents`
- `GET/PATCH /api/documents/{document_id}`
- `POST /api/documents/{document_id}/files` — `multipart/form-data`
- `GET /api/documents/{document_id}/files/{file_id}/download` — 짧은 서명 URL

구조:

- `app/services/storage.py` — 저장소 경계 (업로드 / 서명 URL / 정리)
- `app/services/upload_guard.py` — 파일 검증

보안 규칙:

- **확장자 + 선언 MIME + 실제 파일 signature** 셋을 함께 검사, 하나라도 어긋나면 거절
- 허용: `.pdf` `.png` `.jpg` `.jpeg` `.docx` `.xlsx` `.pptx` — 실행 파일·압축 파일 제외
- **`storage_key`는 어떤 응답에도 넣지 않습니다**
- 저장 경로는 서버가 생성, 원본 파일명은 표시용으로만 보관 (경로 탈출 차단)
- 다운로드는 매 요청마다 팀 권한 재검사 후 60초짜리 서명 URL 발급
- secret 키는 서버 환경변수에서만 읽고 오류 메시지에 넣지 않음
- 형식 위반 `415`, 크기 초과 `413`, 빈 파일·잘못된 파일명 `422`

동작 규칙:

- 자료실은 팀 공유물 — 같은 팀이면 팀원도 모두 조회
- 버전 번호는 서버가 트랜잭션 안에서 할당, 재업로드 시 `version_no` 증가
- **저장소 업로드 후 DB 기록이 실패하면 올린 객체를 삭제** (고아 방지)
- 문서 번호는 서버가 `SL-DC-YYYY-####` 생성
- Storage 미설정 시 `503 storage_not_configured`
- `SUPABASE_URL`은 `DATABASE_URL`의 project ref에서 파생 — 별도 설정 불필요

## 검증

| 검사 | 결과 |
|---|---|
| `uv run ruff check .` | All checks passed |
| `uv run ruff format --check .` | 69 files already formatted |
| `uv run pytest -q` | 112 passed (기존 95 → +17) |
| `git diff --check` | 문제 없음 |

**실제 Supabase 버킷으로 확인한 결과** (테스트 데이터는 버킷·DB 모두 삭제):

```
문서 생성       -> 201 no=SL-DC-2026-0001
업로드 v1       -> 201 version=1  storage_key 노출=False
업로드 v2       -> 201 version=2
위장 exe(.pdf)  -> 415 file_signature_mismatch
zip             -> 415 unsupported_file_extension
MIME 불일치      -> 415 media_type_mismatch
다운로드 발급    -> 200 expires_in=60  storage_key 노출=False
  실제 내려받기 -> 200, 내용 원본과 일치
목록            -> 200 latest_version=2 files=2
정리 완료 (버킷 객체 2개, 문서 1건 삭제)
```

단위 테스트가 확인하는 것: 위장 확장자·MIME 불일치·경로 탈출·빈 파일·미허용 확장자가 **저장소를 건드리기 전에** 거부되는지, DB 실패 시 객체가 삭제되는지, 응답에 `storage_key`가 없는지, 다른 팀 문서가 `404`인지.

## 영향 및 주의 사항

- 백엔드만 변경합니다. Documents 화면 연결은 후속 작업입니다.
- **운영 전 필요:** `SUPABASE_SECRET_KEY`, `SUPABASE_STORAGE_BUCKET` 환경변수와 private 버킷. 버킷은 반드시 Public 해제 상태여야 합니다.
- OCR·텍스트 추출은 범위 밖입니다. `processing_status`는 `uploaded` 고정입니다.
- 파일 삭제 API는 넣지 않았습니다. 참조 이력이 걸려 있어 별도 정책이 필요합니다.
- 새 테이블이나 migration은 없습니다. 기존 `document`, `file`을 사용합니다.

## 관련 이슈

- 없음