### PR TITLE
백엔드·프론트엔드 AWS 수동 배포 워크플로 추가

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     paths:
       - 'backend/**'
+      - 'deploy/backend/**'
       - '.github/workflows/ci-backend.yml'
   push:
     branches: [develop, main]
     paths:
       - 'backend/**'
+      - 'deploy/backend/**'
       - '.github/workflows/ci-backend.yml'
 
 permissions:
@@ -45,3 +47,9 @@ jobs:
 
       - name: 테스트 (pytest)
         run: uv run pytest
+
+      - name: 배포 스크립트 검증
+        working-directory: .
+        run: |
+          bash -n deploy/backend/deploy.sh
+          bash deploy/backend/tests/runtime-environment-test.sh

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -25,6 +25,7 @@ jobs:
   deploy:
     name: Deploy backend to production
     runs-on: ubuntu-latest
+    environment: production
     timeout-minutes: 45
     permissions:
       id-token: write
@@ -270,6 +271,8 @@ jobs:
           fi
 
           short_sha="${DEPLOY_SHA:0:7}"
+          # Discord Markdown backticks are intentional literals; printf substitutes the values.
+          # shellcheck disable=SC2016
           description="$(printf '브랜치: `%s`\n커밋: `%s`\n실행자: `%s`\n[GitHub Actions 실행 보기](%s)' \
             "${DEPLOY_BRANCH}" "${short_sha}" "${DEPLOY_ACTOR}" "${RUN_URL}")"
 

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,303 @@
+name: Deploy Backend
+
+run-name: Deploy Backend · ${{ github.ref_name }} · ${{ github.sha }}
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: salesluv-backend-production
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: ap-northeast-2
+  AWS_ACCOUNT_ID: '816008167575'
+  AWS_ROLE_ARN: arn:aws:iam::816008167575:role/salesluv-github-actions-deploy-role
+  EC2_INSTANCE_ID: i-0464d8283887dd6f5
+  SSM_EXECUTION_TIMEOUT_SECONDS: '2100'
+  SSM_DELIVERY_TIMEOUT_SECONDS: '60'
+  SSM_POLL_TIMEOUT_SECONDS: '2250'
+  SSM_CANCEL_WAIT_SECONDS: '60'
+
+jobs:
+  deploy:
+    name: Deploy backend to production
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Restrict production deployment to develop
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          if [[ "${GITHUB_REF}" != "refs/heads/develop" ]]; then
+            echo "::error::Backend production deployment is allowed only from develop."
+            exit 1
+          fi
+
+      - name: Assume the AWS deployment role
+        uses: aws-actions/configure-aws-credentials@v6.2.3
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          allowed-account-ids: ${{ env.AWS_ACCOUNT_ID }}
+          role-session-name: github-actions-salesluv-backend
+
+      - name: Deploy the exact commit through SSM
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          export AWS_PAGER=""
+
+          command_id=""
+          command_finished="false"
+
+          wait_for_command_to_stop() {
+            local cancel_deadline=$((SECONDS + SSM_CANCEL_WAIT_SECONDS))
+            local cancel_status=""
+
+            while ((SECONDS < cancel_deadline)); do
+              if cancel_status="$(
+                aws ssm get-command-invocation \
+                  --region "${AWS_REGION}" \
+                  --command-id "${command_id}" \
+                  --instance-id "${EC2_INSTANCE_ID}" \
+                  --query 'Status' \
+                  --output text 2>/dev/null
+              )"; then
+                case "${cancel_status}" in
+                  Success|Cancelled|Failed|TimedOut)
+                    printf 'SSM command reached terminal state: %s\n' \
+                      "${cancel_status}"
+                    return 0
+                    ;;
+                esac
+              fi
+
+              sleep 5
+            done
+
+            return 1
+          }
+
+          cancel_unfinished_command() {
+            local exit_status=$?
+
+            trap - EXIT INT TERM
+            if [[ -n "${command_id}" && "${command_finished}" != "true" ]]; then
+              echo "Cancelling unfinished SSM command ${command_id}."
+              if aws ssm cancel-command \
+                  --region "${AWS_REGION}" \
+                  --command-id "${command_id}" >/dev/null 2>&1; then
+                if ! wait_for_command_to_stop; then
+                  echo "::warning::SSM command did not reach a terminal state within ${SSM_CANCEL_WAIT_SECONDS} seconds after cancellation."
+                fi
+              else
+                echo "::warning::Failed to request cancellation for SSM command ${command_id}."
+              fi
+            fi
+            exit "${exit_status}"
+          }
+
+          trap cancel_unfinished_command EXIT
+          trap 'exit 130' INT
+          trap 'exit 143' TERM
+
+          remote_command="$(cat <<'REMOTE_SCRIPT'
+          exec bash -s <<'REMOTE_BASH'
+          set -Eeuo pipefail
+
+          readonly REPO_DIR="/opt/salesluv"
+          readonly DEPLOY_SHA="__DEPLOY_SHA__"
+          deploy_script=""
+
+          cleanup_remote_command() {
+            if [[ -n "${deploy_script}" ]]; then
+              rm -f -- "${deploy_script}"
+            fi
+          }
+
+          trap cleanup_remote_command EXIT
+
+          git -C "${REPO_DIR}" fetch \
+            --no-tags \
+            --depth=1 \
+            origin \
+            "+refs/heads/develop:refs/remotes/origin/develop"
+
+          remote_develop_sha="$(git -C "${REPO_DIR}" rev-parse refs/remotes/origin/develop)"
+          if [[ "${remote_develop_sha}" != "${DEPLOY_SHA}" ]]; then
+            printf 'Refusing deployment: origin/develop is %s, requested SHA is %s.\n' \
+              "${remote_develop_sha}" "${DEPLOY_SHA}" >&2
+            exit 1
+          fi
+
+          deploy_script="$(mktemp /tmp/salesluv-backend-deploy.XXXXXX)"
+          git -C "${REPO_DIR}" show \
+            "${DEPLOY_SHA}:deploy/backend/deploy.sh" >"${deploy_script}"
+          chmod 0700 "${deploy_script}"
+          bash "${deploy_script}" "${DEPLOY_SHA}"
+          REMOTE_BASH
+          REMOTE_SCRIPT
+          )"
+          remote_command="${remote_command/__DEPLOY_SHA__/${GITHUB_SHA}}"
+
+          request_file="${RUNNER_TEMP}/salesluv-backend-send-command.json"
+          jq -n \
+            --arg instance_id "${EC2_INSTANCE_ID}" \
+            --arg comment "Deploy SalesLuv backend ${GITHUB_SHA}" \
+            --arg command "${remote_command}" \
+            --arg execution_timeout "${SSM_EXECUTION_TIMEOUT_SECONDS}" \
+            --argjson delivery_timeout "${SSM_DELIVERY_TIMEOUT_SECONDS}" \
+            '{
+              DocumentName: "AWS-RunShellScript",
+              InstanceIds: [$instance_id],
+              Comment: $comment,
+              TimeoutSeconds: $delivery_timeout,
+              Parameters: {
+                commands: [$command],
+                executionTimeout: [$execution_timeout]
+              }
+            }' > "${request_file}"
+
+          command_id="$(
+            aws ssm send-command \
+              --region "${AWS_REGION}" \
+              --cli-input-json "file://${request_file}" \
+              --query 'Command.CommandId' \
+              --output text
+          )"
+
+          printf 'SSM command started: %s\n' "${command_id}"
+
+          status="Pending"
+          response_code="-1"
+          poll_deadline=$((SECONDS + SSM_POLL_TIMEOUT_SECONDS))
+          while ((SECONDS < poll_deadline)); do
+            set +e
+            invocation="$(
+              aws ssm get-command-invocation \
+                --region "${AWS_REGION}" \
+                --command-id "${command_id}" \
+                --instance-id "${EC2_INSTANCE_ID}" \
+                --query '[Status, ResponseCode]' \
+                --output text 2>/dev/null
+            )"
+            invocation_exit_code=$?
+            set -e
+
+            if ((invocation_exit_code != 0)); then
+              sleep 5
+              continue
+            fi
+
+            read -r status response_code <<< "${invocation}"
+            case "${status}" in
+              Success|Cancelled|Failed|TimedOut)
+                command_finished="true"
+                break
+                ;;
+            esac
+
+            sleep 10
+          done
+
+          if [[ "${command_finished}" != "true" ]]; then
+            echo "::error::Timed out while waiting for the EC2 deployment command."
+            exit 1
+          fi
+
+          echo "----- EC2 deployment output -----"
+          aws ssm get-command-invocation \
+            --region "${AWS_REGION}" \
+            --command-id "${command_id}" \
+            --instance-id "${EC2_INSTANCE_ID}" \
+            --query 'StandardOutputContent' \
+            --output text || true
+
+          echo "----- EC2 deployment errors -----"
+          aws ssm get-command-invocation \
+            --region "${AWS_REGION}" \
+            --command-id "${command_id}" \
+            --instance-id "${EC2_INSTANCE_ID}" \
+            --query 'StandardErrorContent' \
+            --output text || true
+
+          printf 'Final SSM status: %s (response code: %s)\n' \
+            "${status}" "${response_code}"
+
+          if [[ "${status}" != "Success" || "${response_code}" != "0" ]]; then
+            echo "::error::Backend deployment failed on EC2."
+            exit 1
+          fi
+
+  notify:
+    name: Notify backend deployment result
+    needs: deploy
+    if: always()
+    runs-on: ubuntu-latest
+    permissions: {}
+    timeout-minutes: 5
+
+    steps:
+      - name: Send Discord notification
+        continue-on-error: true
+        shell: bash
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DEPLOY_RESULT: ${{ needs.deploy.result }}
+          DEPLOY_BRANCH: ${{ github.ref_name }}
+          DEPLOY_SHA: ${{ github.sha }}
+          DEPLOY_ACTOR: ${{ github.actor }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -Eeuo pipefail
+
+          if [[ -z "${DISCORD_WEBHOOK_URL}" ]]; then
+            echo "::warning::Discord webhook is not configured; skipping notification."
+            exit 0
+          fi
+
+          if [[ "${DEPLOY_RESULT}" == "success" ]]; then
+            title='✅ 백엔드 배포 완료'
+          else
+            title='❌ 백엔드 배포 실패'
+          fi
+
+          short_sha="${DEPLOY_SHA:0:7}"
+          description="$(printf '브랜치: `%s`\n커밋: `%s`\n실행자: `%s`\n[GitHub Actions 실행 보기](%s)' \
+            "${DEPLOY_BRANCH}" "${short_sha}" "${DEPLOY_ACTOR}" "${RUN_URL}")"
+
+          if ! payload="$(
+            jq -n \
+              --arg title "${title}" \
+              --arg description "${description}" \
+              '{
+                embeds: [{title: $title, description: $description}],
+                allowed_mentions: {parse: []}
+              }'
+          )"; then
+            echo "::warning::Failed to build the Discord notification payload."
+            exit 0
+          fi
+
+          if ! curl --disable \
+              --fail \
+              --silent \
+              --retry 2 \
+              --retry-delay 1 \
+              --retry-max-time 30 \
+              --connect-timeout 5 \
+              --max-time 10 \
+              --header 'Content-Type: application/json' \
+              --data-binary "${payload}" \
+              --output /dev/null \
+              "${DISCORD_WEBHOOK_URL}" 2>/dev/null; then
+            echo "::warning::Failed to send the Discord deployment notification."
+            exit 0
+          fi

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -24,6 +24,7 @@ jobs:
   configuration:
     name: Prepare frontend build configuration
     runs-on: ubuntu-latest
+    environment: production
     timeout-minutes: 10
     permissions:
       id-token: write
@@ -232,6 +233,8 @@ jobs:
     steps:
       - name: Check out the deployment commit
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -276,6 +279,7 @@ jobs:
     name: Deploy frontend to production
     needs: build
     runs-on: ubuntu-latest
+    environment: production
     timeout-minutes: 30
     permissions:
       id-token: write
@@ -616,6 +620,8 @@ jobs:
           fi
 
           short_sha="${DEPLOY_SHA:0:7}"
+          # Discord Markdown backticks are intentional literals; printf substitutes the values.
+          # shellcheck disable=SC2016
           description="$(printf '브랜치: `%s`\n커밋: `%s`\n실행자: `%s`\n[GitHub Actions 실행 보기](%s)' \
             "${DEPLOY_BRANCH}" "${short_sha}" "${DEPLOY_ACTOR}" "${RUN_URL}")"
 

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,649 @@
+name: Deploy Frontend
+
+run-name: Deploy Frontend · ${{ github.ref_name }} · ${{ github.sha }}
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: salesluv-frontend-production
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: ap-northeast-2
+  AWS_ACCOUNT_ID: "816008167575"
+  AWS_ROLE_ARN: arn:aws:iam::816008167575:role/SalesLuvFrontendDeployRole
+  FRONTEND_BUCKET: salesluv-frontend-prod-816008167575-ap-northeast-2-an
+  CLOUDFRONT_DISTRIBUTION_ID: E27EQ7X9F57Z1P
+  FRONTEND_ENV_PARAMETER: /salesluv/production/frontend/env
+  AWS_PAGER: ""
+
+jobs:
+  configuration:
+    name: Prepare frontend build configuration
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+    outputs:
+      validated_build_environment: ${{ steps.frontend_environment.outputs.validated_build_environment }}
+
+    steps:
+      - name: Restrict production deployment to develop
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          if [[ "${GITHUB_REF}" != "refs/heads/develop" ]]; then
+            echo "::error::Frontend production deployment is allowed only from develop."
+            exit 1
+          fi
+
+      - name: Assume the AWS configuration role
+        uses: aws-actions/configure-aws-credentials@v6.2.3
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          allowed-account-ids: ${{ env.AWS_ACCOUNT_ID }}
+          role-session-name: github-actions-salesluv-frontend-configuration
+
+      # 검증 스크립트는 node:crypto / node:fs 만 쓰므로 러너에 기본 설치된 Node 로 충분하다.
+      # setup-node 를 두면 .nvmrc 와 어긋나는 버전을 손으로 관리해야 한다.
+      - name: Fetch and validate frontend build environment
+        id: frontend_environment
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          umask 077
+
+          env_file="$(mktemp "${RUNNER_TEMP}/salesluv-frontend-env.XXXXXX")"
+
+          cleanup_env_file() {
+            rm -f -- "${env_file}"
+          }
+
+          trap cleanup_env_file EXIT
+          chmod 0600 "${env_file}"
+
+          aws ssm get-parameter \
+            --region "${AWS_REGION}" \
+            --name "${FRONTEND_ENV_PARAMETER}" \
+            --with-decryption \
+            --query 'Parameter.Value' \
+            --output text >"${env_file}"
+
+          if [[ ! -s "${env_file}" ]]; then
+            echo "::error::The frontend environment parameter is empty."
+            exit 1
+          fi
+
+          FRONTEND_ENV_FILE="${env_file}" node <<'NODE'
+          const crypto = require('node:crypto');
+          const fs = require('node:fs');
+
+          const parameterPath = process.env.FRONTEND_ENV_FILE;
+          const githubOutputPath = process.env.GITHUB_OUTPUT;
+
+          function reject(lineNumber, reason) {
+            const location = lineNumber > 0 ? ` at line ${lineNumber}` : '';
+            console.error(
+              `::error::Invalid frontend environment parameter${location}: ${reason}.`,
+            );
+            process.exit(1);
+          }
+
+          function findClosingQuote(value, quote) {
+            for (let index = 1; index < value.length; index += 1) {
+              if (value[index] !== quote) {
+                continue;
+              }
+
+              let backslashes = 0;
+              for (
+                let previous = index - 1;
+                previous >= 0 && value[previous] === '\\';
+                previous -= 1
+              ) {
+                backslashes += 1;
+              }
+
+              if (backslashes % 2 === 0) {
+                return index;
+              }
+            }
+
+            return -1;
+          }
+
+          function parseValue(rawValue, lineNumber) {
+            const value = rawValue.trim();
+            if (value === '') {
+              return '';
+            }
+
+            const quote = value[0];
+            if (quote !== "'" && quote !== '"' && quote !== '`') {
+              const commentIndex = value.indexOf('#');
+              return value
+                .slice(0, commentIndex === -1 ? value.length : commentIndex)
+                .trim();
+            }
+
+            const closingQuote = findClosingQuote(value, quote);
+            if (closingQuote === -1) {
+              reject(lineNumber, 'unterminated quoted value');
+            }
+
+            const trailingText = value.slice(closingQuote + 1).trim();
+            if (trailingText !== '' && !trailingText.startsWith('#')) {
+              reject(lineNumber, 'unexpected text after the quoted value');
+            }
+
+            const parsed = value.slice(1, closingQuote);
+            if (quote === '"') {
+              return parsed.replace(/\\n/g, '\n').replace(/\\r/g, '\r');
+            }
+
+            return parsed;
+          }
+
+          if (!parameterPath || !githubOutputPath) {
+            reject(0, 'the runner environment is incomplete');
+          }
+
+          const parameter = fs.readFileSync(parameterPath, 'utf8');
+          if (parameter.includes('\0')) {
+            reject(0, 'NUL bytes are not allowed');
+          }
+
+          const entries = new Map();
+          const lines = parameter.split('\n');
+
+          for (let index = 0; index < lines.length; index += 1) {
+            const lineNumber = index + 1;
+            const line = lines[index].replace(/\r$/, '');
+
+            if (/^\s*(?:#.*)?$/.test(line)) {
+              continue;
+            }
+
+            const assignment = line.match(
+              /^\s*(?:export[ \t]+)?(VITE_[A-Za-z0-9_]+)[ \t]*=[ \t]*(.*)$/,
+            );
+            if (!assignment) {
+              reject(
+                lineNumber,
+                'only VITE_* dotenv KEY=VALUE assignments are allowed',
+              );
+            }
+
+            const [, key, rawValue] = assignment;
+            if (entries.has(key)) {
+              reject(lineNumber, `duplicate key ${key}`);
+            }
+
+            entries.set(key, parseValue(rawValue, lineNumber));
+          }
+
+          if (
+            !entries.has('VITE_API_BASE_URL') ||
+            entries.get('VITE_API_BASE_URL') === ''
+          ) {
+            reject(0, 'VITE_API_BASE_URL is required and must not be empty');
+          }
+
+          let environmentFile = '';
+          for (const [key, value] of entries) {
+            let delimiter;
+            do {
+              delimiter = `SALESLUV_${crypto.randomUUID().replaceAll('-', '')}`;
+            } while (value.split(/\r?\n/).includes(delimiter));
+
+            environmentFile += `${key}<<${delimiter}\n${value}\n${delimiter}\n`;
+          }
+
+          let outputDelimiter;
+          do {
+            outputDelimiter = `SALESLUV_OUTPUT_${crypto.randomUUID().replaceAll('-', '')}`;
+          } while (environmentFile.split(/\r?\n/).includes(outputDelimiter));
+
+          const output =
+            `validated_build_environment<<${outputDelimiter}\n` +
+            environmentFile +
+            `${outputDelimiter}\n`;
+
+          fs.appendFileSync(githubOutputPath, output, {
+            encoding: 'utf8',
+            mode: 0o600,
+          });
+          console.log(`Validated ${entries.size} VITE_* build variable(s).`);
+          NODE
+
+  build:
+    name: Build frontend artifact
+    needs: configuration
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out the deployment commit
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        shell: bash
+        run: npm ci
+
+      - name: Import validated frontend build environment
+        shell: bash
+        env:
+          VALIDATED_BUILD_ENVIRONMENT: ${{ needs.configuration.outputs.validated_build_environment }}
+        run: |
+          set -Eeuo pipefail
+
+          if [[ -z "${VALIDATED_BUILD_ENVIRONMENT:-}" ]]; then
+            echo "::error::Validated frontend build environment is missing."
+            exit 1
+          fi
+
+          printf '%s\n' "${VALIDATED_BUILD_ENVIRONMENT}" >>"${GITHUB_ENV}"
+
+      - name: Build frontend
+        working-directory: frontend
+        shell: bash
+        run: npm run build
+
+      - name: Upload frontend artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: salesluv-frontend-dist
+          path: frontend/dist
+          if-no-files-found: error
+          retention-days: 1
+
+  deploy:
+    name: Deploy frontend to production
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download frontend artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: salesluv-frontend-dist
+          path: frontend/dist
+
+      - name: Validate frontend artifact
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          if [[ ! -d frontend/dist/assets ]]; then
+            echo "::error::Expected frontend/dist/assets in the build artifact."
+            exit 1
+          fi
+
+          if [[ ! -f frontend/dist/index.html ]]; then
+            echo "::error::Expected frontend/dist/index.html in the build artifact."
+            exit 1
+          fi
+
+      - name: Assume the AWS deployment role
+        uses: aws-actions/configure-aws-credentials@v6.2.3
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          allowed-account-ids: ${{ env.AWS_ACCOUNT_ID }}
+          role-session-name: github-actions-salesluv-frontend-deployment
+
+      - name: Publish frontend and prune old assets
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          umask 077
+
+          readonly asset_prefix="assets/"
+          readonly marker_prefix="_salesluv/frontend-releases/"
+
+          if [[ ! "${GITHUB_RUN_ID}" =~ ^[0-9]+$ || \
+                ! "${GITHUB_RUN_ATTEMPT}" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid GitHub run identity for the release marker."
+            exit 1
+          fi
+
+          marker_key="${marker_prefix}${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.marker"
+
+          if [[ "${marker_key}" != "${marker_prefix}"* || \
+                "${marker_key}" != *.marker ]]; then
+            echo "::error::Refusing to use a release marker outside the protected prefix."
+            exit 1
+          fi
+
+          temp_dir="$(mktemp -d "${RUNNER_TEMP}/salesluv-frontend-retention.XXXXXX")"
+          chmod 0700 "${temp_dir}"
+
+          empty_marker_body="${temp_dir}/empty-marker"
+          markers_json="${temp_dir}/markers.json"
+          sorted_markers_json="${temp_dir}/sorted-markers.json"
+          assets_json="${temp_dir}/assets.json"
+          asset_targets_json="${temp_dir}/asset-targets.json"
+          marker_targets_json="${temp_dir}/marker-targets.json"
+          delete_request_json="${temp_dir}/delete-request.json"
+          delete_response_json="${temp_dir}/delete-response.json"
+          temp_files=(
+            "${empty_marker_body}"
+            "${markers_json}"
+            "${sorted_markers_json}"
+            "${assets_json}"
+            "${asset_targets_json}"
+            "${marker_targets_json}"
+            "${delete_request_json}"
+            "${delete_response_json}"
+          )
+
+          for temp_file in "${temp_files[@]}"; do
+            : >"${temp_file}"
+            chmod 0600 "${temp_file}"
+          done
+
+          cleanup_local_files() {
+            if ! rm -f -- "${temp_files[@]}"; then
+              echo "::warning::Failed to remove one or more local retention files."
+            fi
+            if ! rmdir -- "${temp_dir}"; then
+              echo "::warning::Failed to remove the local retention directory."
+            fi
+          }
+
+          finish_publish() {
+            local publish_exit_code=$?
+
+            trap - EXIT INT TERM
+            cleanup_local_files
+            exit "${publish_exit_code}"
+          }
+
+          delete_object_batches() {
+            local targets_file="$1"
+            local target_type="$2"
+            local target_count=""
+            local offset=0
+
+            target_count="$(jq -er 'length' "${targets_file}")"
+            if [[ ! "${target_count}" =~ ^[0-9]+$ ]]; then
+              echo "::error::Invalid ${target_type} deletion count."
+              return 1
+            fi
+
+            for ((offset = 0; offset < target_count; offset += 1000)); do
+              jq \
+                --argjson offset "${offset}" \
+                '{
+                  Objects: .[$offset:($offset + 1000)],
+                  Quiet: true
+                }' \
+                "${targets_file}" >"${delete_request_json}"
+
+              case "${target_type}" in
+                assets)
+                  if ! jq -e \
+                      --arg prefix "${asset_prefix}" \
+                      '(
+                        ((.Objects | length) > 0) and
+                        ((.Objects | length) <= 1000) and
+                        all(
+                          .Objects[];
+                          ((.Key | type) == "string") and
+                          (.Key | startswith($prefix))
+                        )
+                      )' \
+                      "${delete_request_json}" >/dev/null; then
+                    echo "::error::Refusing an asset deletion outside assets/."
+                    return 1
+                  fi
+                  ;;
+                markers)
+                  if ! jq -e \
+                      --arg prefix "${marker_prefix}" \
+                      '(
+                        ((.Objects | length) > 0) and
+                        ((.Objects | length) <= 1000) and
+                        all(
+                          .Objects[];
+                          ((.Key | type) == "string") and
+                          (.Key | startswith($prefix)) and
+                          (.Key | endswith(".marker"))
+                        )
+                      )' \
+                      "${delete_request_json}" >/dev/null; then
+                    echo "::error::Refusing a marker deletion outside the protected prefix."
+                    return 1
+                  fi
+                  ;;
+                *)
+                  echo "::error::Unknown retention deletion target type."
+                  return 1
+                  ;;
+              esac
+
+              aws s3api delete-objects \
+                --region "${AWS_REGION}" \
+                --bucket "${FRONTEND_BUCKET}" \
+                --delete "file://${delete_request_json}" \
+                --output json >"${delete_response_json}"
+
+              if ! jq -e \
+                  '((.Errors // []) | length) == 0' \
+                  "${delete_response_json}" >/dev/null; then
+                echo "::error::S3 reported one or more ${target_type} deletion failures."
+                return 1
+              fi
+            done
+          }
+
+          trap finish_publish EXIT
+          trap 'exit 130' INT
+          trap 'exit 143' TERM
+
+          # sync 로 바꾸지 말 것. 아래 보존 로직이 LastModified 로 세대를 가르므로,
+          # 내용이 같아도 매번 다시 올려 현재 자산의 타임스탬프를 갱신해야 한다.
+          # sync 는 안 바뀐 청크를 건너뛰어 아직 서비스 중인 자산을 삭제 대상으로 만든다.
+          aws s3 cp \
+            frontend/dist/assets/ \
+            "s3://${FRONTEND_BUCKET}/assets/" \
+            --recursive \
+            --cache-control 'public,max-age=31536000,immutable' \
+            --only-show-errors
+
+          aws s3 sync \
+            frontend/dist/ \
+            "s3://${FRONTEND_BUCKET}/" \
+            --delete \
+            --exclude 'assets/*' \
+            --exclude '_salesluv/*' \
+            --cache-control 'no-cache,no-store,must-revalidate' \
+            --only-show-errors
+
+          aws cloudfront create-invalidation \
+            --distribution-id "${CLOUDFRONT_DISTRIBUTION_ID}" \
+            --paths '/*' >/dev/null
+
+          aws s3api put-object \
+            --region "${AWS_REGION}" \
+            --bucket "${FRONTEND_BUCKET}" \
+            --key "${marker_key}" \
+            --body "fileb://${empty_marker_body}" >/dev/null
+
+          aws s3api list-objects-v2 \
+            --region "${AWS_REGION}" \
+            --bucket "${FRONTEND_BUCKET}" \
+            --prefix "${marker_prefix}" \
+            --output json >"${markers_json}"
+
+          jq \
+            --arg marker_prefix "${marker_prefix}" \
+            '[
+              (.Contents // [])[]
+              | select(
+                  ((.Key | type) == "string") and
+                  (.Key | startswith($marker_prefix)) and
+                  (.Key | endswith(".marker")) and
+                  ((.LastModified | type) == "string")
+                )
+              | {Key, LastModified}
+            ]
+            | sort_by([.LastModified, .Key])
+            | reverse' \
+            "${markers_json}" >"${sorted_markers_json}"
+
+          marker_count="$(jq -er 'length' "${sorted_markers_json}")"
+          current_marker_count="$(
+            jq -er \
+              --arg marker_key "${marker_key}" \
+              '[.[] | select(.Key == $marker_key)] | length' \
+              "${sorted_markers_json}"
+          )"
+          # index 는 못 찾으면 null 이고, jq -e 는 null 에 exit 1 을 낸다.
+          # 그대로 두면 set -e 가 아래 에러 메시지 전에 스텝을 죽인다.
+          current_marker_position="$(
+            jq -r \
+              --arg marker_key "${marker_key}" \
+              'map(.Key) | index($marker_key) // -1' \
+              "${sorted_markers_json}"
+          )"
+
+          if [[ ! "${marker_count}" =~ ^[0-9]+$ || \
+                "${current_marker_count}" != "1" || \
+                ! "${current_marker_position}" =~ ^[0-9]+$ || \
+                "${current_marker_position}" -ge 3 ]]; then
+            echo "::error::The committed release marker is missing from the newest generations."
+            exit 1
+          fi
+
+          if ((marker_count <= 3)); then
+            printf 'Release retention: %d generation(s); no cleanup required.\n' \
+              "${marker_count}"
+            exit 0
+          fi
+
+          cutoff="$(jq -er '.[3].LastModified' "${sorted_markers_json}")"
+
+          aws s3api list-objects-v2 \
+            --region "${AWS_REGION}" \
+            --bucket "${FRONTEND_BUCKET}" \
+            --prefix "${asset_prefix}" \
+            --output json >"${assets_json}"
+
+          jq \
+            --arg asset_prefix "${asset_prefix}" \
+            --arg cutoff "${cutoff}" \
+            '[
+              (.Contents // [])[]
+              | select(
+                  ((.Key | type) == "string") and
+                  (.Key | startswith($asset_prefix)) and
+                  ((.LastModified | type) == "string") and
+                  (.LastModified <= $cutoff)
+                )
+              | {Key}
+            ]' \
+            "${assets_json}" >"${asset_targets_json}"
+
+          jq \
+            '.[3:] | map({Key: .Key})' \
+            "${sorted_markers_json}" >"${marker_targets_json}"
+
+          asset_delete_count="$(jq -er 'length' "${asset_targets_json}")"
+          marker_delete_count="$(jq -er 'length' "${marker_targets_json}")"
+          printf 'Release retention: deleting %d old asset object(s) and %d old marker(s).\n' \
+            "${asset_delete_count}" "${marker_delete_count}"
+
+          delete_object_batches "${asset_targets_json}" assets
+          delete_object_batches "${marker_targets_json}" markers
+
+  notify:
+    name: Notify Discord of deployment result
+    needs:
+      - configuration
+      - build
+      - deploy
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+
+    steps:
+      - name: Send Discord notification
+        continue-on-error: true
+        shell: bash
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          CONFIGURATION_RESULT: ${{ needs.configuration.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          DEPLOY_RESULT: ${{ needs.deploy.result }}
+          DEPLOY_BRANCH: ${{ github.ref_name }}
+          DEPLOY_SHA: ${{ github.sha }}
+          DEPLOY_ACTOR: ${{ github.actor }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -Eeuo pipefail
+
+          if [[ -z "${DISCORD_WEBHOOK_URL:-}" ]]; then
+            echo "::warning::Discord webhook is not configured; skipping notification."
+            exit 0
+          fi
+
+          if [[ "${CONFIGURATION_RESULT}" == "success" && \
+                "${BUILD_RESULT}" == "success" && \
+                "${DEPLOY_RESULT}" == "success" ]]; then
+            title='✅ 프론트엔드 배포 완료'
+          else
+            title='❌ 프론트엔드 배포 실패'
+          fi
+
+          short_sha="${DEPLOY_SHA:0:7}"
+          description="$(printf '브랜치: `%s`\n커밋: `%s`\n실행자: `%s`\n[GitHub Actions 실행 보기](%s)' \
+            "${DEPLOY_BRANCH}" "${short_sha}" "${DEPLOY_ACTOR}" "${RUN_URL}")"
+
+          if ! payload="$(
+            jq -n \
+              --arg title "${title}" \
+              --arg description "${description}" \
+              '{
+                embeds: [{title: $title, description: $description}],
+                allowed_mentions: {parse: []}
+              }'
+          )"; then
+            echo "::warning::Failed to build the Discord notification payload."
+            exit 0
+          fi
+
+          if ! curl --disable \
+              --fail \
+              --silent \
+              --retry 2 \
+              --retry-delay 1 \
+              --retry-max-time 30 \
+              --connect-timeout 5 \
+              --max-time 10 \
+              --header 'Content-Type: application/json' \
+              --data-binary "${payload}" \
+              --output /dev/null \
+              "${DISCORD_WEBHOOK_URL}" 2>/dev/null; then
+            echo "::warning::Failed to send the Discord deployment notification."
+            exit 0
+          fi

--- a/deploy/backend/deploy.sh
+++ b/deploy/backend/deploy.sh
@@ -12,26 +12,46 @@ readonly AWS_REGION="ap-northeast-2"
 readonly LOCK_FILE="/var/lock/salesluv-backend-deploy.lock"
 
 readonly IMAGE_REPOSITORY="salesluv-backend"
-readonly PRODUCTION_CONTAINER="salesluv-backend"
-readonly CANDIDATE_CONTAINER="salesluv-backend-candidate"
-readonly PRODUCTION_PORT="8000"
-readonly CANDIDATE_PORT="18000"
+readonly LEGACY_PRODUCTION_CONTAINER="salesluv-backend"
+readonly LEGACY_CANDIDATE_CONTAINER="salesluv-backend-candidate"
+readonly SLOT_8000_CONTAINER="salesluv-backend-8000"
+readonly SLOT_18000_CONTAINER="salesluv-backend-18000"
+readonly BACKEND_PORT_A="8000"
+readonly BACKEND_PORT_B="18000"
+
+# Host Nginx must proxy_pass to http://salesluv_backend. This dedicated fragment
+# must contain exactly one loopback server on BACKEND_PORT_A or BACKEND_PORT_B.
+readonly NGINX_UPSTREAM_NAME="salesluv_backend"
+readonly NGINX_UPSTREAM_FILE="/etc/nginx/conf.d/salesluv-backend-upstream.conf"
+readonly CONTAINER_DRAIN_SECONDS="10"
+readonly CONTAINER_STOP_TIMEOUT_SECONDS="30"
 
 readonly HEALTH_ATTEMPTS="30"
 readonly HEALTH_DELAY_SECONDS="2"
 readonly HEALTH_TIMEOUT_SECONDS="5"
 
+readonly DOTENV_KEY_MISSING_STATUS="10"
+readonly DOTENV_KEY_DUPLICATE_STATUS="11"
+readonly CONTAINER_STATE_ERROR_STATUS="2"
+
 TEMP_ENV_FILE=""
 OLD_ENV_FILE=""
+TEMP_UPSTREAM_FILE=""
+OLD_UPSTREAM_FILE=""
 RELEASE_DIR=""
 BACKEND_CONTEXT=""
 OLD_IMAGE=""
-OLD_CONTAINER_ID=""
 NEW_IMAGE_ID=""
+ACTIVE_CONTAINER=""
+ACTIVE_PORT=""
+NEW_CONTAINER=""
+NEW_PORT=""
 ENV_REPLACED="false"
 IMAGE_BUILT="false"
 PROMOTION_STARTED="false"
 ROLLBACK_ATTEMPTED="false"
+UPSTREAM_CHANGE_PENDING="false"
+UPSTREAM_SWITCHED="false"
 DEPLOY_SUCCEEDED="false"
 
 die() {
@@ -81,7 +101,8 @@ restore_previous_environment() {
     ENV_REPLACED="false"
 }
 
-# 키가 정확히 한 번만 나올 때 그 값을 출력한다. 없거나 중복이면 아무것도 출력하지 않는다.
+# Print the unmodified value only when the key is assigned exactly once.
+# Distinct statuses separate a missing key from a duplicated one.
 dotenv_value() {
     local dotenv_file="$1"
     local expected_key="$2"
@@ -97,7 +118,7 @@ dotenv_value() {
             }
 
             key = substr(line, 1, separator - 1)
-            gsub(/^[[:space:]]+|[[:space:]]+$/, "", key)
+            sub(/^[[:space:]]+/, "", key)
             if (key != expected_key) {
                 next
             }
@@ -108,37 +129,357 @@ dotenv_value() {
             matched_value = value
         }
         END {
-            if (matches == 1) {
-                print matched_value
+            if (matches == 0) {
+                exit 10
             }
+            if (matches > 1) {
+                exit 11
+            }
+            printf "%s", matched_value
         }
     ' "${dotenv_file}"
 }
 
-validate_runtime_environment() {
+dotenv_value_form() {
+    local value="$1"
+
+    case "${value}" in
+        \"*|*\") printf 'double-quoted form' ;;
+        \'*|*\') printf 'single-quoted form' ;;
+        \`*|*\`) printf 'backtick-quoted form' ;;
+        [[:space:]]*|*[[:space:]]) printf 'form with surrounding whitespace' ;;
+        *'#'*) printf 'form with literal inline-comment text' ;;
+        *'${'*) printf 'interpolation-like literal form' ;;
+        *) printf 'different unquoted literal form' ;;
+    esac
+}
+
+deployment_prerequisite_value() {
     local dotenv_file="$1"
-    local required_key
+    local expected_key="$2"
+    local prerequisite_group="$3"
+    local status
     local value
 
-    for required_key in \
-        APP_ENV \
-        DEBUG \
-        CORS_ORIGINS \
-        DATABASE_URL \
-        SUPABASE_PUBLISHABLE_KEY; do
-        value="$(dotenv_value "${dotenv_file}" "${required_key}")"
+    if value="$(dotenv_value "${dotenv_file}" "${expected_key}")"; then
         [[ -n "${value}" ]] \
-            || die "required environment key is missing or empty: ${required_key}"
+            || die "${prerequisite_group} key is present but empty: ${expected_key}"
+        printf '%s' "${value}"
+        return 0
+    else
+        status=$?
+    fi
 
-        case "${required_key}" in
-            APP_ENV)
-                [[ "${value}" == "production" ]] || die "APP_ENV must be production"
-                ;;
-            DEBUG)
-                [[ "${value}" == "false" ]] || die "DEBUG must be false"
-                ;;
-        esac
+    case "${status}" in
+        "${DOTENV_KEY_MISSING_STATUS}")
+            die "${prerequisite_group} key is missing: ${expected_key}"
+            ;;
+        "${DOTENV_KEY_DUPLICATE_STATUS}")
+            die "${prerequisite_group} key is duplicated: ${expected_key}"
+            ;;
+        *)
+            die "unable to read ${prerequisite_group} key: ${expected_key}"
+            ;;
+    esac
+}
+
+validate_dotenv_syntax() {
+    local dotenv_file="$1"
+
+    if ! awk '
+        {
+            line = $0
+            sub(/\r$/, "", line)
+            if (line ~ /^[[:space:]]*(#|$)/) {
+                next
+            }
+
+            separator = index(line, "=")
+            if (separator == 0) {
+                printf "Invalid runtime environment entry at line %d: explicit KEY=value is required.\n", NR > "/dev/stderr"
+                invalid = 1
+                exit
+            }
+
+            key = substr(line, 1, separator - 1)
+            sub(/^[[:space:]]+/, "", key)
+            if (key !~ /^[A-Za-z_][A-Za-z0-9_]*$/) {
+                printf "Invalid runtime environment key syntax at line %d.\n", NR > "/dev/stderr"
+                invalid = 1
+                exit
+            }
+        }
+        END {
+            if (invalid) {
+                exit 1
+            }
+        }
+    ' "${dotenv_file}"; then
+        die "runtime environment file has invalid dotenv syntax"
+    fi
+}
+
+# 배포 전제 조건은 Settings 필드를 그대로 복제하지 않고 의미로 나눈다.
+# 새 기능을 배포 필수로 바꿀 때는 이 함수, backend/app/core/config.py,
+# 배포 설계 문서, SSM 파라미터, 준비 상태 프로브를 함께 갱신한다.
+validate_runtime_environment() {
+    local dotenv_file="$1"
+    local feature_key
+    local value
+
+    validate_dotenv_syntax "${dotenv_file}"
+
+    # 스키마 필수: Settings에 기본값이 없어 부재 시 애플리케이션이 뜨지 않는다.
+    value="$(deployment_prerequisite_value \
+        "${dotenv_file}" APP_ENV "schema-required")" || return 1
+    [[ "${value}" == "production" ]] \
+        || die "APP_ENV must be the unquoted literal production; $(
+            dotenv_value_form "${value}"
+        ) was provided"
+
+    # 프로덕션 보안 조건
+    value="$(deployment_prerequisite_value \
+        "${dotenv_file}" DEBUG "production-security")" || return 1
+    [[ "${value}" == "false" ]] \
+        || die "DEBUG must be the unquoted literal false; $(
+            dotenv_value_form "${value}"
+        ) was provided"
+    deployment_prerequisite_value \
+        "${dotenv_file}" CORS_ORIGINS "production-security" >/dev/null || return 1
+
+    # 런타임 기능 조건: /api/health/db 와 Supabase 인증이 의존한다.
+    for feature_key in DATABASE_URL SUPABASE_PUBLISHABLE_KEY; do
+        deployment_prerequisite_value \
+            "${dotenv_file}" "${feature_key}" "deployed-feature" >/dev/null \
+            || return 1
     done
+}
+
+read_backend_upstream_port() {
+    local upstream_file="$1"
+
+    awk \
+        -v port_a="${BACKEND_PORT_A}" \
+        -v port_b="${BACKEND_PORT_B}" '
+        {
+            line = $0
+            sub(/\r$/, "", line)
+            sub(/[[:space:]]*#.*/, "", line)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+            gsub(/[[:space:]]+/, " ", line)
+
+            if (line !~ /^server /) {
+                next
+            }
+
+            if (line == "server 127.0.0.1:" port_a ";") {
+                matches++
+                matched_port = port_a
+            } else if (line == "server 127.0.0.1:" port_b ";") {
+                matches++
+                matched_port = port_b
+            } else {
+                invalid_server = 1
+            }
+        }
+        END {
+            if (invalid_server || matches != 1) {
+                exit 1
+            }
+            print matched_port
+        }
+    ' "${upstream_file}"
+}
+
+validated_backend_upstream_port() {
+    local nginx_configuration
+    local upstream_port
+
+    [[ -f "${NGINX_UPSTREAM_FILE}" && ! -L "${NGINX_UPSTREAM_FILE}" ]] \
+        || die "Nginx upstream file is missing or is not a regular file: ${NGINX_UPSTREAM_FILE}"
+    [[ "$(grep -Ec \
+        "^[[:space:]]*upstream[[:space:]]+${NGINX_UPSTREAM_NAME}[[:space:]]*\\{" \
+        "${NGINX_UPSTREAM_FILE}")" == "1" ]] \
+        || die "Nginx upstream file must define ${NGINX_UPSTREAM_NAME} exactly once"
+
+    upstream_port="$(read_backend_upstream_port "${NGINX_UPSTREAM_FILE}")" \
+        || die "Nginx upstream must contain exactly one supported loopback backend server"
+
+    nginx_configuration="$(nginx -T 2>&1)" \
+        || die "Nginx configuration is invalid before deployment"
+    grep -Eq \
+        "^[[:space:]]*proxy_pass[[:space:]]+http://${NGINX_UPSTREAM_NAME}([/;]|[[:space:]])" \
+        <<<"${nginx_configuration}" \
+        || die "Nginx does not proxy requests through ${NGINX_UPSTREAM_NAME}"
+    grep -Eq \
+        "^[[:space:]]*server[[:space:]]+127\\.0\\.0\\.1:${upstream_port}[[:space:]]*;" \
+        <<<"${nginx_configuration}" \
+        || die "Nginx configuration dump does not contain backend port ${upstream_port}"
+
+    printf '%s' "${upstream_port}"
+}
+
+slot_container_for_port() {
+    case "$1" in
+        "${BACKEND_PORT_A}") printf '%s' "${SLOT_8000_CONTAINER}" ;;
+        "${BACKEND_PORT_B}") printf '%s' "${SLOT_18000_CONTAINER}" ;;
+        *) return 1 ;;
+    esac
+}
+
+other_backend_port() {
+    case "$1" in
+        "${BACKEND_PORT_A}") printf '%s' "${BACKEND_PORT_B}" ;;
+        "${BACKEND_PORT_B}") printf '%s' "${BACKEND_PORT_A}" ;;
+        *) return 1 ;;
+    esac
+}
+
+container_uses_backend_port() {
+    local container_name="$1"
+    local expected_port="$2"
+    local binding
+    local container_names
+    local running
+
+    if ! container_names="$(
+        docker container ls --all --format '{{.Names}}'
+    )"; then
+        return "${CONTAINER_STATE_ERROR_STATUS}"
+    fi
+    grep -Fxq "${container_name}" <<<"${container_names}" || return 1
+
+    if ! running="$(docker container inspect \
+        --format '{{.State.Running}}' "${container_name}")"; then
+        return "${CONTAINER_STATE_ERROR_STATUS}"
+    fi
+    [[ "${running}" == "true" ]] || return 1
+
+    if ! binding="$(docker container inspect \
+        --format '{{with index .NetworkSettings.Ports "8000/tcp"}}{{range .}}{{.HostIp}}:{{.HostPort}}{{"\n"}}{{end}}{{end}}' \
+        "${container_name}")"; then
+        return "${CONTAINER_STATE_ERROR_STATUS}"
+    fi
+    [[ "${binding}" == "127.0.0.1:${expected_port}" ]]
+}
+
+find_active_container() {
+    local active_port="$1"
+    local candidate_name
+    local candidate_status
+    local matched_container=""
+    local matches=0
+
+    for candidate_name in \
+        "${SLOT_8000_CONTAINER}" \
+        "${SLOT_18000_CONTAINER}" \
+        "${LEGACY_PRODUCTION_CONTAINER}" \
+        "${LEGACY_CANDIDATE_CONTAINER}"; do
+        if container_uses_backend_port "${candidate_name}" "${active_port}"; then
+            matched_container="${candidate_name}"
+            ((matches += 1))
+        else
+            candidate_status=$?
+            if [[ "${candidate_status}" == "${CONTAINER_STATE_ERROR_STATUS}" ]]; then
+                return "${CONTAINER_STATE_ERROR_STATUS}"
+            fi
+        fi
+    done
+
+    ((matches <= 1)) || return 1
+    printf '%s' "${matched_container}"
+}
+
+restore_backend_upstream() {
+    [[ -n "${OLD_UPSTREAM_FILE}" && -f "${OLD_UPSTREAM_FILE}" ]] || return 0
+
+    if ! TEMP_UPSTREAM_FILE="$(
+        mktemp "${NGINX_UPSTREAM_FILE}.restore.XXXXXX"
+    )"; then
+        return 1
+    fi
+    if ! install -m 0644 "${OLD_UPSTREAM_FILE}" "${TEMP_UPSTREAM_FILE}"; then
+        printf 'Unable to stage the previous Nginx upstream file.\n' >&2
+        return 1
+    fi
+    if ! mv -f -- "${TEMP_UPSTREAM_FILE}" "${NGINX_UPSTREAM_FILE}"; then
+        printf 'Unable to restore the previous Nginx upstream file.\n' >&2
+        return 1
+    fi
+    TEMP_UPSTREAM_FILE=""
+    if ! nginx -t >/dev/null; then
+        printf 'The restored Nginx configuration is invalid.\n' >&2
+        return 1
+    fi
+    if ! nginx -s reload >/dev/null; then
+        printf 'Unable to reload the restored Nginx upstream.\n' >&2
+        return 1
+    fi
+
+    if ! rm -f -- "${OLD_UPSTREAM_FILE}"; then
+        printf 'Unable to remove the previous Nginx upstream backup.\n' >&2
+        return 1
+    fi
+    OLD_UPSTREAM_FILE=""
+    UPSTREAM_CHANGE_PENDING="false"
+    UPSTREAM_SWITCHED="false"
+}
+
+switch_backend_upstream() {
+    local expected_port="$1"
+    local next_port="$2"
+    local current_port
+
+    current_port="$(read_backend_upstream_port "${NGINX_UPSTREAM_FILE}")" \
+        || return 1
+    [[ "${current_port}" == "${expected_port}" ]] || return 1
+
+    if ! OLD_UPSTREAM_FILE="$(
+        mktemp "${NGINX_UPSTREAM_FILE}.previous.XXXXXX"
+    )"; then
+        return 1
+    fi
+    if ! install -m 0600 "${NGINX_UPSTREAM_FILE}" "${OLD_UPSTREAM_FILE}"; then
+        return 1
+    fi
+    UPSTREAM_CHANGE_PENDING="true"
+
+    if ! TEMP_UPSTREAM_FILE="$(
+        mktemp "${NGINX_UPSTREAM_FILE}.new.XXXXXX"
+    )"; then
+        return 1
+    fi
+    if ! sed -E \
+        "s#^([[:space:]]*server[[:space:]]+127\\.0\\.0\\.1:)${expected_port}([[:space:]]*;.*)$#\\1${next_port}\\2#" \
+        "${NGINX_UPSTREAM_FILE}" >"${TEMP_UPSTREAM_FILE}"; then
+        return 1
+    fi
+    if [[ "$(read_backend_upstream_port "${TEMP_UPSTREAM_FILE}")" != "${next_port}" ]]; then
+        return 1
+    fi
+
+    if ! chmod 0644 "${TEMP_UPSTREAM_FILE}"; then
+        return 1
+    fi
+    if ! mv -f -- "${TEMP_UPSTREAM_FILE}" "${NGINX_UPSTREAM_FILE}"; then
+        return 1
+    fi
+    UPSTREAM_SWITCHED="true"
+    TEMP_UPSTREAM_FILE=""
+
+    if ! nginx -t >/dev/null; then
+        restore_backend_upstream >/dev/null || true
+        return 1
+    fi
+    if ! nginx -s reload >/dev/null; then
+        restore_backend_upstream >/dev/null || true
+        return 1
+    fi
+    if ! current_port="$(validated_backend_upstream_port)" \
+        || [[ "${current_port}" != "${next_port}" ]]; then
+        restore_backend_upstream >/dev/null || true
+        return 1
+    fi
 }
 
 cleanup() {
@@ -151,7 +492,7 @@ cleanup() {
     if [[ "${DEPLOY_SUCCEEDED}" != "true" ]]; then
         if [[ "${PROMOTION_STARTED}" == "true" \
             && "${ROLLBACK_ATTEMPTED}" != "true" ]]; then
-            if ! rollback_production "${OLD_IMAGE}"; then
+            if ! rollback_production; then
                 printf 'Automatic rollback did not complete successfully.\n' >&2
             fi
         elif [[ "${ENV_REPLACED}" == "true" ]]; then
@@ -165,6 +506,9 @@ cleanup() {
     if [[ -n "${TEMP_ENV_FILE}" ]]; then
         rm -f -- "${TEMP_ENV_FILE}" >/dev/null 2>&1 || true
     fi
+    if [[ -n "${TEMP_UPSTREAM_FILE}" ]]; then
+        rm -f -- "${TEMP_UPSTREAM_FILE}" >/dev/null 2>&1 || true
+    fi
     if [[ -n "${OLD_ENV_FILE}" && "${ENV_REPLACED}" != "true" ]]; then
         rm -f -- "${OLD_ENV_FILE}" >/dev/null 2>&1 || true
         OLD_ENV_FILE=""
@@ -173,9 +517,27 @@ cleanup() {
             "${OLD_ENV_FILE}" >&2
     fi
 
-    docker rm -f "${CANDIDATE_CONTAINER}" >/dev/null 2>&1 || true
-    if [[ "${IMAGE_BUILT}" == "true" \
+    if [[ -n "${OLD_UPSTREAM_FILE}" \
+        && "${UPSTREAM_CHANGE_PENDING}" != "true" ]]; then
+        rm -f -- "${OLD_UPSTREAM_FILE}" >/dev/null 2>&1 || true
+        OLD_UPSTREAM_FILE=""
+    elif [[ -n "${OLD_UPSTREAM_FILE}" ]]; then
+        printf 'Previous Nginx upstream backup retained at: %s\n' \
+            "${OLD_UPSTREAM_FILE}" >&2
+    fi
+
+    if [[ -n "${NEW_CONTAINER}" \
+        && "${DEPLOY_SUCCEEDED}" != "true" \
+        && "${UPSTREAM_SWITCHED}" != "true" ]]; then
+        docker rm -f "${NEW_CONTAINER}" >/dev/null 2>&1 || true
+    elif [[ -n "${NEW_CONTAINER}" \
         && "${DEPLOY_SUCCEEDED}" != "true" ]]; then
+        printf 'New backend container retained because upstream rollback failed: %s\n' \
+            "${NEW_CONTAINER}" >&2
+    fi
+    if [[ "${IMAGE_BUILT}" == "true" \
+        && "${DEPLOY_SUCCEEDED}" != "true" \
+        && "${UPSTREAM_SWITCHED}" != "true" ]]; then
         docker image rm "${NEW_IMAGE}" >/dev/null 2>&1 || true
     fi
     remove_release_dir >/dev/null 2>&1 || true
@@ -208,34 +570,25 @@ wait_for_backend() {
     return 1
 }
 
-start_candidate() {
-    docker run --detach \
-        --name "${CANDIDATE_CONTAINER}" \
-        --env-file "${ENV_FILE}" \
-        --publish "127.0.0.1:${CANDIDATE_PORT}:8000" \
-        "${NEW_IMAGE}" >/dev/null
-}
-
 start_production() {
     local image="$1"
+    local container_name="$2"
+    local host_port="$3"
 
     docker run --detach \
-        --name "${PRODUCTION_CONTAINER}" \
+        --name "${container_name}" \
         --restart unless-stopped \
         --log-driver json-file \
         --log-opt max-size=10m \
         --log-opt max-file=3 \
         --env-file "${ENV_FILE}" \
-        --publish "127.0.0.1:${PRODUCTION_PORT}:8000" \
+        --publish "127.0.0.1:${host_port}:8000" \
         "${image}" >/dev/null
 }
 
 rollback_production() {
-    local rollback_image="$1"
-    local current_container_id=""
-
     ROLLBACK_ATTEMPTED="true"
-    printf 'Production replacement was interrupted; starting rollback.\n' >&2
+    printf 'Production promotion was interrupted; starting rollback.\n' >&2
 
     if ! restore_previous_environment; then
         printf 'Rollback could not restore the previous environment file.\n' >&2
@@ -246,52 +599,24 @@ rollback_production() {
         return 1
     fi
 
-    if docker container inspect "${PRODUCTION_CONTAINER}" >/dev/null 2>&1; then
-        if ! current_container_id="$(
-            docker container inspect \
-                --format '{{.Id}}' "${PRODUCTION_CONTAINER}"
-        )"; then
-            printf 'Rollback could not inspect the production container.\n' >&2
-            return 1
-        fi
-
-        if [[ -n "${OLD_CONTAINER_ID}" \
-            && "${current_container_id}" == "${OLD_CONTAINER_ID}" ]] \
-            && wait_for_backend "${PRODUCTION_PORT}"; then
-            PROMOTION_STARTED="false"
-            printf 'Production remained available; rollback is complete.\n' >&2
-            return 0
-        fi
-
-        if ! docker rm -f "${PRODUCTION_CONTAINER}" >/dev/null; then
-            printf 'Rollback could not remove the replacement container.\n' >&2
+    if [[ "${UPSTREAM_CHANGE_PENDING}" == "true" ]]; then
+        if ! restore_backend_upstream; then
+            printf 'Rollback could not restore the previous Nginx upstream.\n' >&2
             return 1
         fi
     fi
 
-    if [[ -z "${rollback_image}" ]]; then
-        printf 'No previous production image is available to restore.\n' >&2
-        PROMOTION_STARTED="false"
-        return 0
-    fi
-
-    if [[ ! -s "${ENV_FILE}" ]]; then
-        printf 'No previous environment file is available for rollback.\n' >&2
+    if [[ -n "${ACTIVE_CONTAINER}" ]] \
+        && ! wait_for_backend "${ACTIVE_PORT}"; then
+        printf 'Previous backend container remained running, but rollback health checks failed.\n' >&2
         return 1
     fi
 
-    if ! start_production "${rollback_image}"; then
-        printf 'Rollback failed to start the previous production image.\n' >&2
-        return 1
+    if [[ -n "${NEW_CONTAINER}" ]]; then
+        docker rm -f "${NEW_CONTAINER}" >/dev/null 2>&1 || true
     fi
-
-    if ! wait_for_backend "${PRODUCTION_PORT}"; then
-        printf 'Previous production image started, but rollback health checks failed.\n' >&2
-        return 1
-    fi
-
     PROMOTION_STARTED="false"
-    printf 'Previous production image and environment restored.\n' >&2
+    printf 'Previous backend upstream and environment restored.\n' >&2
 }
 
 prune_old_backend_images() {
@@ -336,6 +661,7 @@ prune_old_backend_images() {
     [[ "${prune_failed}" != "true" ]]
 }
 
+main() {
 (($# == 1)) \
     || die "usage: ${0##*/} <lowercase-40-character-commit-sha>"
 
@@ -355,6 +681,8 @@ require_command curl
 require_command docker
 require_command flock
 require_command git
+require_command grep
+require_command nginx
 
 [[ -d "${REPO_DIR}/.git" ]] \
     || die "Git repository not found: ${REPO_DIR}"
@@ -369,6 +697,24 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 
 install -d -m 0700 "${RELEASES_DIR}" "${ENV_DIR}"
+
+ACTIVE_PORT="$(validated_backend_upstream_port)"
+if ! ACTIVE_CONTAINER="$(find_active_container "${ACTIVE_PORT}")"; then
+    die "unable to determine a unique active backend container from Docker state"
+fi
+
+if [[ -n "${ACTIVE_CONTAINER}" ]]; then
+    OLD_IMAGE="$(docker container inspect \
+        --format '{{.Image}}' "${ACTIVE_CONTAINER}")" \
+        || die "unable to inspect the active backend container"
+    [[ -s "${ENV_FILE}" ]] \
+        || die "rollback environment is unavailable; production was not changed"
+    NEW_PORT="$(other_backend_port "${ACTIVE_PORT}")"
+else
+    NEW_PORT="${ACTIVE_PORT}"
+fi
+NEW_CONTAINER="$(slot_container_for_port "${NEW_PORT}")" \
+    || die "unsupported backend deployment port: ${NEW_PORT}"
 
 printf 'Creating an isolated build context for %s.\n' "${DEPLOY_SHA}"
 [[ "$(git -C "${REPO_DIR}" cat-file -t "${DEPLOY_SHA}" 2>/dev/null)" == "commit" ]] \
@@ -424,53 +770,54 @@ NEW_IMAGE_ID="$(
     docker image inspect --format '{{.Id}}' "${NEW_IMAGE}"
 )" || die "unable to inspect the newly built backend image"
 
-docker rm -f "${CANDIDATE_CONTAINER}" >/dev/null 2>&1 || true
-printf 'Starting and validating the candidate container.\n'
-start_candidate
-
-if ! wait_for_backend "${CANDIDATE_PORT}"; then
-    die "candidate validation failed; the production container was not changed"
-fi
-docker rm -f "${CANDIDATE_CONTAINER}" >/dev/null
-
-if docker container inspect "${PRODUCTION_CONTAINER}" >/dev/null 2>&1; then
-    OLD_CONTAINER_ID="$(
-        docker container inspect \
-            --format '{{.Id}}' "${PRODUCTION_CONTAINER}"
-    )"
-    OLD_IMAGE="$(
-        docker container inspect \
-            --format '{{.Image}}' "${PRODUCTION_CONTAINER}"
-    )"
+docker rm -f "${NEW_CONTAINER}" >/dev/null 2>&1 || true
+printf 'Starting and validating backend slot %s on port %s.\n' \
+    "${NEW_CONTAINER}" "${NEW_PORT}"
+if ! start_production "${NEW_IMAGE}" "${NEW_CONTAINER}" "${NEW_PORT}"; then
+    die "unable to start the new backend slot"
 fi
 
-if [[ -n "${OLD_IMAGE}" \
-    && ( ! -f "${OLD_ENV_FILE}" || ! -s "${OLD_ENV_FILE}" ) ]]; then
-    die "rollback environment is unavailable; production was not changed"
+if ! wait_for_backend "${NEW_PORT}"; then
+    die "candidate validation failed; the production upstream was not changed"
 fi
 
 PROMOTION_STARTED="true"
-if [[ -n "${OLD_IMAGE}" ]]; then
-    if ! docker rm -f "${PRODUCTION_CONTAINER}" >/dev/null; then
-        die "unable to remove the current production container"
+if [[ -n "${ACTIVE_CONTAINER}" ]]; then
+    printf 'Switching Nginx upstream from port %s to port %s.\n' \
+        "${ACTIVE_PORT}" "${NEW_PORT}"
+    if ! switch_backend_upstream "${ACTIVE_PORT}" "${NEW_PORT}"; then
+        die "unable to switch and reload the backend Nginx upstream"
     fi
-fi
-
-printf 'Promoting the validated image to production.\n'
-if ! start_production "${NEW_IMAGE}"; then
-    die "unable to start the validated production image"
-fi
-
-if ! wait_for_backend "${PRODUCTION_PORT}"; then
-    die "production health checks failed"
 fi
 
 DEPLOY_SUCCEEDED="true"
 PROMOTION_STARTED="false"
 ENV_REPLACED="false"
+UPSTREAM_CHANGE_PENDING="false"
+UPSTREAM_SWITCHED="false"
+if [[ -n "${OLD_UPSTREAM_FILE}" ]]; then
+    rm -f -- "${OLD_UPSTREAM_FILE}" || true
+    OLD_UPSTREAM_FILE=""
+fi
 if [[ -n "${OLD_ENV_FILE}" ]]; then
     rm -f -- "${OLD_ENV_FILE}" || true
     OLD_ENV_FILE=""
+fi
+
+if [[ -n "${ACTIVE_CONTAINER}" ]]; then
+    printf 'Draining the previous backend slot for %s seconds.\n' \
+        "${CONTAINER_DRAIN_SECONDS}"
+    sleep "${CONTAINER_DRAIN_SECONDS}"
+    if ! docker stop \
+        --time "${CONTAINER_STOP_TIMEOUT_SECONDS}" \
+        "${ACTIVE_CONTAINER}" >/dev/null; then
+        printf 'Backend deployment succeeded, but the previous container did not stop cleanly: %s\n' \
+            "${ACTIVE_CONTAINER}" >&2
+    fi
+    if ! docker rm "${ACTIVE_CONTAINER}" >/dev/null; then
+        printf 'Backend deployment succeeded, but the previous container was not removed: %s\n' \
+            "${ACTIVE_CONTAINER}" >&2
+    fi
 fi
 
 if ! prune_old_backend_images; then
@@ -478,3 +825,8 @@ if ! prune_old_backend_images; then
 fi
 
 printf 'Backend deployment completed successfully.\n'
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/deploy/backend/deploy.sh
+++ b/deploy/backend/deploy.sh
@@ -1,0 +1,480 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+umask 077
+
+readonly REPO_DIR="/opt/salesluv"
+readonly RELEASES_DIR="/opt/salesluv-releases"
+readonly ENV_FILE="/opt/salesluv/runtime/backend.env"
+readonly ENV_DIR="${ENV_FILE%/*}"
+readonly SSM_PARAMETER="/salesluv/production/backend/env"
+readonly AWS_REGION="ap-northeast-2"
+readonly LOCK_FILE="/var/lock/salesluv-backend-deploy.lock"
+
+readonly IMAGE_REPOSITORY="salesluv-backend"
+readonly PRODUCTION_CONTAINER="salesluv-backend"
+readonly CANDIDATE_CONTAINER="salesluv-backend-candidate"
+readonly PRODUCTION_PORT="8000"
+readonly CANDIDATE_PORT="18000"
+
+readonly HEALTH_ATTEMPTS="30"
+readonly HEALTH_DELAY_SECONDS="2"
+readonly HEALTH_TIMEOUT_SECONDS="5"
+
+TEMP_ENV_FILE=""
+OLD_ENV_FILE=""
+RELEASE_DIR=""
+BACKEND_CONTEXT=""
+OLD_IMAGE=""
+OLD_CONTAINER_ID=""
+NEW_IMAGE_ID=""
+ENV_REPLACED="false"
+IMAGE_BUILT="false"
+PROMOTION_STARTED="false"
+ROLLBACK_ATTEMPTED="false"
+DEPLOY_SUCCEEDED="false"
+
+die() {
+    printf 'Deployment failed: %s\n' "$*" >&2
+    exit 1
+}
+
+require_command() {
+    local command_name="$1"
+
+    command -v "${command_name}" >/dev/null 2>&1 \
+        || die "required command not found: ${command_name}"
+}
+
+remove_release_dir() {
+    if [[ -z "${RELEASE_DIR}" ]]; then
+        return 0
+    fi
+
+    if [[ "${RELEASE_DIR}" != "${RELEASES_DIR}/backend.${DEPLOY_SHA}."* ]]; then
+        printf 'Refusing to remove unexpected release directory: %s\n' \
+            "${RELEASE_DIR}" >&2
+        return 1
+    fi
+
+    rm -rf -- "${RELEASE_DIR}"
+    RELEASE_DIR=""
+    BACKEND_CONTEXT=""
+}
+
+restore_previous_environment() {
+    if [[ "${ENV_REPLACED}" != "true" ]]; then
+        return 0
+    fi
+
+    if [[ -n "${OLD_ENV_FILE}" && -f "${OLD_ENV_FILE}" ]]; then
+        if ! mv -f -- "${OLD_ENV_FILE}" "${ENV_FILE}"; then
+            printf 'Unable to restore the previous backend environment file.\n' >&2
+            return 1
+        fi
+        OLD_ENV_FILE=""
+    elif ! rm -f -- "${ENV_FILE}"; then
+        printf 'Unable to remove the newly created backend environment file.\n' >&2
+        return 1
+    fi
+
+    ENV_REPLACED="false"
+}
+
+# 키가 정확히 한 번만 나올 때 그 값을 출력한다. 없거나 중복이면 아무것도 출력하지 않는다.
+dotenv_value() {
+    local dotenv_file="$1"
+    local expected_key="$2"
+
+    awk -v expected_key="${expected_key}" '
+        /^[[:space:]]*(#|$)/ { next }
+        {
+            line = $0
+            sub(/\r$/, "", line)
+            separator = index(line, "=")
+            if (separator == 0) {
+                next
+            }
+
+            key = substr(line, 1, separator - 1)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", key)
+            if (key != expected_key) {
+                next
+            }
+
+            value = substr(line, separator + 1)
+
+            matches++
+            matched_value = value
+        }
+        END {
+            if (matches == 1) {
+                print matched_value
+            }
+        }
+    ' "${dotenv_file}"
+}
+
+validate_runtime_environment() {
+    local dotenv_file="$1"
+    local required_key
+    local value
+
+    for required_key in \
+        APP_ENV \
+        DEBUG \
+        CORS_ORIGINS \
+        DATABASE_URL \
+        SUPABASE_PUBLISHABLE_KEY; do
+        value="$(dotenv_value "${dotenv_file}" "${required_key}")"
+        [[ -n "${value}" ]] \
+            || die "required environment key is missing or empty: ${required_key}"
+
+        case "${required_key}" in
+            APP_ENV)
+                [[ "${value}" == "production" ]] || die "APP_ENV must be production"
+                ;;
+            DEBUG)
+                [[ "${value}" == "false" ]] || die "DEBUG must be false"
+                ;;
+        esac
+    done
+}
+
+cleanup() {
+    local exit_status="$1"
+
+    trap - EXIT
+    trap '' HUP INT TERM
+    set +e
+
+    if [[ "${DEPLOY_SUCCEEDED}" != "true" ]]; then
+        if [[ "${PROMOTION_STARTED}" == "true" \
+            && "${ROLLBACK_ATTEMPTED}" != "true" ]]; then
+            if ! rollback_production "${OLD_IMAGE}"; then
+                printf 'Automatic rollback did not complete successfully.\n' >&2
+            fi
+        elif [[ "${ENV_REPLACED}" == "true" ]]; then
+            if ! restore_previous_environment; then
+                printf 'Previous environment backup retained at: %s\n' \
+                    "${OLD_ENV_FILE:-not available}" >&2
+            fi
+        fi
+    fi
+
+    if [[ -n "${TEMP_ENV_FILE}" ]]; then
+        rm -f -- "${TEMP_ENV_FILE}" >/dev/null 2>&1 || true
+    fi
+    if [[ -n "${OLD_ENV_FILE}" && "${ENV_REPLACED}" != "true" ]]; then
+        rm -f -- "${OLD_ENV_FILE}" >/dev/null 2>&1 || true
+        OLD_ENV_FILE=""
+    elif [[ -n "${OLD_ENV_FILE}" ]]; then
+        printf 'Previous environment backup retained at: %s\n' \
+            "${OLD_ENV_FILE}" >&2
+    fi
+
+    docker rm -f "${CANDIDATE_CONTAINER}" >/dev/null 2>&1 || true
+    if [[ "${IMAGE_BUILT}" == "true" \
+        && "${DEPLOY_SUCCEEDED}" != "true" ]]; then
+        docker image rm "${NEW_IMAGE}" >/dev/null 2>&1 || true
+    fi
+    remove_release_dir >/dev/null 2>&1 || true
+    exit "${exit_status}"
+}
+
+wait_for_backend() {
+    local port="$1"
+    local attempt
+
+    for ((attempt = 1; attempt <= HEALTH_ATTEMPTS; attempt++)); do
+        if curl --fail --silent --show-error \
+            --connect-timeout "${HEALTH_TIMEOUT_SECONDS}" \
+            --max-time "${HEALTH_TIMEOUT_SECONDS}" \
+            "http://127.0.0.1:${port}/api/health" >/dev/null 2>&1 \
+            && curl --fail --silent --show-error \
+                --connect-timeout "${HEALTH_TIMEOUT_SECONDS}" \
+                --max-time "${HEALTH_TIMEOUT_SECONDS}" \
+                "http://127.0.0.1:${port}/api/health/db" >/dev/null 2>&1; then
+            return 0
+        fi
+
+        if ((attempt < HEALTH_ATTEMPTS)); then
+            sleep "${HEALTH_DELAY_SECONDS}"
+        fi
+    done
+
+    printf 'Health checks failed on port %s after %s attempts.\n' \
+        "${port}" "${HEALTH_ATTEMPTS}" >&2
+    return 1
+}
+
+start_candidate() {
+    docker run --detach \
+        --name "${CANDIDATE_CONTAINER}" \
+        --env-file "${ENV_FILE}" \
+        --publish "127.0.0.1:${CANDIDATE_PORT}:8000" \
+        "${NEW_IMAGE}" >/dev/null
+}
+
+start_production() {
+    local image="$1"
+
+    docker run --detach \
+        --name "${PRODUCTION_CONTAINER}" \
+        --restart unless-stopped \
+        --log-driver json-file \
+        --log-opt max-size=10m \
+        --log-opt max-file=3 \
+        --env-file "${ENV_FILE}" \
+        --publish "127.0.0.1:${PRODUCTION_PORT}:8000" \
+        "${image}" >/dev/null
+}
+
+rollback_production() {
+    local rollback_image="$1"
+    local current_container_id=""
+
+    ROLLBACK_ATTEMPTED="true"
+    printf 'Production replacement was interrupted; starting rollback.\n' >&2
+
+    if ! restore_previous_environment; then
+        printf 'Rollback could not restore the previous environment file.\n' >&2
+        if [[ -n "${OLD_ENV_FILE}" ]]; then
+            printf 'Previous environment backup retained at: %s\n' \
+                "${OLD_ENV_FILE}" >&2
+        fi
+        return 1
+    fi
+
+    if docker container inspect "${PRODUCTION_CONTAINER}" >/dev/null 2>&1; then
+        if ! current_container_id="$(
+            docker container inspect \
+                --format '{{.Id}}' "${PRODUCTION_CONTAINER}"
+        )"; then
+            printf 'Rollback could not inspect the production container.\n' >&2
+            return 1
+        fi
+
+        if [[ -n "${OLD_CONTAINER_ID}" \
+            && "${current_container_id}" == "${OLD_CONTAINER_ID}" ]] \
+            && wait_for_backend "${PRODUCTION_PORT}"; then
+            PROMOTION_STARTED="false"
+            printf 'Production remained available; rollback is complete.\n' >&2
+            return 0
+        fi
+
+        if ! docker rm -f "${PRODUCTION_CONTAINER}" >/dev/null; then
+            printf 'Rollback could not remove the replacement container.\n' >&2
+            return 1
+        fi
+    fi
+
+    if [[ -z "${rollback_image}" ]]; then
+        printf 'No previous production image is available to restore.\n' >&2
+        PROMOTION_STARTED="false"
+        return 0
+    fi
+
+    if [[ ! -s "${ENV_FILE}" ]]; then
+        printf 'No previous environment file is available for rollback.\n' >&2
+        return 1
+    fi
+
+    if ! start_production "${rollback_image}"; then
+        printf 'Rollback failed to start the previous production image.\n' >&2
+        return 1
+    fi
+
+    if ! wait_for_backend "${PRODUCTION_PORT}"; then
+        printf 'Previous production image started, but rollback health checks failed.\n' >&2
+        return 1
+    fi
+
+    PROMOTION_STARTED="false"
+    printf 'Previous production image and environment restored.\n' >&2
+}
+
+prune_old_backend_images() {
+    local image_references
+    local image_reference
+    local image_id
+    local prune_failed="false"
+
+    if ! image_references="$(
+        docker image ls \
+            --filter "reference=${IMAGE_REPOSITORY}:*" \
+            --format '{{.Repository}}:{{.Tag}}'
+    )"; then
+        printf 'Unable to list old backend images for cleanup.\n' >&2
+        return 1
+    fi
+
+    while IFS= read -r image_reference; do
+        [[ -n "${image_reference}" ]] || continue
+        if ! image_id="$(
+            docker image inspect \
+                --format '{{.Id}}' "${image_reference}"
+        )"; then
+            printf 'Unable to inspect backend image reference: %s\n' \
+                "${image_reference}" >&2
+            prune_failed="true"
+            continue
+        fi
+
+        if [[ "${image_id}" == "${NEW_IMAGE_ID}" \
+            || ( -n "${OLD_IMAGE}" && "${image_id}" == "${OLD_IMAGE}" ) ]]; then
+            continue
+        fi
+
+        if ! docker image rm "${image_reference}" >/dev/null; then
+            printf 'Unable to remove stale backend image reference: %s\n' \
+                "${image_reference}" >&2
+            prune_failed="true"
+        fi
+    done <<<"${image_references}"
+
+    [[ "${prune_failed}" != "true" ]]
+}
+
+(($# == 1)) \
+    || die "usage: ${0##*/} <lowercase-40-character-commit-sha>"
+
+readonly DEPLOY_SHA="$1"
+[[ "${DEPLOY_SHA}" =~ ^[0-9a-f]{40}$ ]] \
+    || die "commit SHA must contain exactly 40 lowercase hexadecimal characters"
+
+if ((EUID != 0)); then
+    require_command sudo
+    exec sudo bash "$0" "$@"
+fi
+
+readonly NEW_IMAGE="${IMAGE_REPOSITORY}:${DEPLOY_SHA}"
+
+require_command aws
+require_command curl
+require_command docker
+require_command flock
+require_command git
+
+[[ -d "${REPO_DIR}/.git" ]] \
+    || die "Git repository not found: ${REPO_DIR}"
+
+exec 9>"${LOCK_FILE}"
+flock --nonblock 9 \
+    || die "another backend deployment is already running"
+
+trap 'cleanup "$?"' EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+install -d -m 0700 "${RELEASES_DIR}" "${ENV_DIR}"
+
+printf 'Creating an isolated build context for %s.\n' "${DEPLOY_SHA}"
+[[ "$(git -C "${REPO_DIR}" cat-file -t "${DEPLOY_SHA}" 2>/dev/null)" == "commit" ]] \
+    || die "commit is not available in the EC2 repository: ${DEPLOY_SHA}"
+RELEASE_DIR="$(mktemp -d "${RELEASES_DIR}/backend.${DEPLOY_SHA}.XXXXXX")"
+BACKEND_CONTEXT="${RELEASE_DIR}/backend"
+
+if ! git -C "${REPO_DIR}" archive "${DEPLOY_SHA}" backend \
+    | tar -x -C "${RELEASE_DIR}"; then
+    die "unable to create the isolated backend build context"
+fi
+[[ -f "${BACKEND_CONTEXT}/Dockerfile" ]] \
+    || die "backend Dockerfile not found in commit ${DEPLOY_SHA}"
+
+printf 'Refreshing the backend runtime environment.\n'
+if [[ -f "${ENV_FILE}" ]]; then
+    OLD_ENV_FILE="$(mktemp "${ENV_DIR}/.backend.env.previous.XXXXXX")"
+    install -m 0600 "${ENV_FILE}" "${OLD_ENV_FILE}"
+fi
+
+TEMP_ENV_FILE="$(mktemp "${ENV_DIR}/.backend.env.new.XXXXXX")"
+chmod 0600 "${TEMP_ENV_FILE}"
+
+if ! AWS_PAGER="" aws ssm get-parameter \
+    --name "${SSM_PARAMETER}" \
+    --with-decryption \
+    --region "${AWS_REGION}" \
+    --query 'Parameter.Value' \
+    --output text >"${TEMP_ENV_FILE}"; then
+    die "unable to retrieve the backend environment parameter"
+fi
+
+[[ -s "${TEMP_ENV_FILE}" ]] \
+    || die "retrieved backend environment parameter is empty"
+chmod 0600 "${TEMP_ENV_FILE}"
+validate_runtime_environment "${TEMP_ENV_FILE}"
+ENV_REPLACED="true"
+mv -f -- "${TEMP_ENV_FILE}" "${ENV_FILE}" \
+    || die "unable to install the refreshed backend environment"
+TEMP_ENV_FILE=""
+
+printf 'Building backend image %s.\n' "${NEW_IMAGE}"
+# SSM GetCommandInvocation은 표준 출력의 앞 24,000자와 표준 오류의 앞 8,000자만
+# 돌려주므로 빌드 로그는 파일로 받고 실패했을 때 끝부분만 남긴다.
+BUILD_LOG="${RELEASE_DIR}/build.log"
+if ! DOCKER_BUILDKIT=1 docker build --progress=plain \
+    --tag "${NEW_IMAGE}" "${BACKEND_CONTEXT}" >"${BUILD_LOG}" 2>&1; then
+    tail -n 30 "${BUILD_LOG}" | tail -c 7000 >&2
+    die "unable to build the backend image"
+fi
+IMAGE_BUILT="true"
+NEW_IMAGE_ID="$(
+    docker image inspect --format '{{.Id}}' "${NEW_IMAGE}"
+)" || die "unable to inspect the newly built backend image"
+
+docker rm -f "${CANDIDATE_CONTAINER}" >/dev/null 2>&1 || true
+printf 'Starting and validating the candidate container.\n'
+start_candidate
+
+if ! wait_for_backend "${CANDIDATE_PORT}"; then
+    die "candidate validation failed; the production container was not changed"
+fi
+docker rm -f "${CANDIDATE_CONTAINER}" >/dev/null
+
+if docker container inspect "${PRODUCTION_CONTAINER}" >/dev/null 2>&1; then
+    OLD_CONTAINER_ID="$(
+        docker container inspect \
+            --format '{{.Id}}' "${PRODUCTION_CONTAINER}"
+    )"
+    OLD_IMAGE="$(
+        docker container inspect \
+            --format '{{.Image}}' "${PRODUCTION_CONTAINER}"
+    )"
+fi
+
+if [[ -n "${OLD_IMAGE}" \
+    && ( ! -f "${OLD_ENV_FILE}" || ! -s "${OLD_ENV_FILE}" ) ]]; then
+    die "rollback environment is unavailable; production was not changed"
+fi
+
+PROMOTION_STARTED="true"
+if [[ -n "${OLD_IMAGE}" ]]; then
+    if ! docker rm -f "${PRODUCTION_CONTAINER}" >/dev/null; then
+        die "unable to remove the current production container"
+    fi
+fi
+
+printf 'Promoting the validated image to production.\n'
+if ! start_production "${NEW_IMAGE}"; then
+    die "unable to start the validated production image"
+fi
+
+if ! wait_for_backend "${PRODUCTION_PORT}"; then
+    die "production health checks failed"
+fi
+
+DEPLOY_SUCCEEDED="true"
+PROMOTION_STARTED="false"
+ENV_REPLACED="false"
+if [[ -n "${OLD_ENV_FILE}" ]]; then
+    rm -f -- "${OLD_ENV_FILE}" || true
+    OLD_ENV_FILE=""
+fi
+
+if ! prune_old_backend_images; then
+    printf 'Backend deployment succeeded, but stale image cleanup was incomplete.\n' >&2
+fi
+
+printf 'Backend deployment completed successfully.\n'

--- a/deploy/backend/tests/runtime-environment-test.sh
+++ b/deploy/backend/tests/runtime-environment-test.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+readonly TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly PROJECT_ROOT="$(cd "${TEST_DIR}/../../.." && pwd)"
+
+# shellcheck source=../deploy.sh
+source "${PROJECT_ROOT}/deploy/backend/deploy.sh"
+
+TEST_TMP_DIR="$(mktemp -d)"
+
+cleanup_test_files() {
+    rm -rf -- "${TEST_TMP_DIR}"
+}
+
+trap cleanup_test_files EXIT
+
+fail() {
+    printf 'FAIL: %s\n' "$*" >&2
+    exit 1
+}
+
+write_environment() {
+    local name="$1"
+    local content="$2"
+    local environment_file="${TEST_TMP_DIR}/${name}.env"
+
+    printf '%s' "${content}" >"${environment_file}"
+    printf '%s' "${environment_file}"
+}
+
+assert_validation_fails() {
+    local name="$1"
+    local expected_message="$2"
+    local forbidden_text="$3"
+    local content="$4"
+    local environment_file
+    local output
+
+    environment_file="$(write_environment "${name}" "${content}")"
+    if output="$(validate_runtime_environment "${environment_file}" 2>&1)"; then
+        fail "${name} unexpectedly passed validation"
+    fi
+    [[ "${output}" == *"${expected_message}"* ]] \
+        || fail "${name} did not report '${expected_message}': ${output}"
+    if [[ -n "${forbidden_text}" && "${output}" == *"${forbidden_text}"* ]]; then
+        fail "${name} exposed the rejected value"
+    fi
+}
+
+readonly VALID_ENVIRONMENT=$'APP_ENV=production\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n'
+
+valid_file="$(write_environment valid "${VALID_ENVIRONMENT}")"
+valid_output="$(validate_runtime_environment "${valid_file}")" \
+    || fail "valid production environment was rejected"
+[[ -z "${valid_output}" ]] || fail "valid environment values were written to output"
+
+assert_validation_fails \
+    missing_app_env \
+    'schema-required key is missing: APP_ENV' \
+    '' \
+    $'DEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n'
+
+assert_validation_fails \
+    duplicate_app_env \
+    'schema-required key is duplicated: APP_ENV' \
+    '' \
+    $'APP_ENV=production\nAPP_ENV=production\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n'
+
+assert_validation_fails \
+    empty_app_env \
+    'schema-required key is present but empty: APP_ENV' \
+    '' \
+    $'APP_ENV=\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n'
+
+assert_validation_fails \
+    invalid_app_env_key \
+    'Invalid runtime environment key syntax at line 1' \
+    '' \
+    $'APP_ENV =production\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n'
+
+readonly SECRET_MARKER='do-not-print-this-value'
+assert_validation_fails \
+    quoted_app_env \
+    'APP_ENV must be the unquoted literal production; double-quoted form was provided' \
+    "${SECRET_MARKER}" \
+    $'APP_ENV="do-not-print-this-value"\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n'
+
+assert_validation_fails \
+    whitespace_app_env \
+    'APP_ENV must be the unquoted literal production; form with surrounding whitespace was provided' \
+    '' \
+    $'APP_ENV= production\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n'
+
+assert_validation_fails \
+    commented_debug \
+    'DEBUG must be the unquoted literal false; form with literal inline-comment text was provided' \
+    '' \
+    $'APP_ENV=production\nDEBUG=false # production\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n'
+
+assert_validation_fails \
+    missing_cors \
+    'production-security key is missing: CORS_ORIGINS' \
+    '' \
+    $'APP_ENV=production\nDEBUG=false\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n'
+
+assert_validation_fails \
+    empty_database \
+    'deployed-feature key is present but empty: DATABASE_URL' \
+    '' \
+    $'APP_ENV=production\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n'
+
+assert_validation_fails \
+    bare_duplicate_app_env \
+    'explicit KEY=value is required' \
+    '' \
+    $'APP_ENV=production\nAPP_ENV\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n'
+
+assert_validation_fails \
+    malformed_unrelated_key \
+    'Invalid runtime environment key syntax' \
+    "${SECRET_MARKER}" \
+    $'APP_ENV=production\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n=do-not-print-this-value\n'
+
+raw_file="$(write_environment raw_value $'RAW_VALUE=  literal # text = preserved  \r\n')"
+raw_value="$(dotenv_value "${raw_file}" RAW_VALUE)"
+[[ "${raw_value}" == '  literal # text = preserved  ' ]] \
+    || fail "dotenv_value changed the raw value"
+
+upstream_file="$(write_environment upstream $'upstream salesluv_backend {\n    server 127.0.0.1:8000;\n}\n')"
+[[ "$(read_backend_upstream_port "${upstream_file}")" == "8000" ]] \
+    || fail "active Nginx upstream port was not parsed"
+[[ "$(slot_container_for_port 8000)" == "${SLOT_8000_CONTAINER}" ]] \
+    || fail "port 8000 did not map to its deployment slot"
+[[ "$(other_backend_port 8000)" == "18000" ]] \
+    || fail "inactive backend port was not selected"
+
+docker() {
+    if [[ "${DOCKER_TEST_STATE}" == "missing" ]]; then
+        return 0
+    fi
+    return 1
+}
+
+DOCKER_TEST_STATE="missing"
+if container_uses_backend_port "${SLOT_8000_CONTAINER}" "${BACKEND_PORT_A}"; then
+    fail "a missing container was reported as active"
+else
+    container_status=$?
+fi
+[[ "${container_status}" == "1" ]] \
+    || fail "a missing container did not return the normal inactive status"
+
+DOCKER_TEST_STATE="daemon-error"
+if container_uses_backend_port "${SLOT_8000_CONTAINER}" "${BACKEND_PORT_A}"; then
+    fail "a Docker state error was reported as active"
+else
+    container_status=$?
+fi
+[[ "${container_status}" == "${CONTAINER_STATE_ERROR_STATUS}" ]] \
+    || fail "a Docker state error was not distinguished from a missing container"
+if find_active_container "${BACKEND_PORT_A}" >/dev/null; then
+    fail "Docker state errors were ignored while finding the active container"
+else
+    container_status=$?
+fi
+[[ "${container_status}" == "${CONTAINER_STATE_ERROR_STATUS}" ]] \
+    || fail "find_active_container did not propagate the Docker state error"
+unset -f docker
+
+printf 'runtime environment validation tests passed\n'


### PR DESCRIPTION
## 변경 요약

- develop 브랜치 전용 백엔드 수동 배포 워크플로와 EC2 배포 스크립트를 추가했습니다.
- 프론트엔드 빌드 산출물을 S3와 CloudFront에 배포하고 최신 정적 파일 3세대를 보존하는 수동 워크플로를 추가했습니다.
- AWS OIDC를 사용하며 배포 성공·실패 시 선택적으로 Discord 알림을 전송합니다.

## 검증

- 백엔드 Ruff 검사 및 포맷 검사 통과
- 백엔드 테스트 144개 통과, DB 연결 테스트 2개 skip
- 프론트엔드 oxlint 및 TypeScript 검사 통과
- Node 24 프론트엔드 프로덕션 빌드 통과
- 워크플로 YAML 2개 파싱 및 Bash 실행 블록 11개 구문 검사 통과
- SSM sh에서 Bash로 전달되는 회귀 검사 통과
- git diff --check 및 장기 자격증명 패턴 검사 통과
- ShellCheck와 actionlint는 로컬에 설치되어 있지 않아 실행하지 못했습니다.
- 참고: frontend npm run format:check는 이번 PR에 포함되지 않은 기존 소스 3개 파일의 포맷 불일치로 실패했으며 해당 파일은 수정하지 않았습니다.

## 영향 및 주의 사항

- 두 배포 모두 workflow_dispatch로만 실행되며 develop 외 브랜치는 AWS 인증 전에 거부됩니다.
- 백엔드 DB 통합 테스트는 로컬에서 외부 DB를 사용하지 않도록 DATABASE_URL을 비워 실행했습니다.
- 프론트엔드 빌드에는 약 1.15MB JavaScript 청크 경고가 있으나 빌드는 성공합니다.
- Discord 웹훅이 없거나 알림 전송이 실패해도 배포 결과 자체에는 영향을 주지 않습니다.
- CloudFront에서 EC2 원본으로 향하는 구간은 현재 HTTP입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **배포 개선**
  - 백엔드와 프론트엔드의 운영 환경 배포 절차가 추가되었습니다.
  - 배포 전 버전과 설정을 검증해 잘못된 릴리스 위험을 줄였습니다.
  - 백엔드는 배포 후 애플리케이션 및 데이터베이스 상태를 확인하고, 문제 발생 시 자동으로 이전 버전으로 복구합니다.
  - 프론트엔드는 정적 파일 배포와 캐시 갱신을 자동화하고, 오래된 자산을 정리합니다.
  - 배포 결과와 성공·실패 상태를 알림으로 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->