### PR TITLE
프론트 연동 제안서에 남은 연결 작업 추가

### DIFF
--- a/docs/technical/영업_파이프라인_프론트_연동_제안서.md
+++ b/docs/technical/영업_파이프라인_프론트_연동_제안서.md
@@ -195,7 +195,51 @@
 
 프론트의 폴더, 파일, 컴포넌트, 화면 배치와 디자인은 이 문서의 범위가 아니다.
 
-## 11. 완료 확인
+## 11. 새로 준비된 백엔드와 남은 프론트 연결
+
+이 문서를 쓴 뒤 백엔드에 아래 API가 추가되었다. 모두 `develop`에서 동작하며 프론트 연결만 남았다.
+프론트의 폴더·컴포넌트·디자인은 이 문서의 범위가 아니고, 어떤 데이터를 어디서 받는지만 정한다.
+
+| 기능 | 메서드와 경로 | 프론트 현재 상태 |
+|---|---|---|
+| 일정 완료·재개 | `POST /api/activities/{activity_id}/complete`, `.../reopen` | 미연결. 캘린더는 `completed_at`을 읽어 표시만 하고 바꾸지 못한다. |
+| 보고서 | `GET/POST /api/reports`, `GET/PATCH/DELETE /api/reports/{report_id}` | 미연결. 업무보고 화면이 API를 호출하지 않는다. |
+| 보고서 제출 | `POST /api/reports/{report_id}/submit` | 미연결. |
+| 공지·개인 지시 | `GET /api/notices`, `GET /api/notices/{notice_id}` | 미연결. 대시보드가 `/api/auth/me` 외에는 호출하지 않는다. |
+| 자료실 문서 | `GET/POST /api/documents`, `GET/PATCH /api/documents/{document_id}` | 미연결. 자료실 화면이 API를 호출하지 않는다. |
+| 자료 파일 | `POST /api/documents/{document_id}/files`, `GET .../files/{file_id}/download` | 미연결. |
+| 보고서 AI 초안 | `POST /api/agent-runs`, `GET /api/agent-runs/{agent_run_id}` | 미연결. |
+
+### 화면별 남은 작업
+
+| 화면 | 지금 상태 | 해야 할 일 |
+|---|---|---|
+| 영업·견적·계약·발주현황 | 조회 연결 완료 | 견적·계약 **작성·수정 폼**을 `PATCH /api/sales-deals/{id}`에 연결한다. 현재 폼은 고객사·상품·금액·유형·시작일·메모 여섯 값만 보내고 `quote_no`, `quote_issued_on`, `quote_valid_until`, `contract_no`, `contract_signed_on`, `contract_ends_on`을 보내지 않는다. |
+| 캘린더 | 일정 조회·등록·수정·삭제 연결 완료 | 완료 토글을 `complete`·`reopen`에 연결한다. 완료 시각은 서버가 정하므로 값을 보내지 않는다. |
+| 대시보드 | `/api/auth/me`만 호출 | 공지·개인 지시를 `GET /api/notices`로 바꾼다. 일정과 완료 처리도 실제 API를 쓴다. KPI 집계 API는 아직 없다. |
+| 업무보고 | 목업 | 미팅·일간·주간·월간 보고서를 `reports` API로 바꾸고 제출은 `submit`을 쓴다. |
+| 자료실 | 목업 | 목록·등록·수정을 `documents` API로, 업로드와 다운로드를 파일 API로 바꾼다. |
+
+### 연결할 때 지킬 것
+
+- 대시보드는 아직 `shared/agenda`의 목업 ID를 쓴다. 실제 API에 `a1` 같은 목업 ID를 보내지 않도록 ID 출처를 먼저 UUID로 바꾼다.
+- 보고서는 `draft`에서만 수정·삭제할 수 있다. 제출한 뒤에는 `409 report_not_editable`이다.
+- 보고서 제출은 `expected_status_code`를 함께 보내 중복 제출을 막는다.
+- 공지는 `scope=team|personal`로 나눠 조회한다. 응답의 `scope`가 팀 공지와 개인 지시를 구분해 주므로 `recipient_member_id`로 다시 판정하지 않는다.
+- 파일 업로드는 `multipart/form-data`만 쓴다. 허용 형식은 `.pdf`, `.png`, `.jpg`, `.jpeg`, `.docx`, `.xlsx`, `.pptx`이고 형식 위반은 `415`, 크기 초과는 `413`이다.
+- 다운로드는 짧게 사는 서명 URL을 받아 쓴다. 서버는 저장소 경로를 응답하지 않으므로 파일 주소를 따로 만들지 않는다.
+- AI 초안은 `202`와 `Location`을 받고 `GET /api/agent-runs/{agent_run_id}`로 polling한다. 같은 작업을 다시 보낼 때는 같은 `idempotency_key`를 쓴다.
+- AI 초안 결과는 제안이다. 사용자가 확인해 `PATCH /api/reports/{report_id}`로 반영하기 전까지 보고서 내용을 바꾸지 않는다.
+- 8절의 목업 교체 원칙을 그대로 적용한다. 한 화면을 전환하면 그 화면에서 목업과 API 데이터를 섞지 않는다.
+
+### 아직 백엔드가 없는 것
+
+- 대시보드 KPI·주간 집계 API
+- 매출 목표 API
+- 팀 명부 조회 API와 담당자 전환
+- 파이프라인 draft·publish·archive와 표시값 관리 (10절)
+
+## 12. 완료 확인
 
 - [ ] 영업현황은 모든 phase의 딜을 보여준다.
 - [ ] 견적·계약·발주는 현재 phase에 맞는 딜만 보여준다.
@@ -208,3 +252,9 @@
 - [ ] 모든 mutation identity가 UUID다.
 - [ ] filled/empty 팀 데이터가 섞이지 않는다.
 - [ ] loading/error/empty와 권한·동시 변경 오류를 구분한다.
+- [ ] 견적·계약 화면에서 견적 번호·발행일·유효기한과 계약 번호·체결일·종료일을 저장한다.
+- [ ] 캘린더에서 일정을 완료·재개하고 새로고침 뒤에도 유지된다.
+- [ ] 대시보드 공지와 개인 지시가 실제 API 데이터다.
+- [ ] 업무보고를 작성·수정·제출하고 제출한 보고서는 수정되지 않는다.
+- [ ] 자료실에서 허용 형식만 업로드되고 다운로드가 서명 URL로 동작한다.
+- [ ] AI 초안이 사용자 확인 전에는 보고서를 바꾸지 않는다.


### PR DESCRIPTION
## 변경 요약

`docs/technical/영업_파이프라인_프론트_연동_제안서.md`에 11절을 추가합니다.

이 문서를 쓴 뒤 백엔드에 아래 API가 붙었고 모두 `develop`에서 동작하지만 프론트 연결만 남아 있습니다.

- 일정 완료·재개 (#39)
- 보고서 작성·수정·제출 (#37)
- 공지·개인 지시 조회 (#40)
- 보고서 AI 초안 (#41)
- 자료실 문서·파일 (#42)

추가한 내용:

- 새로 준비된 API 경로와 **프론트 현재 상태**
- 화면별 남은 작업 (영업/견적/계약/발주, 캘린더, 대시보드, 업무보고, 자료실)
- 연결할 때 지킬 규칙 9가지
- 아직 백엔드가 없는 항목 (KPI 집계, 매출 목표, 팀 명부, 파이프라인 관리)
- 완료 확인 목록에 항목 6개 추가

기존 11절 `완료 확인`은 12절로 번호만 밀렸습니다.

## 검증

프론트를 실제로 띄우고 로그인해 **네트워크 요청을 확인한 결과**를 기준으로 작성했습니다.

| 화면 | 실제 호출 |
|---|---|
| 캘린더 | `/api/activities` |
| 영업현황 | `/api/sales-deals`, `/sales-pipelines`, `/products` |
| 계약현황 | `/api/sales-deals?phase_code=contract` |
| 고객불만 | `/api/support-requests` |
| **대시보드** | `/api/auth/me` **뿐** |
| **자료실** | 호출 없음 |
| **업무보고** | 호출 없음 |

견적·계약 작성 폼이 `quote_no`·`contract_no` 등을 보내지 않는 것은 `useSalesDeals.ts`의 `toPatchRequest`가 6개 필드만 전송하는 것으로 확인했습니다.

문서만 변경하므로 코드 검사 대상이 없습니다.

## 영향 및 주의 사항

- 문서만 변경합니다. **프론트 코드는 변경하지 않았습니다.**
- 프론트 폴더·컴포넌트·디자인은 이 문서의 범위가 아니며, 어떤 데이터를 어디서 받는지만 적었습니다.
- 10절(파이프라인 관리 후속 API 없음)은 여전히 유효합니다.

## 관련 이슈

- 없음