### PR TITLE
feat: 관리자 계정 발급 및 초대 기반 비밀번호 설정 추가

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -25,16 +25,29 @@ DATABASE_URL=
 # Project Settings > API Keys > Publishable key 의 값.
 # password login 호출에만 쓰며 프론트로 내보내지 않는다.
 #
-# 로그인 계정은 Supabase Dashboard > Authentication > Users 에서만 만든다.
+# 일반 계정은 /admin 화면에서 발급한다. 어드민 계정 자신과 개발 DB 재구축만
+# Dashboard > Authentication > Users 에서 직접 만든다 (backend/sql/README.md 참고).
 # 이메일과 비밀번호는 이 파일을 포함해 저장소 어디에도 두지 않는다.
 SUPABASE_PUBLISHABLE_KEY=
+
+# 계정 발급 (/admin)
+#
+# 계정을 발급할 수 있는 Supabase 사용자 id 목록. 쉼표로 여러 개 지정 가능.
+# 권한의 근거를 DB 밖에 둔다. member 행만 고쳐서는 어드민이 될 수 없다.
+# UID 는 자격증명이 아니지만 환경에 종속된 값이라 이 파일에 두지 않는다.
+ADMIN_USER_IDS=
+
+# 초대 메일이 착지할 프론트 주소. Supabase Dashboard 의 Redirect URLs 에도
+# 같은 주소의 /set-password 를 등록해야 링크가 되돌아온다.
+FRONTEND_BASE_URL=http://localhost:5173
 
 # 미사용 세션이 만료되기까지의 시간. 기본 30일.
 # Supabase Dashboard 의 Inactivity timeout 과 같은 값으로 맞춘다.
 # REFRESH_COOKIE_MAX_AGE_SECONDS=2592000
 
-# Supabase Storage (자료실 파일)
+# Supabase Storage (자료실 파일) 와 계정 발급이 함께 쓰는 키
 # Project Settings > API Keys > Secret keys 의 값. 서버에서만 쓰고 브라우저로 보내지 않는다.
+# RLS 를 우회하고 사용자를 만들고 지울 수 있다. 유출되면 계정 전체가 넘어간다.
 SUPABASE_SECRET_KEY=
 SUPABASE_STORAGE_BUCKET=salesluv-documents
 

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 from app.api import (
     activities,
+    admin,
     agent_runs,
     auth,
     customers,
@@ -30,3 +31,4 @@ api_router.include_router(agent_runs.router)
 api_router.include_router(documents.router)
 api_router.include_router(dashboard.router)
 api_router.include_router(transcriptions.router)
+api_router.include_router(admin.router)

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -1,0 +1,131 @@
+"""어드민 계정 발급 API.
+
+계정 하나를 만드는 일이 Supabase Auth 와 public 스키마 양쪽에 걸쳐 있다.
+어느 한쪽만 남는 상태를 만들지 않는 것이 이 모듈의 일이다.
+
+발급 권한의 근거는 member.role_code 가 아니라 ADMIN_USER_IDS 다. deps.get_admin_member 를 본다.
+"""
+
+from uuid import UUID, uuid4
+
+from fastapi import APIRouter, HTTPException, status
+from sqlalchemy import func, select
+
+from app.api.auth import auth_http_error
+from app.api.deps import CurrentAdmin, DbSession
+from app.core.config import settings
+from app.models.workspace import Member, Team
+from app.schemas.admin import AccountCreate, AccountCreated, TeamRead
+from app.services import supabase_auth
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+@router.get("/teams", response_model=list[TeamRead])
+async def list_teams(_admin: CurrentAdmin, db: DbSession) -> list[dict]:
+    """팀과 구성원 전체. 발급 화면이 기존 팀에 붙일지 새로 만들지 고르는 데 쓴다.
+
+    어드민은 팀 경계를 넘어 본다. 다른 라우터의 team_id 스코프가 여기에는 없다.
+    """
+    teams = (await db.execute(select(Team).order_by(Team.created_at))).scalars().all()
+    members = (await db.execute(select(Member).order_by(Member.display_name))).scalars().all()
+
+    by_team: dict[UUID, list[Member]] = {}
+    for member in members:
+        by_team.setdefault(member.team_id, []).append(member)
+
+    return [
+        {
+            "id": team.id,
+            "name": team.name,
+            "company_name": team.company_name,
+            "department": team.department,
+            "business_no": team.business_no,
+            "member_count": len(by_team.get(team.id, [])),
+            "members": by_team.get(team.id, []),
+        }
+        for team in teams
+    ]
+
+
+@router.post(
+    "/accounts",
+    response_model=AccountCreated,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_account(
+    payload: AccountCreate,
+    _admin: CurrentAdmin,
+    db: DbSession,
+) -> Member:
+    """Supabase 사용자 생성·초대 메일·team/member 등록을 한 번에 끝낸다.
+
+    순서를 되돌릴 수 있게 잡는다. member.id 는 auth 사용자 id 와 같아야 하므로
+    초대가 먼저고, 그 뒤 DB 쓰기가 실패하면 만든 사용자를 지워 되돌린다.
+    """
+    team = await _resolve_team(payload, db)
+
+    try:
+        member_id = await supabase_auth.invite_user(
+            email=payload.email,
+            redirect_to=f"{settings.frontend_base_url.rstrip('/')}/set-password",
+        )
+    except supabase_auth.EmailAlreadyExists as error:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="email_already_exists",
+        ) from error
+    except supabase_auth.AuthError as error:
+        raise auth_http_error(error) from error
+
+    member = Member(
+        id=member_id,
+        team_id=team.id,
+        display_name=payload.display_name,
+        role_code=payload.role_code,
+        email=payload.email,
+        active=True,
+    )
+    db.add(member)
+    try:
+        await db.flush()
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        # 초대만 남으면 그 이메일로 다시 발급할 수 없게 된다. 반드시 되돌린다.
+        try:
+            await supabase_auth.delete_user(user_id=member_id)
+        except supabase_auth.AuthError:
+            # 되돌리기까지 실패했다. 원래 실패를 가리지 않고 그대로 올린다.
+            pass
+        raise
+
+    return member
+
+
+async def _resolve_team(payload: AccountCreate, db: DbSession) -> Team:
+    """기존 팀을 찾거나 새 팀을 만든다. 초대를 보내기 전에 끝낸다.
+
+    없는 팀을 가리켰다면 Supabase 사용자를 만들기 전에 멈추는 편이 낫다.
+    되돌릴 것이 없는 실패가 되돌려야 하는 실패보다 낫다.
+    """
+    if payload.team_id is not None:
+        team = await db.get(Team, payload.team_id)
+        if team is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="team_not_found")
+        return team
+
+    assert payload.team is not None  # AccountCreate 가 둘 중 하나임을 보장한다.
+    duplicate = await db.execute(
+        select(func.count()).select_from(Team).where(Team.name == payload.team.name)
+    )
+    if duplicate.scalar_one():
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="team_name_already_exists",
+        )
+
+    team = Team(id=uuid4(), **payload.team.model_dump())
+    db.add(team)
+    await db.flush()
+    return team

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -14,7 +14,7 @@ from fastapi.responses import JSONResponse
 from app.api.deps import CurrentMember, DbSession, active_member
 from app.core.config import settings
 from app.models.workspace import Member
-from app.schemas.auth import LoginRequest, SessionRead
+from app.schemas.auth import LoginRequest, SessionRead, SetPasswordRequest
 from app.services import supabase_auth
 from app.services.supabase_auth import SupabaseSession
 
@@ -69,6 +69,16 @@ def _release_login_attempt(client_host: str) -> None:
         _login_attempts.pop(client_host)
     else:
         _login_attempts[client_host] = (count - 1, started_at)
+
+
+def _session_read(member: Member) -> SessionRead:
+    """세션 응답. is_admin 은 member 행에 없으므로 여기서 채운다.
+
+    권한의 근거를 DB 밖에 두었기 때문에 ORM 객체를 그대로 돌려줄 수 없다.
+    """
+    return SessionRead.model_validate(member).model_copy(
+        update={"is_admin": member.id in settings.admin_user_id_set}
+    )
 
 
 def _set_session_cookies(response: Response, session: SupabaseSession) -> None:
@@ -150,7 +160,7 @@ async def login(
     request: Request,
     response: Response,
     db: DbSession,
-) -> Member:
+) -> SessionRead:
     client_host = request.client.host if request.client else "unknown"
     retry_after = _reserve_login_attempt(client_host)
     if retry_after is not None:
@@ -179,7 +189,7 @@ async def login(
 
     _release_login_attempt(client_host)
     _set_session_cookies(response, session)
-    return member
+    return _session_read(member)
 
 
 def _rejected(status_code: int, detail: str) -> JSONResponse:
@@ -194,7 +204,9 @@ def _rejected(status_code: int, detail: str) -> JSONResponse:
 
 
 @router.post("/refresh", response_model=SessionRead)
-async def refresh(request: Request, response: Response, db: DbSession) -> Member | JSONResponse:
+async def refresh(
+    request: Request, response: Response, db: DbSession
+) -> SessionRead | JSONResponse:
     refresh_token = request.cookies.get(REFRESH_COOKIE, "")
     if not refresh_token:
         return _rejected(status.HTTP_401_UNAUTHORIZED, "not_authenticated")
@@ -214,13 +226,36 @@ async def refresh(request: Request, response: Response, db: DbSession) -> Member
         return _rejected(status.HTTP_403_FORBIDDEN, "member_not_linked")
 
     _set_session_cookies(response, session)
-    return member
+    return _session_read(member)
 
 
 @router.get("/me", response_model=SessionRead)
-async def me(member: CurrentMember, response: Response) -> Member:
+async def me(member: CurrentMember, response: Response) -> SessionRead:
     response.headers["Cache-Control"] = "no-store"
-    return member
+    return _session_read(member)
+
+
+@router.post("/set-password", status_code=status.HTTP_204_NO_CONTENT)
+async def set_password(payload: SetPasswordRequest, response: Response) -> None:
+    """초대 메일로 들어온 사람이 자기 비밀번호를 정한다.
+
+    로그인 상태를 요구하지 않는다. 링크에 실려 온 토큰이 곧 자격증명이고,
+    Supabase 가 그 서명과 만료를 판정한다. 여기서 세션 쿠키를 굽지 않는다.
+    새 비밀번호가 실제로 되는지 로그인 화면에서 바로 확인되는 편이 낫다.
+    """
+    try:
+        await supabase_auth.update_password(
+            access_token=payload.access_token,
+            password=payload.password,
+        )
+    except supabase_auth.WeakPassword as error:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="password_rejected",
+        ) from error
+    except supabase_auth.AuthError as error:
+        raise auth_http_error(error) from error
+    response.headers["Cache-Control"] = "no-store"
 
 
 @router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -11,6 +11,7 @@ from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.db.session import get_db
 from app.models.workspace import Member, Team
 from app.services import supabase_auth
@@ -68,3 +69,22 @@ async def get_current_member(request: Request, db: DbSession) -> Member:
 
 
 type CurrentMember = Annotated[Member, Depends(get_current_member)]
+
+
+async def get_admin_member(member: CurrentMember) -> Member:
+    """계정을 발급할 수 있는 사람인지 본다.
+
+    판단 근거는 member.role_code 가 아니라 환경변수 허용목록이다. DB 행만
+    고쳐서 어드민이 될 수 있으면, 계정을 만들 수 있는 권한이 계정 안에 갇힌다.
+    """
+    if not settings.admin_configured:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="admin_not_configured",
+        )
+    if member.id not in settings.admin_user_id_set:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="admin_only")
+    return member
+
+
+type CurrentAdmin = Annotated[Member, Depends(get_admin_member)]

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -6,6 +6,7 @@
 
 from typing import Literal, Self
 from urllib.parse import urlsplit, urlunsplit
+from uuid import UUID
 
 from pydantic import Field, SecretStr, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -52,6 +53,13 @@ class Settings(BaseSettings):
     # 두 키 모두 서버 프로세스 안에서만 쓰고 브라우저로 보내지 않습니다.
     supabase_publishable_key: SecretStr = SecretStr("")
 
+    # 계정을 발급할 수 있는 Supabase 사용자 id 목록 (쉼표 구분).
+    # 권한의 근거를 DB 밖에 둔다. member 행만 고쳐서는 어드민이 될 수 없다.
+    admin_user_ids: str = ""
+
+    # 초대 메일이 착지할 프론트 주소. Supabase Dashboard 의 Redirect URLs 에도 같은 값을 등록한다.
+    frontend_base_url: str = "http://localhost:5173"
+
     # Supabase Storage. secret 키는 RLS 를 우회하므로 서버에서만 쓴다.
     supabase_secret_key: SecretStr = SecretStr("")
     supabase_storage_bucket: str = ""
@@ -72,6 +80,28 @@ class Settings(BaseSettings):
     def auth_configured(self) -> bool:
         """Supabase Auth 호출에 필요한 값이 모두 있는지. 없으면 인증을 503 으로 막는다."""
         return bool(self.supabase_project_url and self.supabase_publishable_key.get_secret_value())
+
+    @property
+    def admin_user_id_set(self) -> frozenset[UUID]:
+        """계정을 발급할 수 있는 사용자들. 형식이 틀린 값은 조용히 버리지 않는다.
+
+        조용히 버리면 오타 하나로 어드민이 사라지고, 그 사실을 403 을 받고 나서야 안다.
+        """
+        ids = [part.strip() for part in self.admin_user_ids.split(",") if part.strip()]
+        try:
+            return frozenset(UUID(value) for value in ids)
+        except ValueError as error:
+            raise ValueError("ADMIN_USER_IDS 는 쉼표로 구분한 UUID 목록이어야 합니다.") from error
+
+    @property
+    def admin_configured(self) -> bool:
+        """계정 발급에 필요한 값이 모두 있는지. 없으면 기능을 503 으로 막는다."""
+        return bool(
+            self.admin_user_id_set
+            and self.supabase_project_url
+            and self.supabase_secret_key.get_secret_value()
+            and self.frontend_base_url
+        )
 
     @property
     def storage_configured(self) -> bool:
@@ -100,6 +130,12 @@ class Settings(BaseSettings):
     def session_cookie_secure(self) -> bool:
         """access/refresh 쿠키가 함께 쓰는 Secure 플래그."""
         return self.app_env == "production"
+
+    @model_validator(mode="after")
+    def validate_admin_user_ids(self) -> Self:
+        """형식이 틀린 목록은 부팅에서 잡는다. 403 을 받고 나서 알게 하지 않는다."""
+        _ = self.admin_user_id_set
+        return self
 
     @model_validator(mode="after")
     def validate_production_security(self) -> Self:

--- a/backend/app/models/workspace.py
+++ b/backend/app/models/workspace.py
@@ -12,6 +12,10 @@ class Team(Base):
 
     id: Mapped[UUID] = mapped_column(primary_key=True)
     name: Mapped[str]
+    company_name: Mapped[str | None]
+    department: Mapped[str | None]
+    # 하이픈 없는 10자리. 화면에 보일 하이픈은 프론트가 붙인다.
+    business_no: Mapped[str | None]
     created_at: Mapped[datetime] = mapped_column(server_default=text("now()"))
 
 
@@ -25,6 +29,8 @@ class Member(Base):
     display_name: Mapped[str]
     role_code: Mapped[str]
     job_title: Mapped[str | None]
+    # auth.users.email 의 사본. 권한 판단에는 쓰지 않고 어드민 목록 표시에만 쓴다.
+    email: Mapped[str | None]
     active: Mapped[bool] = mapped_column(server_default=text("true"))
     created_at: Mapped[datetime] = mapped_column(server_default=text("now()"))
 

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -1,0 +1,109 @@
+"""어드민 계정 발급 스키마.
+
+비밀번호는 어디에도 없다. Supabase 초대 메일이 그 자리를 대신하므로
+발급하는 쪽이 비밀번호를 알 방법도, 전달할 이유도 없다.
+"""
+
+from typing import Annotated, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, StringConstraints, field_validator, model_validator
+
+from app.schemas.auth import Email
+
+Name = Annotated[
+    str, StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=100)
+]
+RoleCode = Literal["member", "manager"]
+
+# 국세청 사업자등록번호 검증 가중치. 마지막 자리는 검증 숫자다.
+_BUSINESS_NO_WEIGHTS = (1, 3, 7, 1, 3, 7, 1, 3, 5)
+
+
+def _is_valid_business_no(digits: str) -> bool:
+    """10자리 사업자등록번호의 검증 숫자를 확인한다.
+
+    형식만 보면 오타 한 글자가 그대로 저장된다. 세금계산서가 걸리는 값이라
+    자릿수만으로 통과시키지 않는다.
+    """
+    total = sum(int(d) * w for d, w in zip(digits[:9], _BUSINESS_NO_WEIGHTS, strict=True))
+    total += int(digits[8]) * 5 // 10
+    return (10 - total % 10) % 10 == int(digits[9])
+
+
+class TeamCreate(BaseModel):
+    """새로 만들 팀. 회사명·부서명은 없어도 되지만 팀명은 있어야 한다."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: Name
+    company_name: Name | None = None
+    department: Name | None = None
+    # 하이픈과 공백은 받아서 벗긴다. 저장은 숫자 10자리로만 한다.
+    business_no: str | None = None
+
+    @field_validator("business_no")
+    @classmethod
+    def normalize_business_no(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        digits = "".join(ch for ch in value if not ch.isspace() and ch != "-")
+        if not digits:
+            return None
+        if len(digits) != 10 or not digits.isdigit():
+            raise ValueError("사업자등록번호는 숫자 10자리여야 합니다.")
+        if not _is_valid_business_no(digits):
+            raise ValueError("사업자등록번호의 검증 숫자가 맞지 않습니다.")
+        return digits
+
+
+class AccountCreate(BaseModel):
+    """계정 하나를 발급한다. 팀은 고르거나 새로 만들거나 둘 중 하나다."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    email: Email
+    display_name: Name
+    role_code: RoleCode
+    team_id: UUID | None = None
+    team: TeamCreate | None = None
+
+    @model_validator(mode="after")
+    def exactly_one_team(self) -> "AccountCreate":
+        if (self.team_id is None) == (self.team is None):
+            raise ValueError("team_id 와 team 중 정확히 하나만 보냅니다.")
+        return self
+
+
+class TeamMemberRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    display_name: str
+    email: str | None
+    role_code: str
+    active: bool
+
+
+class TeamRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    name: str
+    company_name: str | None
+    department: str | None
+    business_no: str | None
+    member_count: int
+    members: list[TeamMemberRead]
+
+
+class AccountCreated(BaseModel):
+    """발급 결과. 초대 메일이 나갔다는 사실까지가 이 응답의 의미다."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    team_id: UUID
+    display_name: str
+    email: str | None
+    role_code: str

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -16,7 +16,10 @@ Email = Annotated[
         pattern=r"^[^@\s]+@[^@\s]+$",
     ),
 ]
+# 로그인에서는 길이를 막지 않는다. 막으면 비밀번호 정책이 응답으로 새어 나간다.
 Password = Annotated[str, StringConstraints(strict=True, min_length=1, max_length=256)]
+# 새로 정하는 비밀번호에만 하한을 둔다. 나머지 정책은 Supabase 가 판정한다.
+NewPassword = Annotated[str, StringConstraints(strict=True, min_length=8, max_length=256)]
 
 
 class LoginRequest(BaseModel):
@@ -24,6 +27,15 @@ class LoginRequest(BaseModel):
 
     email: Email
     password: Password
+
+
+class SetPasswordRequest(BaseModel):
+    """초대·복구 링크로 받은 토큰이 곧 자격증명이다. 로그인 상태를 요구하지 않는다."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    access_token: str
+    password: NewPassword
 
 
 class SessionRead(BaseModel):
@@ -34,3 +46,5 @@ class SessionRead(BaseModel):
     display_name: str
     role_code: Literal["member", "manager"]
     job_title: str | None
+    # 계정 발급 권한. member 행이 아니라 ADMIN_USER_IDS 에서 나온다.
+    is_admin: bool = False

--- a/backend/app/services/supabase_auth.py
+++ b/backend/app/services/supabase_auth.py
@@ -1,14 +1,17 @@
 """Supabase Auth 호출 경계.
 
-password login, 세션 갱신, 로그아웃, access token 검증 네 가지만 둔다.
+password login, 세션 갱신, 로그아웃, access token 검증에 더해
+어드민 계정 발급이 쓰는 초대·삭제·비밀번호 변경까지 둔다.
 인증 공급자를 바꾸면 이 모듈만 교체한다.
 
 publishable 키는 Auth REST 호출에만 쓰고 브라우저로 보내지 않는다.
+secret 키는 사용자를 만들고 지울 수 있으므로 admin 경로에서만 쓴다.
 비밀번호와 토큰은 예외 메시지나 로그에 남기지 않는다.
 """
 
 import time
 from dataclasses import dataclass
+from urllib.parse import quote
 from uuid import UUID
 
 import httpx
@@ -45,6 +48,14 @@ class InvalidCredentials(AuthError):
     """자격증명이 틀렸거나 refresh token 이 더 이상 유효하지 않다. 401 로 바꾼다."""
 
 
+class EmailAlreadyExists(AuthError):
+    """그 이메일의 Supabase 사용자가 이미 있다. 409 로 바꾼다."""
+
+
+class WeakPassword(AuthError):
+    """Supabase 의 비밀번호 정책에 걸렸다. 422 로 바꾼다. 본문은 옮기지 않는다."""
+
+
 @dataclass(frozen=True, slots=True)
 class SupabaseSession:
     """Supabase 가 돌려준 세션. 쿠키로만 나가고 응답 본문에는 넣지 않는다."""
@@ -63,9 +74,20 @@ def _headers() -> dict[str, str]:
     return {"apikey": key, "Authorization": f"Bearer {key}", "Content-Type": "application/json"}
 
 
+def _admin_headers() -> dict[str, str]:
+    """사용자를 만들고 지울 수 있는 키다. 이 모듈의 admin 함수 밖으로 새어 나가면 안 된다."""
+    key = settings.supabase_secret_key.get_secret_value()
+    return {"apikey": key, "Authorization": f"Bearer {key}", "Content-Type": "application/json"}
+
+
 def _require_config() -> None:
     if not settings.auth_configured:
         raise AuthNotConfigured("auth_not_configured")
+
+
+def _require_admin_config() -> None:
+    if not settings.admin_configured:
+        raise AuthNotConfigured("admin_not_configured")
 
 
 def _session_from(payload: object) -> SupabaseSession:
@@ -132,6 +154,82 @@ async def sign_out(*, access_token: str) -> None:
         raise AuthUnavailable(f"auth_request_failed:{type(error).__name__}") from error
     if response.status_code >= 500:
         raise AuthUnavailable(f"auth_upstream_failed:{response.status_code}")
+
+
+async def invite_user(*, email: str, redirect_to: str) -> UUID:
+    """사용자를 만들고 초대 메일을 보낸다. 두 가지가 한 호출로 끝난다.
+
+    비밀번호는 여기서 정하지 않는다. 받는 사람이 메일 링크에서 직접 정하므로
+    임시 비밀번호가 어디에도 남지 않는다.
+    """
+    _require_admin_config()
+    url = _endpoint(f"invite?redirect_to={quote(redirect_to, safe='')}")
+    try:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            response = await client.post(url, headers=_admin_headers(), json={"email": email})
+    except httpx.HTTPError as error:
+        raise AuthUnavailable(f"auth_request_failed:{type(error).__name__}") from error
+
+    if response.status_code in (409, 422):
+        raise EmailAlreadyExists("email_already_exists")
+    if response.status_code == 429:
+        raise AuthRateLimited("auth_rate_limited")
+    if response.status_code >= 500:
+        raise AuthUnavailable(f"auth_upstream_failed:{response.status_code}")
+    if response.status_code >= 400:
+        raise AuthUnavailable(f"auth_invite_failed:{response.status_code}")
+
+    try:
+        user_id = response.json()["id"]
+    except (ValueError, KeyError, TypeError) as error:
+        raise AuthUnavailable("auth_response_invalid") from error
+    try:
+        return UUID(user_id)
+    except (ValueError, AttributeError, TypeError) as error:
+        raise AuthUnavailable("auth_response_invalid") from error
+
+
+async def delete_user(*, user_id: UUID) -> None:
+    """초대 뒤 DB 기록이 실패했을 때 되돌리기 위해 쓴다. 그 밖에는 부르지 않는다."""
+    _require_admin_config()
+    url = _endpoint(f"admin/users/{user_id}")
+    try:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            response = await client.delete(url, headers=_admin_headers())
+    except httpx.HTTPError as error:
+        raise AuthUnavailable(f"auth_request_failed:{type(error).__name__}") from error
+    # 이미 없으면 되돌릴 것도 없다. 404 는 성공으로 본다.
+    if response.status_code >= 400 and response.status_code != 404:
+        raise AuthUnavailable(f"auth_delete_failed:{response.status_code}")
+
+
+async def update_password(*, access_token: str, password: str) -> None:
+    """초대·복구 링크로 받은 토큰을 자격증명 삼아 비밀번호를 정한다.
+
+    publishable 키를 쓴다. 이 호출은 토큰 주인 자신만 바꿀 수 있으므로
+    사용자를 임의로 건드릴 수 있는 secret 키가 필요하지 않다.
+    """
+    _require_config()
+    if not isinstance(access_token, str) or not access_token:
+        raise InvalidCredentials("invalid_token")
+
+    url = _endpoint("user")
+    headers = {**_headers(), "Authorization": f"Bearer {access_token}"}
+    try:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            response = await client.put(url, headers=headers, json={"password": password})
+    except httpx.HTTPError as error:
+        raise AuthUnavailable(f"auth_request_failed:{type(error).__name__}") from error
+
+    if response.status_code in (401, 403):
+        raise InvalidCredentials("invalid_token")
+    if response.status_code == 429:
+        raise AuthRateLimited("auth_rate_limited")
+    if response.status_code >= 500:
+        raise AuthUnavailable(f"auth_upstream_failed:{response.status_code}")
+    if response.status_code >= 400:
+        # 비밀번호 정책 위반 등. 본문에 비밀번호가 섞일 수 있으므로 코드만 남긴다.
+        raise WeakPassword("password_rejected")
 
 
 # JWKS 는 자주 바뀌지 않는다. TTL 안에서는 다시 받지 않아 요청마다 네트워크를 타지 않는다.

--- a/backend/sql/20260823_0002_admin_account_provisioning.sql
+++ b/backend/sql/20260823_0002_admin_account_provisioning.sql
@@ -1,0 +1,47 @@
+-- 어드민 계정 발급(/admin)을 위한 스키마 변경.
+--
+-- 지금까지 로그인 계정은 Supabase Dashboard 에서 사람이 만들고 public.member 행도
+-- 손으로 넣었다. 이 변경 이후로는 어드민이 화면에서 계정을 발급하고, Supabase Auth 의
+-- invite 가 메일 발송과 비밀번호 설정을 대신한다.
+--
+-- 계정 발급 권한의 근거는 DB 가 아니라 ADMIN_USER_IDS 환경변수다. member 행만
+-- 고쳐서는 어드민이 될 수 없다.
+
+BEGIN;
+
+ALTER TABLE public.team
+    ADD COLUMN company_name text
+        CHECK (company_name IS NULL OR btrim(company_name) <> ''),
+    ADD COLUMN department text
+        CHECK (department IS NULL OR btrim(department) <> ''),
+    -- 하이픈 없이 10자리로만 저장한다. 화면에 보일 하이픈은 프론트가 붙인다.
+    ADD COLUMN business_no text
+        CHECK (business_no IS NULL OR business_no ~ '^[0-9]{10}$');
+
+COMMENT ON COLUMN public.team.business_no IS
+    '사업자등록번호 10자리. 하이픈 없이 저장한다.';
+
+-- 이메일의 주인은 auth.users 다. 여기 값은 어드민 목록 화면이 팀별로 훑기 위한 사본이다.
+-- 사용자가 이메일을 바꿀 수 있는 화면이 없으므로 지금은 어긋날 경로가 없다.
+ALTER TABLE public.member
+    ADD COLUMN email text CHECK (email IS NULL OR btrim(email) <> '');
+
+COMMENT ON COLUMN public.member.email IS
+    'auth.users.email 의 사본. 권한 판단에는 쓰지 않고 어드민 목록 표시에만 쓴다.';
+
+-- 기존 행에는 email 이 없다. NULL 은 서로 충돌하지 않으므로 부분 인덱스로 둔다.
+CREATE UNIQUE INDEX member_email_uq
+    ON public.member (lower(email)) WHERE email IS NOT NULL;
+
+COMMIT;
+
+-- 적용 후 수동으로 해야 하는 일 (실제 UUID 는 저장소에 두지 않는다):
+--
+--   1. Supabase Dashboard > Authentication > Users 에서 어드민 계정 하나를 만든다.
+--   2. 그 user id 를 백엔드 ADMIN_USER_IDS 에 넣는다.
+--   3. 어드민 전용 팀과 member 행을 넣는다. 이 팀은 다른 팀 조회에 섞이지 않는다.
+--      모든 라우터가 team_id 로 스코프를 걸기 때문이다.
+--
+--   INSERT INTO public.team (id, name) VALUES ('<team-uuid>', 'SalesLuv 운영');
+--   INSERT INTO public.member (id, team_id, display_name, role_code, email)
+--   VALUES ('<auth-user-uuid>', '<team-uuid>', '운영자', 'manager', '<admin-email>');

--- a/backend/sql/README.md
+++ b/backend/sql/README.md
@@ -34,7 +34,12 @@
   다만 `app/models/sales.py`가 이름으로 참조하는 네 개(`sales_pipeline_stage_*_key` 3개와
   `sales_deal_sales_pipeline_stage_membership_fkey`)는 그대로 유지합니다.
 
-이 파일은 빈 `public` 스키마에 처음부터 만드는 것을 전제로 합니다. 되돌리는 마이그레이션이
+- `20260823_0002_admin_account_provisioning.sql`: `/admin` 계정 발급 화면이 쓰는 컬럼을 더합니다.
+  `team`에 `company_name`, `department`, `business_no`(하이픈 없는 10자리), `member`에 `email`을
+  추가하고 `member(lower(email))`에 부분 유일 인덱스를 겁니다. `email`의 주인은 여전히
+  `auth.users`이며 여기 값은 어드민 목록 표시용 사본입니다. 권한 판단에는 쓰지 않습니다.
+
+`20260819_0001`은 빈 `public` 스키마에 처음부터 만드는 것을 전제로 합니다. 되돌리는 마이그레이션이
 아니므로 적용 전에 아래 런북의 1~2단계를 먼저 수행합니다.
 
 ## 적용 이력
@@ -43,11 +48,16 @@
 |---|---|---|---|---|
 | 2026-08-19 | 개발 | (런북 1단계) 26테이블 `DROP TABLE ... CASCADE` | session pooler | 성공. public 테이블 0개 |
 | 2026-08-19 | 개발 | `20260819_0001_baseline_schema.sql` | session pooler | 성공. 26테이블 / 264컬럼 / FK 65 / RLS 26 |
+| 2026-08-23 | 개발 | `20260823_0002_admin_account_provisioning.sql` | session pooler | 성공. team +3컬럼 / member +1컬럼 / 부분 유일 인덱스 1. 기존 1팀 2명 그대로 |
 
 ## 개발 DB 재구축 런북
 
-로그인은 Supabase Auth가 담당합니다. 계정의 이메일과 비밀번호는 Supabase Dashboard에서만
-관리하며 `.env`를 포함해 저장소 어디에도 두지 않습니다.
+로그인은 Supabase Auth가 담당합니다. 계정의 이메일과 비밀번호는 저장소 어디에도 두지 않습니다.
+
+`20260823_0002` 적용 이후 일반 계정은 `/admin` 화면에서 발급합니다. 어드민이 이메일과 팀을 넣으면
+Supabase 사용자 생성·초대 메일 발송·`team`/`member` 행 등록이 한 번에 끝나고, 받는 사람이 메일
+링크에서 비밀번호를 직접 정합니다. Dashboard에서 직접 만드는 것은 아래 재구축 런북과 어드민
+계정 자신에게만 해당합니다.
 
 현재 개발 계정은 두 개입니다.
 

--- a/backend/tests/test_admin_accounts.py
+++ b/backend/tests/test_admin_accounts.py
@@ -1,0 +1,350 @@
+"""어드민 계정 발급 테스트.
+
+실제 Supabase 를 부르지 않는다. supabase_auth 의 admin 함수 세 개를 갈아끼워
+"어느 한쪽만 남는 상태"가 생기는지를 본다.
+"""
+
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from app.api.deps import get_current_member
+from app.core.config import settings
+from app.db.session import get_db
+from app.main import app
+from app.models.workspace import Member, Team
+from app.services import supabase_auth
+
+ORIGIN = settings.cors_origin_list[0]
+ADMIN_ID = UUID("aaaaaaaa-1111-4111-8111-111111111111")
+PLAIN_ID = UUID("bbbbbbbb-2222-4222-8222-222222222222")
+INVITED_ID = UUID("cccccccc-3333-4333-8333-333333333333")
+# 검증 숫자가 맞는 사업자등록번호.
+VALID_BUSINESS_NO = "220-81-62517"
+
+
+class _Db:
+    """계정 발급이 실제로 쓰는 만큼만 흉내낸다: get / add / flush / commit / rollback."""
+
+    def __init__(
+        self,
+        *,
+        teams: list[Team] | None = None,
+        members: list[Member] | None = None,
+        fail_on_commit: bool = False,
+    ):
+        self.teams = teams or []
+        self.members = members or []
+        self.added: list[object] = []
+        self.fail_on_commit = fail_on_commit
+        self.committed = False
+        self.rolled_back = False
+
+    async def get(self, _model, key):
+        return next((team for team in self.teams if team.id == key), None)
+
+    async def execute(self, statement):
+        # list_teams 는 Team 과 Member 를 차례로 훑고, _resolve_team 은 count 를 센다.
+        text = str(statement)
+        if "FROM public.member" in text:
+            return _CountResult(len(self.members), self.members)
+        if "count(" in text:
+            return _CountResult(len(self.teams))
+        return _CountResult(len(self.teams), self.teams)
+
+    def add(self, entity):
+        self.added.append(entity)
+
+    async def flush(self):
+        return None
+
+    async def commit(self):
+        if self.fail_on_commit:
+            raise RuntimeError("commit failed")
+        self.committed = True
+
+    async def rollback(self):
+        self.rolled_back = True
+
+
+class _CountResult:
+    """count() 와 목록 조회 두 쓰임을 함께 흉내낸다."""
+
+    def __init__(self, value: int, rows: list | None = None):
+        self.value = value
+        self.rows = rows or []
+
+    def scalar_one(self) -> int:
+        return self.value
+
+    def scalars(self):
+        return self
+
+    def all(self) -> list:
+        return self.rows
+
+
+class _SupabaseSpy:
+    """invite / delete 호출을 기록한다. 되돌리기가 실제로 일어났는지 보려고 둔다."""
+
+    def __init__(self, *, invite: UUID | Exception = INVITED_ID):
+        self.invite_outcome = invite
+        self.invited: list[str] = []
+        self.deleted: list[UUID] = []
+
+    async def invite_user(self, *, email: str, redirect_to: str) -> UUID:
+        self.invited.append(email)
+        self.redirect_to = redirect_to
+        if isinstance(self.invite_outcome, Exception):
+            raise self.invite_outcome
+        return self.invite_outcome
+
+    async def delete_user(self, *, user_id: UUID) -> None:
+        self.deleted.append(user_id)
+
+
+def _member(member_id: UUID) -> Member:
+    return Member(
+        id=member_id,
+        team_id=uuid4(),
+        display_name="합성 사용자",
+        role_code="manager",
+        job_title=None,
+        active=True,
+    )
+
+
+@pytest.fixture(autouse=True)
+def admin_environment(monkeypatch):
+    monkeypatch.setattr(settings, "supabase_url", "https://project.supabase.test")
+    monkeypatch.setattr(settings, "supabase_secret_key", SecretStr("secret-test-key"))
+    monkeypatch.setattr(settings, "admin_user_ids", str(ADMIN_ID))
+    monkeypatch.setattr(settings, "frontend_base_url", "https://app.salesluv.test")
+    app.dependency_overrides.clear()
+    yield
+    app.dependency_overrides.clear()
+
+
+def _client(*, signed_in_as: UUID | None, db: _Db, spy: _SupabaseSpy, monkeypatch) -> TestClient:
+    monkeypatch.setattr(supabase_auth, "invite_user", spy.invite_user)
+    monkeypatch.setattr(supabase_auth, "delete_user", spy.delete_user)
+
+    async def override_db():
+        yield db
+
+    app.dependency_overrides[get_db] = override_db
+    if signed_in_as is not None:
+        app.dependency_overrides[get_current_member] = lambda: _member(signed_in_as)
+    return TestClient(app)
+
+
+def _payload(**overrides) -> dict:
+    payload = {
+        "email": "new.member@salesluv.test",
+        "display_name": "김신입",
+        "role_code": "member",
+        "team": {
+            "name": "영업 1팀",
+            "company_name": "세일즈러브",
+            "department": "영업본부",
+            "business_no": VALID_BUSINESS_NO,
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _post(client: TestClient, payload: dict):
+    return client.post("/api/admin/accounts", headers={"Origin": ORIGIN}, json=payload)
+
+
+def test_non_admin_member_cannot_create_accounts(monkeypatch):
+    spy = _SupabaseSpy()
+    client = _client(signed_in_as=PLAIN_ID, db=_Db(), spy=spy, monkeypatch=monkeypatch)
+
+    with client:
+        response = _post(client, _payload())
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "admin_only"
+    # 막혔다면 Supabase 사용자도 생기지 않아야 한다.
+    assert spy.invited == []
+
+
+def test_admin_creates_team_and_member_and_sends_one_invite(monkeypatch):
+    spy = _SupabaseSpy()
+    db = _Db()
+    client = _client(signed_in_as=ADMIN_ID, db=db, spy=spy, monkeypatch=monkeypatch)
+
+    with client:
+        response = _post(client, _payload())
+
+    assert response.status_code == 201
+    body = response.json()
+    # member.id 는 초대가 만든 auth 사용자 id 와 같아야 한다.
+    assert body["id"] == str(INVITED_ID)
+    assert body["email"] == "new.member@salesluv.test"
+    assert spy.invited == ["new.member@salesluv.test"]
+    assert spy.redirect_to == "https://app.salesluv.test/set-password"
+    assert db.committed and not db.rolled_back
+    assert spy.deleted == []
+
+    team = next(entity for entity in db.added if isinstance(entity, Team))
+    member = next(entity for entity in db.added if isinstance(entity, Member))
+    assert team.business_no == "2208162517"
+    assert team.company_name == "세일즈러브"
+    assert member.team_id == team.id
+    assert member.role_code == "member"
+
+
+def test_db_failure_removes_the_invited_supabase_user(monkeypatch):
+    spy = _SupabaseSpy()
+    db = _Db(fail_on_commit=True)
+    client = _client(signed_in_as=ADMIN_ID, db=db, spy=spy, monkeypatch=monkeypatch)
+
+    with client, pytest.raises(RuntimeError):
+        _post(client, _payload())
+
+    assert db.rolled_back and not db.committed
+    # 초대만 남으면 그 이메일로 다시 발급할 수 없게 된다.
+    assert spy.deleted == [INVITED_ID]
+
+
+def test_existing_email_is_a_conflict_and_writes_nothing(monkeypatch):
+    spy = _SupabaseSpy(invite=supabase_auth.EmailAlreadyExists("email_already_exists"))
+    db = _Db()
+    client = _client(signed_in_as=ADMIN_ID, db=db, spy=spy, monkeypatch=monkeypatch)
+
+    with client:
+        response = _post(client, _payload())
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "email_already_exists"
+    assert not db.committed
+    assert not any(isinstance(entity, Member) for entity in db.added)
+
+
+def test_unknown_team_id_fails_before_any_supabase_user_is_made(monkeypatch):
+    spy = _SupabaseSpy()
+    db = _Db()
+    client = _client(signed_in_as=ADMIN_ID, db=db, spy=spy, monkeypatch=monkeypatch)
+
+    with client:
+        response = _post(client, _payload(team=None, team_id=str(uuid4())))
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "team_not_found"
+    # 되돌릴 것이 없는 실패가 되돌려야 하는 실패보다 낫다.
+    assert spy.invited == []
+
+
+def test_account_joins_an_existing_team_without_creating_one(monkeypatch):
+    existing = Team(id=uuid4(), name="영업 1팀")
+    spy = _SupabaseSpy()
+    db = _Db(teams=[existing])
+    client = _client(signed_in_as=ADMIN_ID, db=db, spy=spy, monkeypatch=monkeypatch)
+
+    with client:
+        response = _post(client, _payload(team=None, team_id=str(existing.id)))
+
+    assert response.status_code == 201
+    assert response.json()["team_id"] == str(existing.id)
+    assert not any(isinstance(entity, Team) for entity in db.added)
+
+
+@pytest.mark.parametrize("business_no", ["220-81-62518", "12345", "abcdefghij"])
+def test_business_no_checksum_is_enforced(business_no, monkeypatch):
+    spy = _SupabaseSpy()
+    db = _Db()
+    client = _client(signed_in_as=ADMIN_ID, db=db, spy=spy, monkeypatch=monkeypatch)
+    payload = _payload()
+    payload["team"]["business_no"] = business_no
+
+    with client:
+        response = _post(client, payload)
+
+    assert response.status_code == 422
+    assert spy.invited == []
+
+
+def test_admin_surface_is_unavailable_when_unconfigured(monkeypatch):
+    monkeypatch.setattr(settings, "admin_user_ids", "")
+    spy = _SupabaseSpy()
+    client = _client(signed_in_as=ADMIN_ID, db=_Db(), spy=spy, monkeypatch=monkeypatch)
+
+    with client:
+        response = _post(client, _payload())
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "admin_not_configured"
+
+
+def test_signed_out_request_is_unauthenticated(monkeypatch):
+    spy = _SupabaseSpy()
+    client = _client(signed_in_as=None, db=_Db(), spy=spy, monkeypatch=monkeypatch)
+
+    with client:
+        response = _post(client, _payload())
+
+    assert response.status_code == 401
+    assert spy.invited == []
+
+
+def test_teams_listing_is_admin_only(monkeypatch):
+    spy = _SupabaseSpy()
+    client = _client(signed_in_as=PLAIN_ID, db=_Db(), spy=spy, monkeypatch=monkeypatch)
+
+    with client:
+        assert client.get("/api/admin/teams").status_code == 403
+
+
+def test_teams_listing_carries_members_and_counts(monkeypatch):
+    """발급 화면이 기존 팀을 고르고 이미 있는 계정을 확인하는 데 쓰는 응답이다."""
+    team = Team(
+        id=uuid4(),
+        name="영업 1팀",
+        company_name="세일즈러브",
+        department="영업본부",
+        business_no="2208162517",
+    )
+    member = Member(
+        id=uuid4(),
+        team_id=team.id,
+        display_name="김지훈",
+        role_code="member",
+        job_title=None,
+        email="jihoon@salesluv.test",
+        active=True,
+    )
+    client = _client(
+        signed_in_as=ADMIN_ID,
+        db=_Db(teams=[team], members=[member]),
+        spy=_SupabaseSpy(),
+        monkeypatch=monkeypatch,
+    )
+
+    with client:
+        response = client.get("/api/admin/teams")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "id": str(team.id),
+            "name": "영업 1팀",
+            "company_name": "세일즈러브",
+            "department": "영업본부",
+            "business_no": "2208162517",
+            "member_count": 1,
+            "members": [
+                {
+                    "id": str(member.id),
+                    "display_name": "김지훈",
+                    "email": "jihoon@salesluv.test",
+                    "role_code": "member",
+                    "active": True,
+                }
+            ],
+        }
+    ]

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -186,6 +186,8 @@ def test_login_sets_token_cookies_and_a_readable_session_hint(monkeypatch):
         "display_name": "합성 팀장",
         "role_code": "manager",
         "job_title": "영업팀장",
+        # ADMIN_USER_IDS 가 비어 있으므로 어드민이 아니다.
+        "is_admin": False,
     }
     cookies = _cookie_text(response)
     assert _cookie_names(response) == SESSION_COOKIES
@@ -459,6 +461,64 @@ def test_validation_error_does_not_echo_password(monkeypatch):
     assert response.status_code == 422
     assert submitted_password not in response.text
     assert all("input" not in error for error in response.json()["detail"])
+
+
+def test_set_password_forwards_the_invite_token_and_keeps_the_password_quiet(monkeypatch):
+    """초대 링크로 들어온 사람이 로그인 없이 비밀번호를 정한다."""
+    calls: list[tuple[str, str]] = []
+
+    async def fake_update_password(*, access_token: str, password: str) -> None:
+        calls.append((access_token, password))
+
+    monkeypatch.setattr(supabase_auth, "update_password", fake_update_password)
+    client, _stub = _client(None, monkeypatch)
+    token = access_token()
+    chosen = secrets.token_urlsafe(16)
+
+    with client:
+        response = client.post(
+            "/api/auth/set-password",
+            headers={"Origin": ORIGIN},
+            json={"access_token": token, "password": chosen},
+        )
+
+    assert response.status_code == 204
+    assert calls == [(token, chosen)]
+    # 쿠키를 굽지 않는다. 새 비밀번호는 로그인 화면에서 확인시킨다.
+    assert _cookie_names(response) == set()
+
+
+def test_set_password_rejects_a_short_password_without_echoing_it(monkeypatch):
+    submitted = "1234567"
+    client, _stub = _client(None, monkeypatch)
+
+    with client:
+        response = client.post(
+            "/api/auth/set-password",
+            headers={"Origin": ORIGIN},
+            json={"access_token": access_token(), "password": submitted},
+        )
+
+    assert response.status_code == 422
+    assert submitted not in response.text
+
+
+def test_set_password_with_a_dead_link_is_401(monkeypatch):
+    async def fake_update_password(**_kwargs) -> None:
+        raise supabase_auth.InvalidCredentials("invalid_token")
+
+    monkeypatch.setattr(supabase_auth, "update_password", fake_update_password)
+    client, _stub = _client(None, monkeypatch)
+
+    with client:
+        response = client.post(
+            "/api/auth/set-password",
+            headers={"Origin": ORIGIN},
+            json={"access_token": access_token(), "password": secrets.token_urlsafe(16)},
+        )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "invalid_credentials"
 
 
 def test_production_auth_settings_fail_closed(monkeypatch):

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -10,8 +10,9 @@ from app.db.base import Base
 from app.models.agent import AgentRun
 
 EXPECTED_COLUMN_COUNTS = {
-    "team": 3,
-    "member": 7,
+    # 20260823_0002 로 team 에 company_name/department/business_no, member 에 email 이 늘었다.
+    "team": 6,
+    "member": 8,
     "customer_company": 5,
     "customer_contact": 12,
     "customer_contact_status": 9,
@@ -46,7 +47,7 @@ def test_all_database_tables_are_mapped():
     assert {
         table.name: len(table.columns) for table in Base.metadata.sorted_tables
     } == EXPECTED_COLUMN_COUNTS
-    assert sum(len(table.columns) for table in Base.metadata.tables.values()) == 264
+    assert sum(len(table.columns) for table in Base.metadata.tables.values()) == 268
 
     foreign_key_constraints = [
         foreign_key

--- a/deploy/backend/deploy.sh
+++ b/deploy/backend/deploy.sh
@@ -247,8 +247,14 @@ validate_runtime_environment() {
     deployment_prerequisite_value \
         "${dotenv_file}" CORS_ORIGINS "production-security" >/dev/null || return 1
 
-    # 런타임 기능 조건: /api/health/db 와 Supabase 인증이 의존한다.
-    for feature_key in DATABASE_URL SUPABASE_PUBLISHABLE_KEY; do
+    # 런타임 기능 조건: /api/health/db, Supabase 인증, 계정 발급(/admin)이 의존한다.
+    # SUPABASE_SECRET_KEY 가 없으면 계정 발급이 조용히 503 으로 죽으므로 여기서 막는다.
+    for feature_key in \
+        DATABASE_URL \
+        SUPABASE_PUBLISHABLE_KEY \
+        SUPABASE_SECRET_KEY \
+        ADMIN_USER_IDS \
+        FRONTEND_BASE_URL; do
         deployment_prerequisite_value \
             "${dotenv_file}" "${feature_key}" "deployed-feature" >/dev/null \
             || return 1

--- a/deploy/backend/tests/runtime-environment-test.sh
+++ b/deploy/backend/tests/runtime-environment-test.sh
@@ -49,7 +49,7 @@ assert_validation_fails() {
     fi
 }
 
-readonly VALID_ENVIRONMENT=$'APP_ENV=production\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n'
+readonly VALID_ENVIRONMENT=$'APP_ENV=production\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\nSUPABASE_SECRET_KEY=synthetic-secret\nADMIN_USER_IDS=aaaaaaaa-1111-4111-8111-111111111111\nFRONTEND_BASE_URL=https://app.example.com\n'
 
 valid_file="$(write_environment valid "${VALID_ENVIRONMENT}")"
 valid_output="$(validate_runtime_environment "${valid_file}")" \
@@ -60,68 +60,82 @@ assert_validation_fails \
     missing_app_env \
     'schema-required key is missing: APP_ENV' \
     '' \
-    $'DEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n'
+    $'DEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\nSUPABASE_SECRET_KEY=synthetic-secret\nADMIN_USER_IDS=aaaaaaaa-1111-4111-8111-111111111111\nFRONTEND_BASE_URL=https://app.example.com\n'
 
 assert_validation_fails \
     duplicate_app_env \
     'schema-required key is duplicated: APP_ENV' \
     '' \
-    $'APP_ENV=production\nAPP_ENV=production\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n'
+    $'APP_ENV=production\nAPP_ENV=production\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\nSUPABASE_SECRET_KEY=synthetic-secret\nADMIN_USER_IDS=aaaaaaaa-1111-4111-8111-111111111111\nFRONTEND_BASE_URL=https://app.example.com\n'
 
 assert_validation_fails \
     empty_app_env \
     'schema-required key is present but empty: APP_ENV' \
     '' \
-    $'APP_ENV=\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n'
+    $'APP_ENV=\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\nSUPABASE_SECRET_KEY=synthetic-secret\nADMIN_USER_IDS=aaaaaaaa-1111-4111-8111-111111111111\nFRONTEND_BASE_URL=https://app.example.com\n'
 
 assert_validation_fails \
     invalid_app_env_key \
     'Invalid runtime environment key syntax at line 1' \
     '' \
-    $'APP_ENV =production\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n'
+    $'APP_ENV =production\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\nSUPABASE_SECRET_KEY=synthetic-secret\nADMIN_USER_IDS=aaaaaaaa-1111-4111-8111-111111111111\nFRONTEND_BASE_URL=https://app.example.com\n'
 
 readonly SECRET_MARKER='do-not-print-this-value'
 assert_validation_fails \
     quoted_app_env \
     'APP_ENV must be the unquoted literal production; double-quoted form was provided' \
     "${SECRET_MARKER}" \
-    $'APP_ENV="do-not-print-this-value"\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n'
+    $'APP_ENV="do-not-print-this-value"\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\nSUPABASE_SECRET_KEY=synthetic-secret\nADMIN_USER_IDS=aaaaaaaa-1111-4111-8111-111111111111\nFRONTEND_BASE_URL=https://app.example.com\n'
 
 assert_validation_fails \
     whitespace_app_env \
     'APP_ENV must be the unquoted literal production; form with surrounding whitespace was provided' \
     '' \
-    $'APP_ENV= production\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n'
+    $'APP_ENV= production\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\nSUPABASE_SECRET_KEY=synthetic-secret\nADMIN_USER_IDS=aaaaaaaa-1111-4111-8111-111111111111\nFRONTEND_BASE_URL=https://app.example.com\n'
 
 assert_validation_fails \
     commented_debug \
     'DEBUG must be the unquoted literal false; form with literal inline-comment text was provided' \
     '' \
-    $'APP_ENV=production\nDEBUG=false # production\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n'
+    $'APP_ENV=production\nDEBUG=false # production\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\nSUPABASE_SECRET_KEY=synthetic-secret\nADMIN_USER_IDS=aaaaaaaa-1111-4111-8111-111111111111\nFRONTEND_BASE_URL=https://app.example.com\n'
 
 assert_validation_fails \
     missing_cors \
     'production-security key is missing: CORS_ORIGINS' \
     '' \
-    $'APP_ENV=production\nDEBUG=false\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n'
+    $'APP_ENV=production\nDEBUG=false\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\nSUPABASE_SECRET_KEY=synthetic-secret\nADMIN_USER_IDS=aaaaaaaa-1111-4111-8111-111111111111\nFRONTEND_BASE_URL=https://app.example.com\n'
 
 assert_validation_fails \
     empty_database \
     'deployed-feature key is present but empty: DATABASE_URL' \
     '' \
-    $'APP_ENV=production\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n'
+    $'APP_ENV=production\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\nSUPABASE_SECRET_KEY=synthetic-secret\nADMIN_USER_IDS=aaaaaaaa-1111-4111-8111-111111111111\nFRONTEND_BASE_URL=https://app.example.com\n'
+
+# 계정 발급(/admin)이 의존하는 키다. 없으면 배포는 되고 발급만 503 으로 죽으므로
+# 조용한 실패 대신 배포를 멈춘다.
+assert_validation_fails \
+    missing_supabase_secret \
+    'deployed-feature key is missing: SUPABASE_SECRET_KEY' \
+    '' \
+    $'APP_ENV=production\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\nADMIN_USER_IDS=aaaaaaaa-1111-4111-8111-111111111111\nFRONTEND_BASE_URL=https://app.example.com\n'
+
+assert_validation_fails \
+    missing_admin_user_ids \
+    'deployed-feature key is missing: ADMIN_USER_IDS' \
+    '' \
+    $'APP_ENV=production\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\nSUPABASE_SECRET_KEY=synthetic-secret\nFRONTEND_BASE_URL=https://app.example.com\n'
 
 assert_validation_fails \
     bare_duplicate_app_env \
     'explicit KEY=value is required' \
     '' \
-    $'APP_ENV=production\nAPP_ENV\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n'
+    $'APP_ENV=production\nAPP_ENV\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\nSUPABASE_SECRET_KEY=synthetic-secret\nADMIN_USER_IDS=aaaaaaaa-1111-4111-8111-111111111111\nFRONTEND_BASE_URL=https://app.example.com\n'
 
 assert_validation_fails \
     malformed_unrelated_key \
     'Invalid runtime environment key syntax' \
     "${SECRET_MARKER}" \
-    $'APP_ENV=production\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\n=do-not-print-this-value\n'
+    $'APP_ENV=production\nDEBUG=false\nCORS_ORIGINS=https://app.example.com\nDATABASE_URL=postgresql://example.invalid/app\nSUPABASE_PUBLISHABLE_KEY=synthetic-key\nSUPABASE_SECRET_KEY=synthetic-secret\nADMIN_USER_IDS=aaaaaaaa-1111-4111-8111-111111111111\nFRONTEND_BASE_URL=https://app.example.com\n=do-not-print-this-value\n'
 
 raw_file="$(write_environment raw_value $'RAW_VALUE=  literal # text = preserved  \r\n')"
 raw_value="$(dotenv_value "${raw_file}" RAW_VALUE)"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router'
 
+import AdminRoute from '@/auth/AdminRoute'
 import ManagerRoute from '@/auth/ManagerRoute'
 import ProtectedRoute from '@/auth/ProtectedRoute'
 import SessionProvider from '@/auth/SessionProvider'
@@ -11,6 +12,7 @@ import Complaints from '@/pages/Complaints'
 import Contracts from '@/pages/Contracts'
 import Customers from '@/pages/Customers'
 import Daily, { DailyCompose, DailyDetail, DailyMeetingPick } from '@/pages/Daily'
+import Admin from '@/pages/Admin'
 import Dashboard from '@/pages/Dashboard'
 import Documents from '@/pages/Documents'
 import LegalDoc from '@/pages/Legal'
@@ -22,6 +24,7 @@ import Notifications from '@/pages/Notifications'
 import Orders, { OrderDetail, OrderNew } from '@/pages/Orders'
 import Quotes from '@/pages/Quotes'
 import Sales from '@/pages/Sales'
+import SetPassword from '@/pages/SetPassword'
 import Team from '@/pages/Team'
 import Deals, { DealBoard } from '@/pages/Deals'
 
@@ -33,6 +36,8 @@ export default function App() {
         <ConnectionAlert />
         <Routes>
           <Route path={ROUTES.LOGIN} element={<Login />} />
+          {/* 초대 메일이 착지하는 곳. 아직 비밀번호가 없는 사람이 여는 화면이라 셸 밖입니다. */}
+          <Route path={ROUTES.SET_PASSWORD} element={<SetPassword />} />
 
           <Route element={<ProtectedRoute />}>
             {/* 404 도 셸 안에 둡니다. 사이드바가 남아 있어야 바로 다른 메뉴로 옮겨갈 수 있습니다. */}
@@ -44,6 +49,11 @@ export default function App() {
               {/* 팀장만 들어갈 수 있는 화면. 팀원이 주소를 직접 치면 대시보드로 돌아갑니다. */}
               <Route element={<ManagerRoute />}>
                 <Route path={ROUTES.TEAM} element={<Team />} />
+              </Route>
+
+              {/* 계정 발급. 사이드바에 없고 어드민만 들어갑니다. */}
+              <Route element={<AdminRoute />}>
+                <Route path={ROUTES.ADMIN} element={<Admin />} />
               </Route>
 
               {/* 알림은 사이드바에 없습니다. 진입은 헤더 벨에서만 합니다. */}

--- a/frontend/src/api/errorMessage.ts
+++ b/frontend/src/api/errorMessage.ts
@@ -34,6 +34,13 @@ const MESSAGE_BY_DETAIL: Record<string, string> = {
   auth_not_configured: '로그인 설정이 완료되지 않았습니다. 서버 설정을 확인해 주세요.',
   auth_unavailable: '인증 서버에 연결할 수 없습니다. 잠시 후 다시 시도해 주세요.',
   origin_not_allowed: '허용되지 않은 주소에서 보낸 요청입니다.',
+  // 계정 발급 (/admin)
+  admin_only: '계정을 발급할 수 있는 계정이 아닙니다.',
+  admin_not_configured: '계정 발급 설정이 완료되지 않았습니다. 서버 설정을 확인해 주세요.',
+  email_already_exists: '이미 등록된 이메일입니다.',
+  team_name_already_exists: '같은 이름의 팀이 이미 있습니다.',
+  team_not_found: '고른 팀을 찾을 수 없습니다. 목록을 새로 불러와 주세요.',
+  password_rejected: '비밀번호가 정책에 맞지 않습니다. 더 길고 복잡하게 정해 주세요.',
 }
 
 const MESSAGE_BY_STATUS: Record<number, string> = {

--- a/frontend/src/auth/AdminRoute.tsx
+++ b/frontend/src/auth/AdminRoute.tsx
@@ -1,0 +1,17 @@
+// 계정 발급 화면의 문지기. 메뉴에 없다는 것만으로는 주소를 직접 친 사람을 막지 못합니다.
+//
+// 서버도 같은 판단을 합니다. 화면단의 이 검사는 잘못 들어온 사람을 돌려보내는 것이지
+// 권한을 지키는 수단이 아닙니다. 실제 근거는 백엔드의 ADMIN_USER_IDS 입니다.
+import { Navigate, Outlet } from 'react-router'
+
+import { ROUTES } from '@/constants/routes'
+
+import { useCurrentUser } from './sessionContext'
+
+export default function AdminRoute() {
+  const { isAdmin } = useCurrentUser()
+
+  if (!isAdmin) return <Navigate to={ROUTES.DASHBOARD} replace />
+
+  return <Outlet />
+}

--- a/frontend/src/auth/SessionProvider.tsx
+++ b/frontend/src/auth/SessionProvider.tsx
@@ -13,11 +13,13 @@ interface AuthUser {
   display_name: string
   role_code: Session['role']
   job_title: string | null
+  is_admin: boolean
 }
 
-const toSession = ({ display_name, role_code, job_title }: AuthUser): Session => ({
+const toSession = ({ display_name, role_code, job_title, is_admin }: AuthUser): Session => ({
   role: role_code,
   profile: { name: display_name, title: job_title ?? '' },
+  isAdmin: is_admin,
 })
 
 export default function SessionProvider({ children }: { children: ReactNode }) {

--- a/frontend/src/auth/sessionContext.ts
+++ b/frontend/src/auth/sessionContext.ts
@@ -10,6 +10,11 @@ export interface Profile {
 export interface Session {
   role: Role
   profile: Profile
+  /**
+   * 계정을 발급할 수 있는지. 서버의 ADMIN_USER_IDS 에서 나오며 role 과 무관합니다.
+   * 화면을 감추는 용도일 뿐이고 실제 권한은 백엔드가 매 요청 다시 판단합니다.
+   */
+  isAdmin: boolean
 }
 
 /**

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -6,7 +6,10 @@ import type { ReportKind } from '@/types'
 // 화면을 구현할 때 src/pages/<Name>/ 을 만들고 App.tsx 에 <Route> 를 추가하세요.
 export const ROUTES = {
   LOGIN: '/login', // 셸 밖. 내비게이션에 넣지 않습니다.
+  // 초대 메일이 착지하는 곳. 로그인 전에 여는 화면이라 셸 밖에 둡니다.
+  SET_PASSWORD: '/set-password',
   DASHBOARD: '/',
+  ADMIN: '/admin', // 계정 발급 (어드민 전용). 사이드바에 넣지 않습니다.
   TEAM: '/team', // 팀 관리 (팀장 전용)
   CUSTOMERS: '/customers',
   COMPLAINTS: '/complaints', // 고객 불만 관리

--- a/frontend/src/pages/Admin/Admin.module.scss
+++ b/frontend/src/pages/Admin/Admin.module.scss
@@ -1,0 +1,156 @@
+// 목록 화면들과 같은 카드 골격을 씁니다(pages/listPage.module.scss 참고).
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px;
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+}
+
+.cardTitle {
+  font-size: 16px;
+  letter-spacing: -0.02em;
+}
+
+// 팀 정보와 구성원 정보를 눈으로 갈라 둡니다. 한쪽만 채우는 일이 잦습니다.
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+
+  legend {
+    padding: 0 6px;
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--ink-2);
+  }
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+
+  @include md {
+    grid-template-columns: 1fr;
+  }
+}
+
+.field {
+  display: grid;
+  gap: 8px;
+
+  label,
+  .label {
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--ink-2);
+  }
+}
+
+.input {
+  width: 100%;
+  height: 40px;
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  padding: 0 12px;
+  transition:
+    border-color var(--t-fast),
+    box-shadow var(--t-fast);
+
+  &:focus {
+    outline: none;
+    border-color: var(--blue);
+    box-shadow: 0 0 0 4px var(--blue-ring);
+  }
+}
+
+.choices {
+  display: flex;
+  gap: 16px;
+}
+
+.choice {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.hint {
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.error {
+  border-radius: var(--r-sm);
+  border-left: 3px solid var(--red);
+  background: var(--red-tint);
+  padding: 10px 12px;
+  color: var(--red-ink);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+// 발급 성공은 초대 메일이 나갔다는 뜻이라 실패만큼 분명히 보여야 합니다.
+.notice {
+  border-radius: var(--r-sm);
+  border-left: 3px solid var(--green);
+  background: var(--green-tint);
+  padding: 10px 12px;
+  color: var(--green-ink);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.team {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px 0;
+  border-top: 1px solid var(--line);
+}
+
+.teamHead {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.meta {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.members {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  li {
+    display: grid;
+    grid-template-columns: minmax(0, 140px) minmax(0, 1fr) minmax(0, 120px);
+    gap: 10px;
+    font-size: 13px;
+
+    @include md {
+      grid-template-columns: 1fr;
+      gap: 2px;
+    }
+  }
+}

--- a/frontend/src/pages/Admin/Admin.tsx
+++ b/frontend/src/pages/Admin/Admin.tsx
@@ -1,0 +1,317 @@
+// 계정 발급. 어드민이 팀과 구성원 정보를 넣으면 Supabase 사용자 생성·초대 메일·
+// team/member 등록이 한 번에 끝납니다.
+//
+// 비밀번호 입력란이 없습니다. 초대 메일을 받은 사람이 직접 정하므로 발급하는 쪽이
+// 비밀번호를 알 방법도, 전달할 이유도 없습니다.
+import { type FormEvent, useCallback, useEffect, useState } from 'react'
+
+import { client } from '@/api/client'
+import { errorMessage } from '@/api/errorMessage'
+import Button from '@/components/Button'
+
+import styles from './Admin.module.scss'
+
+interface AdminTeamMember {
+  id: string
+  display_name: string
+  email: string | null
+  role_code: 'member' | 'manager'
+  active: boolean
+}
+
+interface AdminTeam {
+  id: string
+  name: string
+  company_name: string | null
+  department: string | null
+  business_no: string | null
+  member_count: number
+  members: AdminTeamMember[]
+}
+
+/** 팀 선택란의 "새 팀 만들기" 항목. 실제 팀 id 와 섞이지 않는 값을 씁니다. */
+const NEW_TEAM = 'new'
+
+/** 표시용으로만 하이픈을 넣습니다. 서버에는 숫자 10자리로 저장됩니다. */
+function formatBusinessNo(value: string | null): string {
+  if (value === null || value.length !== 10) return value ?? '-'
+  return `${value.slice(0, 3)}-${value.slice(3, 5)}-${value.slice(5)}`
+}
+
+export default function Admin() {
+  const [teams, setTeams] = useState<AdminTeam[]>([])
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  const [teamChoice, setTeamChoice] = useState<string>(NEW_TEAM)
+  const [teamName, setTeamName] = useState('')
+  const [companyName, setCompanyName] = useState('')
+  const [department, setDepartment] = useState('')
+  const [businessNo, setBusinessNo] = useState('')
+
+  const [email, setEmail] = useState('')
+  const [displayName, setDisplayName] = useState('')
+  const [roleCode, setRoleCode] = useState<'member' | 'manager'>('member')
+
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+
+  const loadTeams = useCallback(async () => {
+    try {
+      const { data } = await client.get<AdminTeam[]>('/admin/teams')
+      setTeams(data)
+      setLoadError(null)
+    } catch (cause) {
+      setLoadError(errorMessage(cause, '팀 목록을 불러올 수 없습니다.'))
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadTeams()
+  }, [loadTeams])
+
+  const creatingTeam = teamChoice === NEW_TEAM
+
+  const onSubmit = async (event: FormEvent) => {
+    event.preventDefault()
+    setSubmitting(true)
+    setError(null)
+    setNotice(null)
+
+    const payload = {
+      email: email.trim(),
+      display_name: displayName.trim(),
+      role_code: roleCode,
+      ...(creatingTeam
+        ? {
+            team: {
+              name: teamName.trim(),
+              company_name: companyName.trim() || null,
+              department: department.trim() || null,
+              business_no: businessNo.trim() || null,
+            },
+          }
+        : { team_id: teamChoice }),
+    }
+
+    try {
+      await client.post('/admin/accounts', payload)
+      setNotice(`${email.trim()} 으로 초대 메일을 보냈습니다.`)
+      // 방금 만든 계정이 목록에 뜨는 것으로 발급을 확인시킵니다.
+      await loadTeams()
+      setEmail('')
+      setDisplayName('')
+      if (creatingTeam) {
+        setTeamName('')
+        setCompanyName('')
+        setDepartment('')
+        setBusinessNo('')
+      }
+    } catch (cause) {
+      setError(errorMessage(cause, '계정을 발급할 수 없습니다. 잠시 후 다시 시도해 주세요.'))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <section className={styles.page}>
+      <h1 className="sr-only">계정 발급</h1>
+
+      <form className={styles.card} onSubmit={onSubmit}>
+        <h2 className={styles.cardTitle}>새 계정 발급</h2>
+
+        <div className={styles.field}>
+          <label htmlFor="team">팀</label>
+          <select
+            className={styles.input}
+            id="team"
+            value={teamChoice}
+            onChange={(e) => setTeamChoice(e.target.value)}
+            disabled={submitting}
+          >
+            <option value={NEW_TEAM}>+ 새 팀 만들기</option>
+            {teams.map((team) => (
+              <option key={team.id} value={team.id}>
+                {team.name}
+                {team.company_name ? ` · ${team.company_name}` : ''} ({team.member_count}명)
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {creatingTeam && (
+          <fieldset className={styles.group}>
+            <legend>새 팀 정보</legend>
+
+            <div className={styles.field}>
+              <label htmlFor="team-name">팀명</label>
+              <input
+                className={styles.input}
+                id="team-name"
+                value={teamName}
+                onChange={(e) => setTeamName(e.target.value)}
+                disabled={submitting}
+                required
+              />
+            </div>
+
+            <div className={styles.row}>
+              <div className={styles.field}>
+                <label htmlFor="company-name">회사명</label>
+                <input
+                  className={styles.input}
+                  id="company-name"
+                  value={companyName}
+                  onChange={(e) => setCompanyName(e.target.value)}
+                  disabled={submitting}
+                />
+              </div>
+
+              <div className={styles.field}>
+                <label htmlFor="department">부서명</label>
+                <input
+                  className={styles.input}
+                  id="department"
+                  value={department}
+                  onChange={(e) => setDepartment(e.target.value)}
+                  disabled={submitting}
+                />
+              </div>
+            </div>
+
+            <div className={styles.field}>
+              <label htmlFor="business-no">사업자등록번호</label>
+              <input
+                className={styles.input}
+                id="business-no"
+                inputMode="numeric"
+                placeholder="000-00-00000"
+                value={businessNo}
+                onChange={(e) => setBusinessNo(e.target.value)}
+                disabled={submitting}
+              />
+              <p className={styles.hint}>하이픈은 넣어도 되고 빼도 됩니다.</p>
+            </div>
+          </fieldset>
+        )}
+
+        <fieldset className={styles.group}>
+          <legend>구성원</legend>
+
+          <div className={styles.row}>
+            <div className={styles.field}>
+              <label htmlFor="email">이메일</label>
+              <input
+                className={styles.input}
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                disabled={submitting}
+                required
+              />
+            </div>
+
+            <div className={styles.field}>
+              <label htmlFor="display-name">이름</label>
+              <input
+                className={styles.input}
+                id="display-name"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                disabled={submitting}
+                required
+              />
+            </div>
+          </div>
+
+          <div className={styles.field}>
+            <span className={styles.label}>역할</span>
+            <div className={styles.choices}>
+              <label className={styles.choice}>
+                <input
+                  type="radio"
+                  name="role"
+                  value="member"
+                  checked={roleCode === 'member'}
+                  onChange={() => setRoleCode('member')}
+                  disabled={submitting}
+                />
+                팀원
+              </label>
+              <label className={styles.choice}>
+                <input
+                  type="radio"
+                  name="role"
+                  value="manager"
+                  checked={roleCode === 'manager'}
+                  onChange={() => setRoleCode('manager')}
+                  disabled={submitting}
+                />
+                팀장
+              </label>
+            </div>
+          </div>
+        </fieldset>
+
+        {error && (
+          <p className={styles.error} role="alert">
+            {error}
+          </p>
+        )}
+        {notice && (
+          <p className={styles.notice} role="status">
+            {notice}
+          </p>
+        )}
+
+        <Button type="submit" disabled={submitting}>
+          {submitting ? '발급 중…' : '계정 발급'}
+        </Button>
+        <p className={styles.hint}>
+          비밀번호는 여기서 정하지 않습니다. 초대 메일을 받은 사람이 직접 정합니다.
+        </p>
+      </form>
+
+      <div className={styles.card}>
+        <h2 className={styles.cardTitle}>등록된 팀</h2>
+
+        {loadError && (
+          <p className={styles.error} role="alert">
+            {loadError}
+          </p>
+        )}
+
+        {!loadError && teams.length === 0 && (
+          <p className={styles.hint}>아직 등록된 팀이 없습니다.</p>
+        )}
+
+        {teams.map((team) => (
+          <article key={team.id} className={styles.team}>
+            <header className={styles.teamHead}>
+              <strong>{team.name}</strong>
+              <span className={styles.meta}>
+                {[team.company_name, team.department].filter(Boolean).join(' · ') || '-'} ·
+                사업자등록번호 {formatBusinessNo(team.business_no)}
+              </span>
+            </header>
+
+            <ul className={styles.members}>
+              {team.members.map((member) => (
+                <li key={member.id}>
+                  <span>{member.display_name}</span>
+                  <span className={styles.meta}>{member.email ?? '-'}</span>
+                  <span className={styles.meta}>
+                    {member.role_code === 'manager' ? '팀장' : '팀원'}
+                    {member.active ? '' : ' · 비활성'}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/pages/Admin/index.ts
+++ b/frontend/src/pages/Admin/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Admin'

--- a/frontend/src/pages/Calendar/components/EventModal/EventModal.tsx
+++ b/frontend/src/pages/Calendar/components/EventModal/EventModal.tsx
@@ -1008,10 +1008,7 @@ function TargetPicker({
 
   // 아무것도 치지 않았으면 회사 이름으로 그 회사 사람들을 부릅니다.
   const search = query.trim() === '' ? (company?.org ?? '') : query
-  const { matches, loading, loadError, reload } = useContactSearch(
-    search,
-    open && company !== null,
-  )
+  const { matches, loading, loadError, reload } = useContactSearch(search, open && company !== null)
 
   // 다른 회사 사람과 이미 담은 사람은 목록에서 뺍니다.
   const candidates = useMemo(() => {

--- a/frontend/src/pages/Contracts/Contracts.tsx
+++ b/frontend/src/pages/Contracts/Contracts.tsx
@@ -348,7 +348,6 @@ export default function Contracts() {
       )}
 
       {createOpen && <ContractForm onClose={closeCreate} onSubmit={closeCreate} />}
-
     </section>
   )
 }

--- a/frontend/src/pages/Quotes/Quotes.tsx
+++ b/frontend/src/pages/Quotes/Quotes.tsx
@@ -359,7 +359,6 @@ export default function Quotes() {
       )}
 
       {createOpen && <QuoteForm onClose={closeCreate} onSubmit={closeCreate} />}
-
     </section>
   )
 }

--- a/frontend/src/pages/SetPassword/SetPassword.module.scss
+++ b/frontend/src/pages/SetPassword/SetPassword.module.scss
@@ -1,0 +1,92 @@
+// 로그인 화면(Login.module.scss)의 오른쪽 패널을 한 칸짜리로 줄인 것입니다.
+// 아직 로그인하지 못한 사람이 보는 화면이라 셸도 사이드바도 없습니다.
+.shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+  background: linear-gradient(145deg, #0a84ff 0%, #0066d6 58%, #004a9f 100%);
+}
+
+.panel {
+  width: min(100%, 440px);
+  padding: clamp(30px, 5vw, 48px);
+  background: rgba(255, 255, 255, 0.96);
+  color: var(--ink);
+  border-radius: 28px;
+  box-shadow: 0 22px 80px rgba(0, 42, 100, 0.2);
+
+  h1 {
+    font-size: 26px;
+    letter-spacing: -0.04em;
+  }
+}
+
+.eyebrow {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+
+.lead {
+  margin: 10px 0 26px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.field {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 16px;
+
+  label {
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--ink-2);
+  }
+}
+
+.input {
+  width: 100%;
+  height: 44px;
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  padding: 0 14px;
+  transition:
+    border-color var(--t-fast),
+    box-shadow var(--t-fast);
+
+  &:focus {
+    outline: none;
+    border-color: var(--blue);
+    box-shadow: 0 0 0 4px var(--blue-ring);
+  }
+}
+
+// 입력하는 동안 바로 알려 주는 짧은 안내라 실패(.error)보다 조용하게 둡니다.
+.hint {
+  font-size: 12px;
+  color: var(--red-ink);
+}
+
+.error {
+  margin-top: -4px;
+  margin-bottom: 16px;
+  border-radius: var(--r-sm);
+  border-left: 3px solid var(--red);
+  background: var(--red-tint);
+  padding: 10px 12px;
+  color: var(--red-ink);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.mainBtn {
+  width: 100%;
+  height: 44px;
+  margin-top: 4px;
+}

--- a/frontend/src/pages/SetPassword/SetPassword.tsx
+++ b/frontend/src/pages/SetPassword/SetPassword.tsx
@@ -1,0 +1,149 @@
+import { type FormEvent, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router'
+
+import { client } from '@/api/client'
+import { errorMessage } from '@/api/errorMessage'
+import Button from '@/components/Button'
+import { ROUTES } from '@/constants/routes'
+
+import styles from './SetPassword.module.scss'
+
+/** Supabase 정책과 별개로 화면이 먼저 막는 최소 길이입니다. 서버도 같은 값을 봅니다. */
+const MIN_LENGTH = 8
+
+/**
+ * 초대 메일 링크에 실려 온 토큰을 읽습니다.
+ *
+ * Supabase 는 `#access_token=...&type=invite` 형태로 되돌려 보냅니다.
+ * 읽기만 하고 지우지는 않습니다. StrictMode 가 초기화 함수를 두 번 부르므로,
+ * 여기서 해시를 지우면 두 번째 호출이 빈 해시를 보고 토큰이 없다고 판단합니다.
+ */
+function readAccessToken(): string | null {
+  const hash = window.location.hash.replace(/^#/, '')
+  if (!hash) return null
+  return new URLSearchParams(hash).get('access_token')
+}
+
+export default function SetPassword() {
+  const navigate = useNavigate()
+  // 링크를 여는 순간 한 번만 읽습니다. 이후 렌더는 지워진 해시를 다시 보지 않습니다.
+  const [accessToken] = useState(readAccessToken)
+
+  // 토큰을 state 로 옮겼으면 주소창에서는 지웁니다. 남겨 두면 어깨너머로도,
+  // 뒤로가기로도, 공유된 링크로도 새어 나갑니다. 두 번 지워도 문제가 없습니다.
+  useEffect(() => {
+    if (window.location.hash) {
+      window.history.replaceState(null, '', window.location.pathname + window.location.search)
+    }
+  }, [])
+
+  const [password, setPassword] = useState('')
+  const [confirmation, setConfirmation] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const tooShort = password.length > 0 && password.length < MIN_LENGTH
+  const mismatched = confirmation.length > 0 && password !== confirmation
+  const submittable = password.length >= MIN_LENGTH && password === confirmation
+
+  const onSubmit = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!accessToken || !submittable) return
+
+    setSubmitting(true)
+    setError(null)
+    try {
+      await client.post('/auth/set-password', { access_token: accessToken, password })
+      // 세션을 여기서 만들지 않습니다. 새 비밀번호가 실제로 되는지 로그인에서 바로 확인합니다.
+      navigate(ROUTES.LOGIN, { replace: true })
+    } catch (cause) {
+      setError(errorMessage(cause, '비밀번호를 설정할 수 없습니다. 잠시 후 다시 시도해 주세요.'))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <section className={styles.shell}>
+      <div className={styles.panel}>
+        <p className={styles.eyebrow}>SalesLuv</p>
+        <h1>비밀번호 설정</h1>
+
+        {accessToken === null ? (
+          <>
+            <p className={styles.lead}>
+              링크가 만료되었거나 올바르지 않습니다. 초대 메일의 링크는 한 번만 쓸 수 있습니다.
+            </p>
+            <p className={styles.error} role="alert">
+              관리자에게 초대 메일 재발송을 요청해 주세요.
+            </p>
+          </>
+        ) : (
+          <>
+            <p className={styles.lead}>
+              앞으로 로그인에 쓸 비밀번호를 정해 주세요. {MIN_LENGTH}자 이상이어야 합니다.
+            </p>
+
+            <form onSubmit={onSubmit}>
+              <div className={styles.field}>
+                <label htmlFor="password">새 비밀번호</label>
+                <input
+                  className={styles.input}
+                  id="password"
+                  type="password"
+                  autoComplete="new-password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  disabled={submitting}
+                  aria-invalid={tooShort}
+                  aria-describedby={tooShort ? 'password-hint' : undefined}
+                  required
+                />
+                {tooShort && (
+                  <p id="password-hint" className={styles.hint}>
+                    {MIN_LENGTH}자 이상 입력해 주세요.
+                  </p>
+                )}
+              </div>
+
+              <div className={styles.field}>
+                <label htmlFor="confirmation">비밀번호 확인</label>
+                <input
+                  className={styles.input}
+                  id="confirmation"
+                  type="password"
+                  autoComplete="new-password"
+                  value={confirmation}
+                  onChange={(e) => setConfirmation(e.target.value)}
+                  disabled={submitting}
+                  aria-invalid={mismatched}
+                  aria-describedby={mismatched ? 'confirmation-hint' : undefined}
+                  required
+                />
+                {mismatched && (
+                  <p id="confirmation-hint" className={styles.hint}>
+                    두 비밀번호가 다릅니다.
+                  </p>
+                )}
+              </div>
+
+              {error && (
+                <p className={styles.error} role="alert">
+                  {error}
+                </p>
+              )}
+
+              <Button
+                className={styles.mainBtn}
+                type="submit"
+                disabled={submitting || !submittable}
+              >
+                {submitting ? '설정 중…' : '비밀번호 설정'}
+              </Button>
+            </form>
+          </>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/pages/SetPassword/index.ts
+++ b/frontend/src/pages/SetPassword/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SetPassword'


### PR DESCRIPTION
## 변경 요약

- 환경변수 기반 관리자 allowlist를 적용하고 팀 조회·계정 발급 API를 추가했습니다.
- Supabase 초대 메일을 통해 사용자가 직접 비밀번호를 설정하는 흐름을 구현했습니다.
- 관리자 계정 발급 화면과 `/set-password` 화면을 추가했습니다.
- 팀 회사 정보와 구성원 이메일을 저장하는 DB 마이그레이션을 추가했습니다.
- 운영 환경변수 검증과 관리자 권한·계정 발급·실패 롤백 테스트를 보강했습니다.

## 검증

- Backend Ruff lint 및 format 검사 통과
- Backend pytest: 160 passed, 2 skipped
- Backend 배포 스크립트 문법 및 환경변수 검증 테스트 통과
- Frontend lint 및 Prettier 검사 통과
- Frontend TypeScript·Vite production build 통과

## 영향 및 주의 사항

- 배포 전에 `backend/sql/20260823_0002_admin_account_provisioning.sql`을 적용해야 합니다.
- Backend SSM 환경변수에 `ADMIN_USER_IDS`, `FRONTEND_BASE_URL`, `SUPABASE_SECRET_KEY`가 필요합니다.
- Supabase Redirect URLs에 `${FRONTEND_BASE_URL}/set-password`를 등록해야 합니다.
- 기존 구성원의 `email` 값은 필요에 따라 별도로 보완해야 합니다.