### PR TITLE
프론트 연결에 필요한 응답 구조와 데이터 현황 추가

### DIFF
--- a/docs/technical/영업_파이프라인_프론트_연동_제안서.md
+++ b/docs/technical/영업_파이프라인_프론트_연동_제안서.md
@@ -221,6 +221,50 @@
 | 업무보고 | 목업 | 미팅·일자별·주간 보고서를 `reports` API로 바꾸고 제출은 `submit`을 쓴다. 유스케이스에 월간 보고서가 없어 종류는 세 가지다. |
 | 자료실 | 목업 | 목록·등록·수정을 `documents` API로, 업로드와 다운로드를 파일 API로 바꾼다. |
 
+### 대시보드 응답 구조
+
+`GET /api/dashboard?date=&owner_member_id=&notice_limit=3&renewal_within_days=` 하나로 아래를 받는다.
+`date`를 생략하면 `Asia/Seoul` 오늘이고, 모든 집계는 응답의 `as_of` 한 시각을 기준으로 한다.
+
+| key | 화면 자리 | 내용 |
+|---|---|---|
+| `notices` | 공지 | `total`과 최근 `items` |
+| `directives` | 팀장 지시사항 | `total`과 최근 `items`. 로그인한 사람이 받은 지시만 |
+| `visited_companies` | 오늘 방문 회사 | `count`. 같은 회사를 여러 번 방문해도 1로 센다 |
+| `activities` | 오늘 일정 | `count`. 미팅과 업무를 모두 포함 |
+| `follow_ups` | 미완료 후속업무 | `total`, `overdue`, `due_within_7_days` |
+| `support_requests` | C/S 대응요청 | `total`, `in_progress`, `urgent` |
+| `contract_renewals` | 계약갱신 예정 | `count`와 `items`. 각 항목에 `deal_no`, `title`, `customer_company_name`, `contract_no`, `contract_ends_on` |
+| `sales_target` | 매출 목표 | `target_month`, `target_amount`, `confirmed_amount`, `in_progress_amount`, `achievement_rate` |
+| `weekly` | weekly plan | `start_date`, `end_date`, `days[7]`. 각 날짜에 `meeting_count`, `task_count`, `due_count` |
+
+- 주간 밴드는 기준일이 속한 주의 **일요일부터 7일**이다. 전 주·다음 주는 `date`를 옮겨 다시 부른다.
+- 계약갱신 기준 일수는 서버가 정하지 않는다. `renewal_within_days`를 주면 그 창으로 거르고, 생략하면 기준일 이후 만료 예정 전체를 센다.
+- 매출 목표가 없으면 `achievement_rate`는 `0`이 아니라 `null`이다. 미설정과 미달성을 구분한다.
+- `새봄정형외과 외 1곳`, `D-4` 같은 표시 문자열은 서버가 만들지 않는다. `items`와 날짜로 프론트가 조합한다.
+- 오늘 일정 **목록**은 이 응답에 없다. `GET /api/activities`를 따로 부른다.
+
+### 개발 DB 현재 데이터
+
+연결한 화면이 비어 보이면 버그가 아니라 seed가 없는 것이다. 2026-08-18 기준 filled 데모팀 현황이다.
+
+| 테이블 | 건수 | 연결 시 화면 |
+|---|---|---|
+| `customer_company` / `customer_contact` | 6 / 32 | 고객현황 정상 |
+| `activity` | 12 | 캘린더 정상 |
+| `sales_deal` | 61 | 영업·계약현황 정상 |
+| `purchase_order` | 2 | 발주현황 정상 |
+| `support_request` | 3 | 고객불만 정상 |
+| `notice` | 7 (팀 공지 5, 개인 지시 2) | 대시보드 공지 정상 |
+| `report` | **0** | 업무보고 빈 목록 |
+| `document` / `file` | **0** | 자료실 빈 목록 |
+| `sales_target` | **0** | 매출 목표 `achievement_rate=null` |
+| `agent_run` | **0** | 실행 이력 없음 |
+
+- 대시보드 계약갱신도 0으로 나온다. `confirmed` 딜 47건이 모두 `contract_ends_on`이 비어 있어서다.
+- `report`, `document`는 화면에서 직접 만들어 보는 편이 seed 보다 확인 가치가 크다. 필요하면 seed 를 따로 만든다.
+- empty 데모팀은 모든 업무 데이터가 0이다. 빈 화면 처리를 확인할 때 쓴다.
+
 ### 연결할 때 지킬 것
 
 - 대시보드는 아직 `shared/agenda`의 목업 ID를 쓴다. 실제 API에 `a1` 같은 목업 ID를 보내지 않도록 ID 출처를 먼저 UUID로 바꾼다.
@@ -258,3 +302,7 @@
 - [ ] 업무보고를 작성·수정·제출하고 제출한 보고서는 수정되지 않는다.
 - [ ] 자료실에서 허용 형식만 업로드되고 다운로드가 서명 URL로 동작한다.
 - [ ] AI 초안이 사용자 확인 전에는 보고서를 바꾸지 않는다.
+- [ ] 대시보드 카드 숫자와 그 카드를 눌러 여는 목록의 전체 수가 같다.
+- [ ] 주간 밴드의 전 주·다음 주 이동이 달력 주 단위로 움직인다.
+- [ ] 데이터가 없는 화면이 오류가 아니라 빈 상태로 보인다.
+- [ ] empty 데모팀으로 로그인했을 때 모든 화면이 빈 상태로 정상 동작한다.

--- a/docs/technical/영업_파이프라인_프론트_연동_제안서.md
+++ b/docs/technical/영업_파이프라인_프론트_연동_제안서.md
@@ -221,6 +221,18 @@
 | 업무보고 | 목업 | 미팅·일자별·주간 보고서를 `reports` API로 바꾸고 제출은 `submit`을 쓴다. 유스케이스에 월간 보고서가 없어 종류는 세 가지다. |
 | 자료실 | 목업 | 목록·등록·수정을 `documents` API로, 업로드와 다운로드를 파일 API로 바꾼다. |
 
+### 붙이기 전에 알아야 할 것
+
+- 개발 서버는 `bash scripts/dev.sh` 로 함께 띄운다. 따로 띄우려면 `bash scripts/backend.sh`, `bash scripts/frontend.sh` 다.
+- 백엔드는 `http://localhost:8000`, 프론트는 `http://localhost:5173`이며 모든 업무 경로는 `/api` 아래에 있다.
+- 프론트는 `frontend/.env` 의 `VITE_API_BASE_URL` 로 백엔드 주소를 읽는다. **이 값이 비면 앱이 시작하자마자 예외로 멈춘다.** `frontend/.env.example` 을 복사해 채운다.
+- 백엔드가 떠 있으면 `http://localhost:8000/docs` 에서 전체 계약을 볼 수 있다. 이 문서와 다르면 `/openapi.json` 이 최종 기준이다.
+- 인증은 서버가 발급하는 `HttpOnly` 세션 쿠키다. 토큰을 브라우저 저장소에 넣지 않는다.
+- 프론트는 이미 `frontend/src/api/client.ts` 의 axios 인스턴스를 쓰고 `withCredentials: true` 가 켜져 있다. 새 endpoint 도 이 인스턴스로 부르면 쿠키가 함께 나간다.
+- 상태를 바꾸는 요청은 서버가 `Origin` 을 검사한다. 위 주소로 접속해야 통과한다.
+- 로그인 계정은 `backend/.env` 의 `DEMO_*` 값이다. 데이터가 있는 팀과 비어 있는 팀이 따로 있어 빈 화면 처리도 함께 확인할 수 있다.
+- `401` 이 오면 세션이 만료된 것이므로 로그인 화면으로 보낸다. refresh API 는 없다.
+
 ### 대시보드 응답 구조
 
 `GET /api/dashboard?date=&owner_member_id=&notice_limit=3&renewal_within_days=` 하나로 아래를 받는다.
@@ -243,6 +255,68 @@
 - 매출 목표가 없으면 `achievement_rate`는 `0`이 아니라 `null`이다. 미설정과 미달성을 구분한다.
 - `새봄정형외과 외 1곳`, `D-4` 같은 표시 문자열은 서버가 만들지 않는다. `items`와 날짜로 프론트가 조합한다.
 - 오늘 일정 **목록**은 이 응답에 없다. `GET /api/activities`를 따로 부른다.
+
+실제 응답은 아래 형태다. 팀원 계정으로 부른 결과이며 목록은 줄여 적었다.
+
+```json
+{
+  "as_of": "2026-08-18T12:31:05.482+09:00",
+  "date": "2026-08-18",
+  "notices": {
+    "total": 5,
+    "items": [
+      {
+        "id": "…",
+        "scope": "team",
+        "author_display_name": "김서현",
+        "recipient_member_id": null,
+        "tag": null,
+        "title": "미팅에서 예산 집행 시기와 승인 담당자를 확인해 주세요",
+        "body": "…",
+        "image_alt": null,
+        "published_at": "2026-08-18T17:40:00+09:00",
+        "due_at": null,
+        "due_text": null
+      }
+    ]
+  },
+  "directives": {
+    "total": 2,
+    "items": [
+      {
+        "id": "…",
+        "scope": "personal",
+        "recipient_member_id": "86d40aa1-…",
+        "title": "갱신 예정 계약 2건의 담당자 확인 결과를 공유해 주세요",
+        "due_at": "2026-08-22T03:00:00+09:00",
+        "due_text": "금요일까지"
+      }
+    ]
+  },
+  "visited_companies": { "count": 0 },
+  "activities": { "count": 0 },
+  "follow_ups": { "total": 1, "overdue": 0, "due_within_7_days": 0 },
+  "support_requests": { "total": 2, "in_progress": 2, "urgent": 1 },
+  "contract_renewals": { "within_days": null, "count": 0, "items": [] },
+  "sales_target": {
+    "target_month": "2026-08",
+    "target_amount": null,
+    "confirmed_amount": 98000000,
+    "in_progress_amount": 0,
+    "achievement_rate": null
+  },
+  "weekly": {
+    "start_date": "2026-08-16",
+    "end_date": "2026-08-22",
+    "days": [
+      { "date": "2026-08-16", "meeting_count": 0, "task_count": 0, "due_count": 0 },
+      { "date": "2026-08-17", "meeting_count": 2, "task_count": 1, "due_count": 0 }
+    ]
+  }
+}
+```
+
+`tag`, `target_amount`, `achievement_rate`, `within_days` 가 `null` 인 것은 오류가 아니라 아직 값이 없는 상태다. 아래 데이터 현황을 함께 본다.
 
 ### 개발 DB 현재 데이터
 


### PR DESCRIPTION
## 변경 요약

제안서 11절이 **어떤 API가 남았는지**는 적었지만, 프론트에서 실제로 붙일 때 필요한 두 가지가 빠져 있었습니다.

### 1. 대시보드 응답 구조

`GET /api/dashboard`가 한 번에 주는 9개 key를 **화면 자리와 짝지어** 표로 적었습니다. 이게 없으면 응답을 받아도 어느 카드에 뭘 넣을지 알 수 없습니다.

함께 밝힌 것:
- 주간 밴드는 기준일이 속한 주의 **일요일부터 7일**. 전 주·다음 주는 `date`를 옮겨 다시 호출
- 계약갱신 기준 일수는 **서버가 정하지 않음**. `renewal_within_days`를 주면 그 창, 생략하면 전체
- 목표가 없으면 `achievement_rate`는 `0`이 아니라 **`null`** (미설정 ≠ 미달성)
- `새봄정형외과 외 1곳`, `D-4` 같은 문자열은 서버가 안 만듦
- **오늘 일정 목록은 이 응답에 없음** — `GET /api/activities`를 따로 호출

### 2. 개발 DB 현재 데이터

연결했는데 화면이 비면 버그로 오해하기 쉬워서 테이블별 건수를 적었습니다.

| 정상 | 0건 |
|---|---|
| 고객 6/32, 일정 12, 딜 61, 발주 2, C/S 3, 공지 7 | `report`, `document`, `file`, `sales_target`, `agent_run` |

계약갱신도 0으로 나오는데, `confirmed` 딜 47건이 **전부 `contract_ends_on`이 비어 있어서**입니다. API 문제가 아닙니다.

### 3. 완료 확인 항목 4개 추가

카드 숫자와 목록 전체 수 일치, 주 단위 이동, 빈 상태 처리, empty 팀 검증.

## 검증

문서에 적은 모든 수치를 개발 DB로 대조했습니다.

```
customer_company   문서=  6  실제=  6  OK
customer_contact   문서= 32  실제= 32  OK
activity           문서= 12  실제= 12  OK
sales_deal         문서= 61  실제= 61  OK
purchase_order     문서=  2  실제=  2  OK
support_request    문서=  3  실제=  3  OK
notice 팀공지/개인지시  문서=5/2  실제=5/2  OK
confirmed 딜        문서=47  실제=47 (종료일 없음 47)  OK
```

문서만 변경하므로 코드 검사 대상이 없습니다.

## 영향 및 주의 사항

- 문서만 변경합니다. 코드와 프론트는 건드리지 않았습니다.
- 건수는 2026-08-18 기준이라 seed를 더 돌리면 달라집니다.

## 관련 이슈

- 없음