### PR TITLE
미팅 음성 전사 API를 추가

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -42,3 +42,10 @@ LLM_API_URL=https://api.openai.com/v1/responses
 LLM_API_KEY=
 LLM_MODEL=gpt-5.6-luna
 LLM_TIMEOUT_SECONDS=30
+
+# OpenAI 미팅 음성 전사. API 키는 서버에서만 사용한다.
+STT_API_KEY=
+STT_MODEL=gpt-4o-transcribe
+STT_TIMEOUT_SECONDS=120
+# OpenAI 파일 전사 한도인 25 MiB 이하에서만 설정한다.
+# STT_MAX_BYTES=26214400

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -13,6 +13,7 @@ from app.api import (
     reports,
     sales_deals,
     support,
+    transcriptions,
 )
 
 api_router = APIRouter()
@@ -28,3 +29,4 @@ api_router.include_router(notices.router)
 api_router.include_router(agent_runs.router)
 api_router.include_router(documents.router)
 api_router.include_router(dashboard.router)
+api_router.include_router(transcriptions.router)

--- a/backend/app/api/transcriptions.py
+++ b/backend/app/api/transcriptions.py
@@ -1,0 +1,52 @@
+from typing import Annotated
+
+from fastapi import APIRouter, File, HTTPException, UploadFile, status
+from pydantic import BaseModel
+
+from app.api.deps import CurrentMember
+from app.core.config import settings
+from app.services import stt
+from app.services.upload_guard import UploadRejected, check_audio_upload, check_size
+
+router = APIRouter(tags=["transcriptions"])
+
+
+class TranscriptionRead(BaseModel):
+    transcript: str
+
+
+@router.post("/transcriptions", response_model=TranscriptionRead)
+async def create_transcription(
+    _member: CurrentMember,
+    audio: Annotated[UploadFile, File()],
+) -> TranscriptionRead:
+    # 제한보다 한 바이트만 더 읽어 대용량 파일을 메모리에 올리지 않고 413을 판정한다.
+    content = await audio.read(settings.stt_max_bytes + 1)
+    try:
+        check_size(len(content), settings.stt_max_bytes)
+        allowed = check_audio_upload(
+            file_name=audio.filename or "",
+            declared_media_type=audio.content_type,
+            content=content,
+        )
+    except UploadRejected as rejected:
+        raise HTTPException(status_code=rejected.status_code, detail=rejected.detail) from rejected
+
+    try:
+        transcript = await stt.transcribe(
+            file_name=audio.filename or "",
+            media_type=allowed.media_type,
+            content=content,
+        )
+    except stt.STTNotConfigured as error:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="stt_not_configured",
+        ) from error
+    except stt.STTError as error:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="stt_unavailable",
+        ) from error
+
+    return TranscriptionRead(transcript=transcript)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -42,6 +42,12 @@ class Settings(BaseSettings):
     llm_model: str = ""
     llm_timeout_seconds: float = Field(default=30.0, gt=0, le=300)
 
+    # 미팅 음성은 저장하지 않고 OpenAI 전사 API 로 바로 보낸다.
+    stt_api_key: SecretStr = SecretStr("")
+    stt_model: str = "gpt-4o-transcribe"
+    stt_timeout_seconds: float = Field(default=120.0, gt=0, le=300)
+    stt_max_bytes: int = Field(default=25 * 1024 * 1024, gt=0, le=25 * 1024 * 1024)
+
     # Supabase Auth. password login 은 secret 이 아니라 publishable 키를 씁니다.
     # 두 키 모두 서버 프로세스 안에서만 쓰고 브라우저로 보내지 않습니다.
     supabase_publishable_key: SecretStr = SecretStr("")
@@ -80,6 +86,11 @@ class Settings(BaseSettings):
     def llm_configured(self) -> bool:
         """LLM 호출에 필요한 값이 모두 있는지. 없으면 기능을 503 으로 막는다."""
         return bool(self.llm_api_url and self.llm_api_key.get_secret_value() and self.llm_model)
+
+    @property
+    def stt_configured(self) -> bool:
+        """STT 호출에 필요한 값이 모두 있는지. 없으면 기능을 503 으로 막는다."""
+        return bool(self.stt_api_key.get_secret_value() and self.stt_model)
 
     @property
     def cors_origin_list(self) -> list[str]:

--- a/backend/app/services/stt.py
+++ b/backend/app/services/stt.py
@@ -1,0 +1,61 @@
+"""OpenAI 미팅 음성 전사 경계.
+
+라우터는 이 모듈의 ``transcribe``만 호출한다. 추후 로컬 STT를 도입해도
+라우터와 보고서 흐름은 바꾸지 않고 이 경계 안의 구현만 교체한다.
+"""
+
+from typing import Any
+
+import httpx
+
+from app.core.config import settings
+
+_TRANSCRIPTIONS_URL = "https://api.openai.com/v1/audio/transcriptions"
+_CONTEXT = "한국어 영업 미팅입니다. 고객, 계약, 견적, 일정, 후속 조치를 정확히 전사하세요."
+_MAX_TRANSCRIPT_CHARS = 50_000
+
+
+class STTError(Exception):
+    """전사 공급자 호출이 실패했다. 메시지에 키·음성·전사문을 담지 않는다."""
+
+
+class STTNotConfigured(STTError):
+    """STT_API_KEY 또는 STT_MODEL이 설정되지 않았다."""
+
+
+async def transcribe(*, file_name: str, media_type: str, content: bytes) -> str:
+    """완성된 음성 파일을 전사해 텍스트만 반환한다."""
+    if not settings.stt_configured:
+        raise STTNotConfigured("stt_not_configured")
+
+    try:
+        async with httpx.AsyncClient(timeout=settings.stt_timeout_seconds) as client:
+            response = await client.post(
+                _TRANSCRIPTIONS_URL,
+                headers={"Authorization": f"Bearer {settings.stt_api_key.get_secret_value()}"},
+                data={
+                    "model": settings.stt_model,
+                    "language": "ko",
+                    "prompt": _CONTEXT,
+                },
+                files={"file": (file_name, content, media_type)},
+            )
+    except httpx.HTTPError as error:
+        raise STTError("stt_request_failed") from error
+
+    if response.status_code >= 400:
+        raise STTError("stt_provider_error")
+
+    try:
+        payload: Any = response.json()
+    except ValueError as error:
+        raise STTError("stt_response_not_json") from error
+
+    text = payload.get("text") if isinstance(payload, dict) else None
+    if not isinstance(text, str) or not text.strip():
+        raise STTError("empty_stt_output")
+    text = text.strip()
+    if len(text) > _MAX_TRANSCRIPT_CHARS:
+        # 기존 Report.transcript 한도와 맞추며 내용을 임의로 자르지는 않는다.
+        raise STTError("stt_output_too_long")
+    return text

--- a/backend/app/services/upload_guard.py
+++ b/backend/app/services/upload_guard.py
@@ -4,6 +4,7 @@
 어긋나면 거절한다. 단순화를 이유로 생략하지 않는다.
 """
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
 # 허용 형식만 둔다. 실행 가능한 형식과 압축 파일은 넣지 않는다.
@@ -30,6 +31,14 @@ class AllowedType:
     magic: tuple[bytes, ...]
 
 
+@dataclass(frozen=True)
+class AllowedAudioType:
+    extension: str
+    media_type: str
+    declared_media_types: frozenset[str]
+    has_signature: Callable[[bytes], bool]
+
+
 # 멀티에이전트 운영 플로우의 자료실 입력이 PDF·PPTX·DOCX 다. HTML 은 규약 13절에 따라
 # 인라인 실행 위험이 있어 받지 않는다.
 _ALLOWED: tuple[AllowedType, ...] = (
@@ -41,6 +50,58 @@ _ALLOWED: tuple[AllowedType, ...] = (
 _BY_EXTENSION = {allowed.extension: allowed for allowed in _ALLOWED}
 
 ALLOWED_EXTENSIONS = tuple(sorted(_BY_EXTENSION))
+
+
+def _is_mpeg_audio(content: bytes) -> bool:
+    if content.startswith(b"ID3"):
+        return True
+    return (
+        len(content) >= 2
+        and content[0] == 0xFF
+        and content[1] & 0xE0 == 0xE0
+        and content[1] & 0x06 != 0
+    )
+
+
+def _is_m4a(content: bytes) -> bool:
+    return len(content) >= 12 and content[4:8] == b"ftyp"
+
+
+def _is_wav(content: bytes) -> bool:
+    return len(content) >= 12 and content.startswith(b"RIFF") and content[8:12] == b"WAVE"
+
+
+def _is_webm(content: bytes) -> bool:
+    return content.startswith(b"\x1aE\xdf\xa3")
+
+
+_AUDIO_ALLOWED: tuple[AllowedAudioType, ...] = (
+    AllowedAudioType(
+        ".mp3",
+        "audio/mpeg",
+        frozenset(("audio/mpeg", "audio/mp3")),
+        _is_mpeg_audio,
+    ),
+    AllowedAudioType(
+        ".m4a",
+        "audio/mp4",
+        frozenset(("audio/mp4", "audio/m4a", "audio/x-m4a")),
+        _is_m4a,
+    ),
+    AllowedAudioType(
+        ".wav",
+        "audio/wav",
+        frozenset(("audio/wav", "audio/wave", "audio/x-wav")),
+        _is_wav,
+    ),
+    AllowedAudioType(
+        ".webm",
+        "audio/webm",
+        frozenset(("audio/webm",)),
+        _is_webm,
+    ),
+)
+_AUDIO_BY_EXTENSION = {allowed.extension: allowed for allowed in _AUDIO_ALLOWED}
 
 
 def _extension_of(file_name: str) -> str:
@@ -71,6 +132,30 @@ def check_upload(*, file_name: str, declared_media_type: str | None, content: by
     if not any(content.startswith(magic) for magic in allowed.magic):
         raise UploadRejected("file_signature_mismatch", 415)
 
+    return allowed
+
+
+def check_audio_upload(
+    *, file_name: str, declared_media_type: str | None, content: bytes
+) -> AllowedAudioType:
+    """STT가 받을 음성인지 확장자·MIME·signature를 함께 확인한다."""
+    name = file_name.strip()
+    if not name or "/" in name or "\\" in name or name in {".", ".."}:
+        raise UploadRejected("invalid_file_name", 422)
+
+    allowed = _AUDIO_BY_EXTENSION.get(_extension_of(name))
+    if allowed is None:
+        raise UploadRejected("unsupported_file_extension", 415)
+
+    if declared_media_type is not None:
+        declared = declared_media_type.split(";")[0].strip().lower()
+        if declared and declared not in allowed.declared_media_types:
+            raise UploadRejected("media_type_mismatch", 415)
+
+    if not content:
+        raise UploadRejected("empty_file", 422)
+    if not allowed.has_signature(content):
+        raise UploadRejected("file_signature_mismatch", 415)
     return allowed
 
 

--- a/backend/tests/test_transcriptions.py
+++ b/backend/tests/test_transcriptions.py
@@ -1,0 +1,144 @@
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from app.api.deps import get_current_member
+from app.core.config import settings
+from app.main import app
+from app.models.workspace import Member
+from app.services import stt
+
+ORIGIN = settings.cors_origin_list[0]
+WAV = b"RIFF" + b"\x24\x00\x00\x00" + b"WAVE"
+
+
+class _Response:
+    status_code = 200
+
+    def json(self):
+        return {"text": "고객과 다음 주 계약 일정을 논의했습니다."}
+
+
+class _OpenAIStub:
+    def __init__(self):
+        self.calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    async def post(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        return _Response()
+
+
+@pytest.fixture(autouse=True)
+def transcription_environment(monkeypatch):
+    member = Member(
+        id=uuid4(),
+        team_id=uuid4(),
+        display_name="합성 영업 담당자",
+        role_code="member",
+        job_title="영업 담당자",
+        active=True,
+    )
+
+    async def override_member():
+        return member
+
+    app.dependency_overrides[get_current_member] = override_member
+    monkeypatch.setattr(settings, "stt_api_key", SecretStr("synthetic-stt-key"))
+    yield
+    app.dependency_overrides.clear()
+
+
+def test_transcribes_valid_audio_through_openai(monkeypatch):
+    provider = _OpenAIStub()
+    monkeypatch.setattr(stt.httpx, "AsyncClient", lambda **_kwargs: provider)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/transcriptions",
+            headers={"Origin": ORIGIN},
+            files={"audio": ("meeting.wav", WAV, "audio/wav")},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"transcript": "고객과 다음 주 계약 일정을 논의했습니다."}
+    assert len(provider.calls) == 1
+    url, request = provider.calls[0]
+    assert url == "https://api.openai.com/v1/audio/transcriptions"
+    assert request["data"]["model"] == settings.stt_model
+    assert request["data"]["language"] == "ko"
+    assert request["files"]["file"] == ("meeting.wav", WAV, "audio/wav")
+
+
+@pytest.mark.parametrize(
+    ("file_name", "media_type", "content", "detail", "code"),
+    [
+        ("meeting.exe", "audio/wav", WAV, "unsupported_file_extension", 415),
+        ("meeting.wav", "image/png", WAV, "media_type_mismatch", 415),
+        ("meeting.wav", "audio/wav", b"MZ\x90\x00", "file_signature_mismatch", 415),
+        ("meeting.wav", "audio/wav", b"", "empty_file", 422),
+    ],
+)
+def test_rejects_invalid_audio_before_provider(
+    monkeypatch, file_name, media_type, content, detail, code
+):
+    called = False
+
+    async def never_transcribe(**_kwargs):
+        nonlocal called
+        called = True
+        return "호출되면 안 됩니다."
+
+    monkeypatch.setattr(stt, "transcribe", never_transcribe)
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/transcriptions",
+            headers={"Origin": ORIGIN},
+            files={"audio": (file_name, content, media_type)},
+        )
+
+    assert response.status_code == code
+    assert response.json() == {"detail": detail}
+    assert called is False
+
+
+def test_rejects_audio_over_configured_limit_before_provider(monkeypatch):
+    monkeypatch.setattr(settings, "stt_max_bytes", len(WAV) - 1)
+
+    async def never_transcribe(**_kwargs):
+        raise AssertionError("크기 검증 전에 공급자를 호출했습니다.")
+
+    monkeypatch.setattr(stt, "transcribe", never_transcribe)
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/transcriptions",
+            headers={"Origin": ORIGIN},
+            files={"audio": ("meeting.wav", WAV, "audio/wav")},
+        )
+
+    assert response.status_code == 413
+    assert response.json() == {"detail": "file_too_large"}
+
+
+def test_provider_failure_returns_only_safe_error(monkeypatch):
+    async def failed_transcription(**_kwargs):
+        raise stt.STTError("provider secret response")
+
+    monkeypatch.setattr(stt, "transcribe", failed_transcription)
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/transcriptions",
+            headers={"Origin": ORIGIN},
+            files={"audio": ("meeting.wav", WAV, "audio/wav")},
+        )
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "stt_unavailable"}
+    assert "secret" not in response.text


### PR DESCRIPTION
## 변경 요약

- 인증된 멤버가 음성 파일을 업로드해 한국어 전사문을 받는 POST /api/transcriptions를 추가했습니다.
- MP3, M4A, WAV, WebM의 확장자, MIME, 파일 시그니처와 최대 25 MiB 크기를 검증합니다.
- OpenAI 전사 호출을 app/services/stt.py에 분리하고 공급자 오류는 비밀정보가 없는 503 응답으로 변환합니다.
- STT 키, 모델, 타임아웃, 최대 크기를 서버 환경변수로 관리하며 음성 파일은 저장하지 않습니다.

## 검증

- DEBUG=false pytest -q tests/test_upload_guard.py tests/test_transcriptions.py — 14 passed
- 관련 파일 Ruff 검사 통과
- git diff --check 통과
- 고객 데이터가 아닌 5초 합성 WAV로 gpt-4o-transcribe 실제 호출 및 한국어 전사 성공
- 전체 변경 통합 상태에서 백엔드 테스트 — 143 passed, 2 skipped

## 영향 및 주의 사항

- 배포 환경에 STT_API_KEY가 필요하며 미설정 시 503을 반환합니다.
- 사용자 요청에 따라 원본 파일명을 유지해 OpenAI로 전달합니다. 음성 내용과 파일명에 고객 정보가 포함될 수 있으므로 운영 전 고객 동의, 개인정보 처리, 보존 및 리전 정책 검토가 필요합니다.
- 로컬 STT fallback은 구현하지 않았고 추후 교체 가능한 서비스 경계만 마련했습니다.
- 프론트 연동, DB 변경, 신규 패키지 의존성은 포함하지 않습니다.