### PR TITLE
docs: 딜 승산 ML 모델 2차 수정본 반영

### DIFF
--- a/docs/technical/딜_승산_점수_데이터_전처리_및_AI_학습_모델.md
+++ b/docs/technical/딜_승산_점수_데이터_전처리_및_AI_학습_모델.md
@@ -1,32 +1,39 @@
 # 딜 승산 점수 데이터 전처리 및 AI 학습 모델
 
+> SalesLuv ML Model Report 2차 수정본
+>
+> 검증 기준일: 2026-08-17
+
 ## 1. 결정 요약
 
 | 항목 | 결정 |
 |---|---|
 | 학습 문제 | 딜 성사 여부 `Won / Lost` 이진 분류 |
 | 학습 데이터 | Salvirt B2B Sales Dataset |
-| 입력 | 미팅에서 구조화한 범주형 딜 특성 10개 |
-| 전처리 | 완전 중복 제거, One-Hot Encoding, 동일 특성 조합 그룹 분할 |
-| 최종 모델 | L2 Logistic Regression |
+| 입력 | 22개 후보 특성 중 10개로 1차 테스트 |
+| 전처리 | 중복 제거, One-Hot Encoding, 그룹 분할 |
+| 1차 기준 모델 | One-Hot + Logistic Regression(`C=0.1, L2`) |
+| 최종 모델 | 입력 특성 재검토 및 하이퍼파라미터 튜닝 후 확정 |
 | 출력 | 실험적 딜 승산 점수 `0~100점` |
 | 사용 범위 | 화면에 참고 정보로만 표시 |
 
-이 모델은 STT나 미팅 원문을 직접 학습하는 NLP 모델이 아닙니다. 미팅 분석 Agent가 원문을 10개 딜 특성으로 변환하고, ML 모델은 그 구조화된 값만 입력받습니다.
+이 모델은 STT나 미팅 원문을 직접 학습하는 NLP 모델이 아닙니다. 미팅 분석 Agent가 원문과 CRM 정보에서 범주형 특성을 구성하고, ML 모델은 그 구조화된 값만 입력받습니다.
+
+현재는 단일 미팅에서 비교적 추출 가능한 10개 특성으로 1차 테스트를 진행했으며, 향후 22개 전체 특성으로 확장해 적용할 예정입니다.
 
 ## 2. 학습 목적과 사용 범위
 
-- 입력: 미팅에서 추출한 10개 딜 특성
+- 입력: 현재 10개 특성(향후 22개 후보 전체)
 - 정답: 영업 딜 성사 `Won=1`, 취소 `Lost=0`
 - 출력: 딜 승산 점수
 - 활용: 고객 및 진행 딜 화면에 표시
 - 제외: 영업 단계·실제 계약의 자동 변경, 다른 Agent 실행, 담당자 평가
 
-> 출력값은 공개 데이터의 패턴을 기준으로 계산한 참고 점수이며, SalesLuv 환경의 실제 영업 딜 성사 확률을 보장하지 않습니다.
+> 출력값은 공개 데이터의 패턴을 기준으로 계산한 참고값이며, SalesLuv 환경의 실제 영업 딜 성사 확률을 보장하지 않습니다.
 
 ## 3. 학습 데이터
 
-[Salvirt B2B Sales Dataset](https://www.salvirt.com/research/b2bdataset/)을 사용합니다. Salvirt가 공개한 B2B 영업 데이터로, 대화 원문이 아니라 범주형 딜 조건과 최종 결과로 구성됩니다.
+[Salvirt B2B Sales Dataset](https://www.salvirt.com/research/b2bdataset/)을 사용합니다. 대화 원문이 아니라 범주형 딜 조건과 최종 결과로 구성된 공개 B2B 영업 데이터입니다.
 
 | 항목 | 확인 결과 |
 |---|---:|
@@ -40,11 +47,13 @@
 | `Won` | 173건 |
 | `Lost` | 192건 |
 
-`Won` 173건과 `Lost` 192건으로 두 정답의 비율이 비슷합니다. 따라서 SMOTE, 임의 데이터 증강, class weight는 적용하지 않습니다.
+`Won` 173건과 `Lost` 192건으로 정답 비율이 비슷합니다. 따라서 SMOTE, 임의 데이터 증강, class weight는 적용하지 않습니다.
 
-## 4. 사용할 입력 특성
+## 4. 전체 입력 후보 22개
 
-전체 22개 특성 중 한 번의 미팅 내용에서 비교적 명확하게 추출할 수 있는 10개만 사용합니다.
+현재는 22개 후보 컬럼을 전체로 관리하고, 1차 테스트에서는 미팅에서 상대적으로 추출 가능한 10개만 사용합니다. 향후 22개 입력 스키마 확장을 목표로 운영합니다.
+
+### 4.1 현재 1차 테스트 특성 10개
 
 | 원본 컬럼 | 의미 | 원본 범주 |
 |---|---|---|
@@ -59,12 +68,26 @@
 | `Scope` | 계약 범위 구체화 정도 | Clear / Few questions / Low |
 | `Needs_def` | 고객 요구사항 구체화 정도 | Yes / Poor / Info gathering / No |
 
-`Posit_statm`은 고객의 감정을 분석하는 항목이 아닙니다. 예를 들어 “이 조건이면 검토해 보겠다”처럼 구매와 관련된 명시적 표현이 있었는지를 나타냅니다.
+### 4.2 추가 적용 후보 12개
 
-### 제외할 특성
+- `Product`: 추후 적용
+- `Seller`: 추후 적용
+- `Comp_size`: 추후 적용
+- `Partnership`: 추후 적용
+- `Growth`: 추후 적용
+- `Source`: 추후 적용
+- `Client`: 추후 적용
+- `Strat_deal`: 추후 적용
+- `Cross_sale`: 추후 적용
+- `Up_sale`: 추후 적용
+- `Deal_type`: 추후 적용
+- `Att_t_client`: 추후 적용
 
-- `Product`, `Seller`: Salvirt 내부의 익명 코드라 SalesLuv 상품·담당자와 연결할 수 없으며, 담당자 편향을 만들 수 있어 제외합니다.
-- `Comp_size`, `Partnership`, `Growth`, `Source`, `Client`, `Strat_deal`, `Cross_sale`, `Up_sale`, `Deal_type`, `Att_t_client`: 단일 미팅 내용에서 일관되게 추출하기 어려워 첫 모델에서 제외합니다.
+### 향후 처리 원칙
+
+- 22개 컬럼 중 미팅 또는 CRM에서 확인 가능한 값은 실제 범주값을 기록합니다.
+- 확인되지 않으면 `Unknown`으로 통일해 처리합니다.
+- `Product`, `Seller`는 SalesLuv 상품/담당자 매핑 규칙이 정해진 뒤 적용합니다.
 
 ## 5. 데이터 전처리
 
@@ -72,68 +95,66 @@
 
 1. 컬럼명과 문자열의 앞뒤 공백을 정리합니다.
 2. 정답을 `Won=1`, `Lost=0`으로 변환합니다.
-3. 23개 컬럼의 값이 모두 같은 완전 중복 행 83건을 제거합니다.
-4. 선택한 10개 입력 특성만 남깁니다.
-5. `Unknown`을 하나의 유효한 범주로 유지합니다.
-6. 범주형 특성을 One-Hot Encoding으로 변환합니다.
-7. 10개 특성 조합이 같은 행을 하나의 그룹으로 지정합니다.
+3. 23개 컬럼 값이 모두 같은 완전 중복 행 83건을 제거합니다.
+4. 1차 테스트에서는 선정한 10개 입력 특성만 사용합니다.
+5. 향후 22개 전체 컬럼에서는 확인되지 않은 값을 `Unknown`으로 처리합니다.
+6. `Unknown`을 하나의 유효한 범주로 유지합니다.
+7. 범주형 특성을 One-Hot Encoding으로 변환합니다.
+8. 1차 테스트는 10개 조합으로 그룹을 지정하고, 확장 테스트는 22개 조합으로 재설정합니다.
 
 모든 입력이 범주형이므로 평균값 대체와 수치 정규화는 적용하지 않습니다.
 
-미팅에서 확인할 수 없는 값을 `No`로 가정하지 않고 `Unknown`으로 처리합니다. 원본에 `Unknown`이 없는 특성은 `OneHotEncoder(handle_unknown="ignore")`로 처리하여 임의의 다른 값으로 바꾸지 않습니다. 단, `Unknown`이 많은 딜의 점수는 신뢰도가 낮다는 한계를 남깁니다.
+미팅에서 확인할 수 없는 값을 `No`로 가정하지 않고 `Unknown`으로 처리합니다. 원본에 `Unknown`이 없는 특성은 `OneHotEncoder(handle_unknown="ignore")`로 처리합니다.
 
 ## 6. 학습·검증 방식
 
-일반적인 행 단위 무작위 분할은 사용하지 않습니다. 동일한 특성 조합이 학습과 평가 데이터에 나뉘면 모델이 같은 입력을 미리 보게 되어 성능이 부풀려질 수 있습니다.
+행 단위 무작위 분할은 사용하지 않습니다. 동일 특성 조합이 학습과 평가 데이터에 나뉘면 같은 입력을 미리 보게 되어 성능이 부풀려질 수 있습니다.
 
 - 10개 특성 조합이 같은 행을 하나의 그룹으로 설정
-- 그룹이 학습·평가 데이터에 겹치지 않는 `StratifiedGroupKFold`를 사용
-- 5-Fold 교차검증을 분할 시드를 바꾸어 10회 반복
-- 총 50개 평가 fold의 평균으로 모델 비교
+- 그룹 분할 시 학습·평가 겹침 없음 보장: `StratifiedGroupKFold`
+- 5-Fold 교차검증을 시드 10회 반복
+- 총 50개 평가 fold 평균으로 모델 비교
 
-선택한 10개 특성 기준으로 중복 제거 후 365행은 133개의 고유 특성 조합으로 구성됩니다. 같은 특성 조합인데 실제 결과가 `Won`과 `Lost`로 다른 사례도 있어, 현재 입력만으로 모든 딜을 완벽하게 구분할 수는 없습니다.
+선택한 10개 특성 기준으로 중복 제거 후 365행은 133개의 고유 특성 조합으로 구성됩니다. 같은 특성 조합인데 실제 결과가 `Won`과 `Lost`로 다른 사례도 있어, 현재 입력만으로 모든 딜을 완벽히 구분할 수는 없습니다.
 
 ### 평가 지표
 
 1. `ROC-AUC`: 승산이 높은 딜을 더 위에 배치하는 능력
-2. `Brier Score`: 출력 점수가 실제 결과와 얼마나 맞는지를 측정하는 지표
+2. `Brier Score`: 출력 점수와 실제 결과의 일치 정도
 3. `Accuracy`: 전체 예측 중 정답 비율
 
-`Brier Score`는 낮을수록 좋고, 나머지 지표는 높을수록 좋습니다. 이 기능은 순위와 점수를 표시하므로 단일 정확도보다 `ROC-AUC`와 `Brier Score`를 우선합니다.
+`Brier Score`는 낮을수록 좋고, 나머지 지표는 높을수록 좋습니다. 이 기능은 점수의 순위와 확률 품질을 함께 보는 성격이라 단일 정확도보다 `ROC-AUC`와 `Brier Score`를 우선합니다.
 
-## 7. 모델 비교 결과
+## 7. 10개 특성 기준 1차 모델 비교
 
-- 검증 기준일: 2026-08-17
-- 검증 데이터: 중복 제거 후 365건
-- 입력: 미팅 기반 10개 특성
-- 검증: 10회 반복 5-Fold `StratifiedGroupKFold`
+현재 선정한 10개 특성으로 후보 모델을 간단히 비교한 초기 결과입니다. 22개 특성 확장과 튜닝 전의 기준값이며 최종 모델 확정 결과가 아닙니다.
 
 | 모델 | ROC-AUC | Brier Score | Accuracy |
 |---|---:|---:|---:|
 | Dummy 기준 모델 | 0.500 | 0.249 | 52.6% |
-| One-Hot + Logistic Regression | **0.793** | **0.190** | 71.0% |
-| CatBoost | 0.792 | 0.191 | **72.0%** |
+| One-Hot + Logistic Regression | 0.793 | 0.190 | 71.0% |
+| CatBoost | 0.792 | 0.191 | 72.0% |
 | One-Hot + MLP 신경망 | 0.785 | 0.197 | 70.6% |
 
-CatBoost와 Logistic Regression의 성능 차이는 거의 없습니다. MLP 신경망은 데이터가 적어 점수 품질과 정확도 모두 Logistic Regression보다 낮았습니다.
+1차 기준에서는 Logistic Regression와 CatBoost의 성능 차이가 거의 없습니다.
 
-## 8. 최종 학습 모델
+## 8. 1차 기준 모델
 
-> `OneHotEncoder(handle_unknown="ignore") + LogisticRegression(C=0.1, L2)`
+`OneHotEncoder(handle_unknown="ignore") + LogisticRegression(C=0.1, L2)`
 
 선정 이유는 다음과 같습니다.
 
-- CatBoost와 거의 같은 ROC-AUC를 보이면서 Brier Score는 더 좋습니다.
-- MLP 신경망보다 검증 성능이 높습니다.
-- 현재 데이터 규모에 적합합니다.
-- 모델의 입력과 영향을 설명하기 쉽습니다.
-- 추가 학습 인프라 없이 가벼게 운영할 수 있습니다.
+- CatBoost와 거의 같은 ROC-AUC를 보이면서 Brier Score는 더 좋음
+- MLP 신경망보다 검증 성능이 높음
+- 현재 데이터 규모에 적합
+- 모델의 입력과 영향이 설명되기 쉬움
+- 추가 학습 인프라 없이 가볍게 운영 가능
 
-DL을 사용하기 위해 성능이 낮은 MLP를 운영 모델로 선택하지 않습니다. 이 기능에서는 Logistic Regression이 SalesLuv의 ML 적용 모델입니다.
+현재 비교에서는 1차 기준 모델로 Logistic Regression을 우선 적용합니다. 최종 모델은 특성 조합 재검토, 하이퍼파라미터 튜닝, 추가 검증 후 확정합니다.
 
 ## 9. 실제 입력과 점수 산출
 
-`STT·메모·직접 입력 → 미팅 분석 Agent → 10개 특성 추출 → ML 모델 → 딜 승산 점수 표시`
+`STT·메모·직접 입력 → 미팅 분석 Agent → 특성 구성(현재 10 / 향후 22) → ML 모델 → 딜 승산 점수`
 
 ML 모델의 `Won` 예측값에 100을 곱해 화면용 점수로 변환합니다.
 
@@ -141,12 +162,12 @@ ML 모델의 `Won` 예측값에 100을 곱해 화면용 점수로 변환합니�
 >
 > 실험 모델 · 미팅 내용 기반
 
-점수는 승인 없이 표시하지만 다른 Agent를 실행하거나 영업 딜 단계와 실제 계약을 변경하지 않습니다.
+점수는 승인 없이 표시하지만 다른 Agent 실행이나 영업 딜 단계·실제 계약 변경에는 사용하지 않습니다.
 
-실행 결과는 별도 점수 테이블을 만들지 않고 `agent_run`에 보존합니다.
+실행 결과 저장(임시 예시)
 
 - `agent_code`: `meeting_analysis`
-- `source_refs`: 원천 `activity_id`와 대상 `sales_deal_id`
+- `source_refs`: 원천 `activity_id`, 대상 `sales_deal_id`
 - `output_snapshot.deal_assessment`: 계산 시점의 10개 `features`, `score`, ML `model_version`
 - 화면 표시: 같은 `sales_deal_id`의 완료 실행 중 `finished_at DESC, id DESC` 첫 행
 - 재분석: 기존 실행을 덮어쓰지 않고 새 `agent_run` 행 추가
@@ -154,27 +175,30 @@ ML 모델의 `Won` 예측값에 100을 곱해 화면용 점수로 변환합니�
 ## 10. 한계와 향후 재학습
 
 - 중복 제거 후 데이터가 365건으로 작습니다.
-- 같은 10개 특성에서도 실제 영업 딜 결과가 다른 사례가 있습니다.
+- 같은 특성 조합에서도 실제 영업 딜 결과가 다른 사례가 있습니다.
+- 현재는 22개 후보 중 10개 특성만 사용해 1차 테스트했으며, 모델 비교와 튜닝 범위가 제한적입니다.
 - 데이터는 SalesLuv의 한국어 영업 미팅이 아닌 외부 B2B 딜 데이터입니다.
-- 원본에는 각 범주의 세부 판정 기준이 부족하므로, 미팅 분석 Agent에 일관된 변환 기준이 필요합니다.
+- 원본에 각 범주의 세부 판정 기준이 부족해 미팅 분석 Agent에 일관된 변환 기준이 필요합니다.
 - 따라서 현재 점수는 기능 시연과 참고 용도로만 사용합니다.
 
-SalesLuv의 실제 종료 딜이 쌓이면 다음 기준으로 재학습합니다.
+### 실제 종료 딜 기반 재학습 기준
 
-- `sales_pipeline_stage.outcome_code=confirmed`이고 `contract_signed_on`이 있는 딜: `Won`; 결과 시각은 실제 계약 체결일인 `contract_signed_on`
-- `sales_pipeline_stage.outcome_code=cancelled`이고 `closed_on`이 있는 딜: `Lost`; 결과 시각은 파이프라인 종료일인 `closed_on`
-- `sales_pipeline_stage.outcome_code=in_progress`: 결과가 없으므로 학습에서 제외
+- `Won` 학습 표본: `sales_pipeline_stage.outcome_code=confirmed`이고 `contract_signed_on`이 있는 딜
+  - 결과 시각: `contract_signed_on`
+- `Lost` 학습 표본: `sales_pipeline_stage.outcome_code=cancelled`이고 `closed_on`이 있는 딜
+  - 결과 시각: `closed_on`
+- 결과 미정: `sales_pipeline_stage.outcome_code=in_progress`
 
-재학습할 때는 결과가 난 뒤의 정보가 입력에 섞이지 않도록, **점수를 계산한 시점의 10개 특성과 이후 결과**를 쌍으로 사용합니다. `Won`은 `contract_signed_on`, `Lost`는 `closed_on`보다 앞서 생성된 점수만 학습 표본으로 사용합니다. `closed_on`은 계약 체결일이나 매출 확정일로 사용하지 않습니다.
+재학습 시에는 결과가 난 뒤 정보가 입력에 섞이지 않도록 점수 계산 시점의 특성과 이후 결과를 쌍으로 사용합니다. `Won`은 `contract_signed_on` 이전, `Lost`는 `closed_on` 이전에 생성된 점수만 표본으로 사용합니다. `closed_on`은 계약 체결일/매출 확정일로 해석하지 않습니다.
 
 ## 11. 데이터 사용 주의사항
 
-[Hugging Face 데이터 카드](https://huggingface.co/datasets/markobo/B2B_Sales_data)에는 CC BY 4.0으로 표시되어 있지만, Salvirt 공식 페이지에는 데이터셋의 별도 라이선스가 명확하게 적혀 있지 않습니다.
+[Hugging Face 데이터 카드](https://huggingface.co/datasets/markobo/B2B_Sales_data)에는 CC BY 4.0으로 표시되지만, Salvirt 공식 페이지에는 라이선스가 명확히 적혀 있지 않습니다.
 
 - 문서와 발표에 Salvirt 출처를 표시합니다.
-- 부트캠프 학습·시연 목적으로 사용합니다.
+- 부트캠프 학습·시연 용도로 사용합니다.
 - 원본 CSV는 공개 저장소에 올리지 않습니다.
-- 상업적 사용이나 원본 재배포 전에는 Salvirt에 사용 조건을 확인합니다.
+- 상업적 사용이나 원본 재배포 전에는 Salvirt 사용 조건을 확인합니다.
 
 ## 참고 자료
 


### PR DESCRIPTION
## 변경 요약
- 2차 수정본 기준으로 딜 승산 ML 문서의 입력 특성 범위와 상태(1차 기준) 기준을 반영했습니다.
- 10개 특성 1차 테스트, 22개 후보 확장 원칙, 최종 모델 미확정(튜닝 후 확정) 문구를 추가했습니다.

## 검증
- 실행한 자동 검증 없음(문서 변경만 있음).

## 영향 및 주의 사항
- 문서 변경 단일 커밋, 운영 코드 영향 없음.