### PR TITLE
전역 보기 범위 스위처와 담당자 기준 목록 필터 추가

### DIFF
--- a/backend/app/api/activities.py
+++ b/backend/app/api/activities.py
@@ -8,7 +8,7 @@ from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
-from app.api.deps import CurrentMember, DbSession
+from app.api.deps import CurrentMember, DbSession, owner_scope
 from app.models.configuration import ActivityActionTag, ActivityCategory
 from app.models.crm import Activity, CustomerCompany, CustomerContact
 from app.models.sales import Product, SalesDeal
@@ -145,35 +145,6 @@ def _activity_read(
         created_at=_seoul(activity.created_at),
         updated_at=_seoul(activity.updated_at),
     )
-
-
-async def _owner_filter(
-    db: AsyncSession,
-    member: Member,
-    requested: list[UUID] | None,
-) -> tuple[UUID, ...] | None:
-    if requested is None:
-        return None
-    if member.role_code != "manager":
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="scope_not_allowed",
-        )
-    owner_ids = tuple(dict.fromkeys(requested))
-    result = await db.execute(
-        select(Member.id).where(
-            Member.id.in_(owner_ids),
-            Member.team_id == member.team_id,
-            Member.active.is_(True),
-            Member.role_code.in_(("member", "manager")),
-        )
-    )
-    if set(result.scalars().all()) != set(owner_ids):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="scope_not_allowed",
-        )
-    return owner_ids
 
 
 async def _activity_row(
@@ -396,7 +367,7 @@ async def list_activities(
     member: CurrentMember,
     db: DbSession,
 ) -> ActivityPage:
-    owner_ids = await _owner_filter(db, member, page.owner_member_id)
+    owner_ids = await owner_scope(db, member, page.owner_member_id)
     start_at = datetime.combine(page.start_date, time.min, _SEOUL)
     end_at = datetime.combine(page.end_date or page.start_date, time.min, _SEOUL) + timedelta(
         days=1

--- a/backend/app/api/customers.py
+++ b/backend/app/api/customers.py
@@ -7,7 +7,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
-from app.api.deps import CurrentMember, DbSession
+from app.api.deps import CurrentMember, DbSession, owner_scope
 from app.models.configuration import CustomerContactStatus
 from app.models.crm import CustomerCompany, CustomerContact, CustomerContactAssignee
 from app.models.workspace import Member
@@ -19,6 +19,7 @@ from app.schemas.customers import (
     CustomerCompanyRead,
     CustomerContactCreate,
     CustomerContactPage,
+    CustomerContactPageParams,
     CustomerContactPatch,
     CustomerContactRead,
     CustomerContactStatusOptionRead,
@@ -53,7 +54,32 @@ async def _get_company(
     return company
 
 
-def _contact_scope(member: Member):
+def _assigned_to(member_ids: tuple[UUID, ...]):
+    """대표 담당자가 아니어도 담당자로 지정됐으면 자기 고객이다.
+
+    담당자는 별도 표에 있어 조인으로 끌어오면 고객 한 명이 담당자 수만큼 늘어난다.
+    EXISTS 로만 묻는다.
+
+    한 명이면 IN 대신 = 로 쓴다. 본인 것만 보는 팀원이 이 경로를 늘 지나므로 지금 나가는
+    쿼리 모양을 그대로 둔다.
+    """
+    one = len(member_ids) == 1
+
+    def matches(column):
+        return column == member_ids[0] if one else column.in_(member_ids)
+
+    return or_(
+        matches(CustomerContact.owner_member_id),
+        select(CustomerContactAssignee.member_id)
+        .where(
+            CustomerContactAssignee.customer_contact_id == CustomerContact.id,
+            matches(CustomerContactAssignee.member_id),
+        )
+        .exists(),
+    )
+
+
+def _contact_scope(member: Member, owner_ids: tuple[UUID, ...] | None = None):
     conditions = [
         CustomerCompany.team_id == member.team_id,
         Member.team_id == member.team_id,
@@ -61,18 +87,12 @@ def _contact_scope(member: Member):
         Member.role_code.in_(("member", "manager")),
     ]
     if member.role_code == "member":
-        # 대표 담당자가 아니어도 담당자로 지정됐으면 자기 고객이다.
-        conditions.append(
-            or_(
-                CustomerContact.owner_member_id == member.id,
-                select(CustomerContactAssignee.member_id)
-                .where(
-                    CustomerContactAssignee.customer_contact_id == CustomerContact.id,
-                    CustomerContactAssignee.member_id == member.id,
-                )
-                .exists(),
-            )
-        )
+        conditions.append(_assigned_to((member.id,)))
+    elif owner_ids is not None:
+        # 팀장이 고른 보기 범위다. 목록 쿼리가 Member 를 owner_member_id 로 조인하고
+        # 있어서 Member.id.in_() 로 쓰고 싶어지지만, 그러면 그 사람이 담당자이되
+        # 대표 담당자가 아닌 고객이 조용히 빠진다. 팀원이 볼 때와 기준이 달라진다.
+        conditions.append(_assigned_to(owner_ids))
     return conditions
 
 
@@ -398,11 +418,13 @@ async def update_customer_company(
 
 @router.get("/customer-contacts", response_model=CustomerContactPage)
 async def list_customer_contacts(
-    page: Annotated[CustomerPageParams, Query()],
+    page: Annotated[CustomerContactPageParams, Query()],
     member: CurrentMember,
     db: DbSession,
 ) -> CustomerContactPage:
-    scope = _contact_scope(member)
+    # 범위를 먼저 검증한다. 거절이면 데이터 쿼리가 한 건도 나가지 않아야 한다.
+    owner_ids = await owner_scope(db, member, page.owner_member_id)
+    scope = _contact_scope(member, owner_ids)
     if page.q is not None:
         pattern = _contains(page.q)
         scope.append(

--- a/backend/app/api/dashboard.py
+++ b/backend/app/api/dashboard.py
@@ -19,7 +19,7 @@ from app.api import notices as notices_api
 from app.api import orders as orders_api
 from app.api import sales_deals as deals_api
 from app.api import support as support_api
-from app.api.deps import CurrentMember, DbSession
+from app.api.deps import CurrentMember, DbSession, owner_scope
 from app.models.crm import Activity, SupportRequest
 from app.models.sales import PurchaseOrder, SalesDeal, SalesTarget
 from app.models.workspace import Member, Notice
@@ -120,8 +120,13 @@ async def _activity_cards(
     )
 
 
-async def _support_card(db: AsyncSession, member: Member) -> SupportCard:
-    scope = support_api._scope(member)
+async def _support_card(
+    db: AsyncSession,
+    member: Member,
+    owner_ids: tuple[UUID, ...] | None,
+) -> SupportCard:
+    """C/S 카드도 다른 카드와 같은 담당자 범위를 쓴다. 여기만 팀 전체면 숫자가 어긋난다."""
+    scope = support_api._scope(member, owner_ids)
     total, in_progress, urgent = (
         await db.execute(
             support_api._joined_select(
@@ -297,7 +302,7 @@ async def read_dashboard(
     # 한 요청의 모든 집계는 같은 시각을 기준으로 한다.
     as_of = datetime.now(UTC).astimezone(_SEOUL)
     day = params.date or as_of.date()
-    owner_ids = await activities_api._owner_filter(db, member, params.owner_member_id)
+    owner_ids = await owner_scope(db, member, params.owner_member_id)
 
     visited, activity_total, follow_ups = await _activity_cards(db, member, owner_ids, day, as_of)
     return DashboardRead(
@@ -308,7 +313,7 @@ async def read_dashboard(
         visited_companies=visited,
         activities=activity_total,
         follow_ups=follow_ups,
-        support_requests=await _support_card(db, member),
+        support_requests=await _support_card(db, member, owner_ids),
         contract_renewals=await _renewal_card(
             db, member, owner_ids, day, params.renewal_within_days
         ),

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -71,6 +71,45 @@ async def get_current_member(request: Request, db: DbSession) -> Member:
 type CurrentMember = Annotated[Member, Depends(get_current_member)]
 
 
+async def owner_scope(
+    db: AsyncSession,
+    member: Member,
+    requested: list[UUID] | None,
+) -> tuple[UUID, ...] | None:
+    """전역 보기 범위가 고른 담당자를 조회 조건으로 바꾼다.
+
+    남의 현황을 보는 건 팀장만 할 수 있다. 그리고 요청된 id 는 매번 같은 팀의 활성
+    구성원인지 다시 확인한다. 화면이 보낸 값을 그대로 믿으면 팀 경계가 쿼리 파라미터
+    하나로 뚫린다.
+
+    None 은 "담당자를 좁히지 않는다"는 뜻이고, 팀 범위는 라우터의 `_scope` 가 따로 건다.
+    """
+    if requested is None:
+        return None
+    if member.role_code != "manager":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="scope_not_allowed",
+        )
+    owner_ids = tuple(dict.fromkeys(requested))
+    result = await db.execute(
+        select(Member.id).where(
+            Member.id.in_(owner_ids),
+            Member.team_id == member.team_id,
+            Member.active.is_(True),
+            Member.role_code.in_(("member", "manager")),
+        )
+    )
+    if set(result.scalars().all()) != set(owner_ids):
+        # 없는 사람이나 남의 팀이 섞였으면 빈 목록이 아니라 거절이다. 조용히 비우면
+        # 화면은 "그 사람 실적이 0" 이라고 읽는다.
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="scope_not_allowed",
+        )
+    return owner_ids
+
+
 async def get_admin_member(member: CurrentMember) -> Member:
     """계정을 발급할 수 있는 사람인지 본다.
 

--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -9,7 +9,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
-from app.api.deps import CurrentMember, DbSession
+from app.api.deps import CurrentMember, DbSession, owner_scope
 from app.models.configuration import PurchaseOrderStatus
 from app.models.crm import CustomerCompany
 from app.models.sales import (
@@ -199,29 +199,6 @@ async def _items_by_order_ids(
             )
         )
     return items_by_order
-
-
-async def _owner_filter(
-    db: AsyncSession,
-    member: Member,
-    requested: list[UUID] | None,
-) -> tuple[UUID, ...] | None:
-    if requested is None:
-        return None
-    if member.role_code != "manager":
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="scope_not_allowed")
-    owner_ids = tuple(dict.fromkeys(requested))
-    result = await db.execute(
-        select(Member.id).where(
-            Member.id.in_(owner_ids),
-            Member.team_id == member.team_id,
-            Member.active.is_(True),
-            Member.role_code.in_(("member", "manager")),
-        )
-    )
-    if set(result.scalars().all()) != set(owner_ids):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="scope_not_allowed")
-    return owner_ids
 
 
 async def _order_row(
@@ -488,7 +465,7 @@ async def list_orders(
     member: CurrentMember,
     db: DbSession,
 ) -> OrderPage:
-    owner_ids = await _owner_filter(db, member, page.owner_member_id)
+    owner_ids = await owner_scope(db, member, page.owner_member_id)
     scope = _scope(member, owner_ids)
     scope.append(_sales_stage.phase_code == "order")
     if page.supplier_name is not None:

--- a/backend/app/api/reports.py
+++ b/backend/app/api/reports.py
@@ -8,7 +8,7 @@ from sqlalchemy import delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
-from app.api.deps import CurrentMember, DbSession
+from app.api.deps import CurrentMember, DbSession, owner_scope
 from app.models.content import Report, ReportActivity
 from app.models.crm import Activity
 from app.models.workspace import Member
@@ -104,35 +104,6 @@ def _report_read(
         created_at=_seoul(report.created_at),
         updated_at=_seoul(report.updated_at),
     )
-
-
-async def _author_filter(
-    db: AsyncSession,
-    member: Member,
-    requested: list[UUID] | None,
-) -> tuple[UUID, ...] | None:
-    if requested is None:
-        return None
-    if member.role_code != "manager":
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="scope_not_allowed",
-        )
-    author_ids = tuple(dict.fromkeys(requested))
-    result = await db.execute(
-        select(Member.id).where(
-            Member.id.in_(author_ids),
-            Member.team_id == member.team_id,
-            Member.active.is_(True),
-            Member.role_code.in_(("member", "manager")),
-        )
-    )
-    if set(result.scalars().all()) != set(author_ids):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="scope_not_allowed",
-        )
-    return author_ids
 
 
 async def _visible_activity_ids(
@@ -269,7 +240,7 @@ async def list_reports(
     member: CurrentMember,
     db: DbSession,
 ) -> ReportPage:
-    author_ids = await _author_filter(db, member, page.author_member_id)
+    author_ids = await owner_scope(db, member, page.author_member_id)
     scope = _scope(member, author_ids)
     if page.report_kind is not None:
         scope.append(Report.report_kind.in_(tuple(dict.fromkeys(page.report_kind))))

--- a/backend/app/api/sales_deals.py
+++ b/backend/app/api/sales_deals.py
@@ -9,7 +9,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
-from app.api.deps import CurrentMember, DbSession
+from app.api.deps import CurrentMember, DbSession, owner_scope
 from app.models.configuration import SalesDealType
 from app.models.crm import CustomerCompany, CustomerContact
 from app.models.sales import Product, SalesDeal, SalesPipeline, SalesPipelineStage
@@ -237,29 +237,6 @@ def _validate_sales_deal_dates(sales_deal: SalesDeal) -> None:
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail="invalid_sales_deal_dates",
         )
-
-
-async def _owner_filter(
-    db: AsyncSession,
-    member: Member,
-    requested: list[UUID] | None,
-) -> tuple[UUID, ...] | None:
-    if requested is None:
-        return None
-    if member.role_code != "manager":
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="scope_not_allowed")
-    owner_ids = tuple(dict.fromkeys(requested))
-    result = await db.execute(
-        select(Member.id).where(
-            Member.id.in_(owner_ids),
-            Member.team_id == member.team_id,
-            Member.active.is_(True),
-            Member.role_code.in_(("member", "manager")),
-        )
-    )
-    if set(result.scalars().all()) != set(owner_ids):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="scope_not_allowed")
-    return owner_ids
 
 
 async def _team_pipeline(
@@ -610,7 +587,7 @@ async def list_sales_deals(
     member: CurrentMember,
     db: DbSession,
 ) -> SalesDealPage:
-    owner_ids = await _owner_filter(db, member, page.owner_member_id)
+    owner_ids = await owner_scope(db, member, page.owner_member_id)
     stage_ids = await _stage_filter(db, member, page.sales_pipeline_stage_id)
     if page.sales_pipeline_id is not None:
         await _team_pipeline(db, member, page.sales_pipeline_id)

--- a/backend/app/api/support.py
+++ b/backend/app/api/support.py
@@ -7,7 +7,7 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
-from app.api.deps import CurrentMember, DbSession
+from app.api.deps import CurrentMember, DbSession, owner_scope
 from app.models.crm import CustomerCompany, CustomerContact, SupportRequest, SupportResponse
 from app.models.workspace import Member
 from app.schemas.support import (
@@ -46,7 +46,7 @@ def _joined_select(*entities):
     )
 
 
-def _scope(member: Member):
+def _scope(member: Member, assignee_ids: tuple[UUID, ...] | None = None):
     conditions = [
         SupportRequest.team_id == member.team_id,
         _assignee.team_id == member.team_id,
@@ -59,6 +59,8 @@ def _scope(member: Member):
     ]
     if member.role_code == "member":
         conditions.append(SupportRequest.assignee_member_id == member.id)
+    elif assignee_ids is not None:
+        conditions.append(SupportRequest.assignee_member_id.in_(assignee_ids))
     return conditions
 
 
@@ -201,7 +203,9 @@ async def list_support_requests(
     member: CurrentMember,
     db: DbSession,
 ) -> SupportRequestPage:
-    scope = _scope(member)
+    # 범위를 먼저 검증한다. 거절이면 데이터 쿼리가 한 건도 나가지 않아야 한다.
+    assignee_ids = await owner_scope(db, member, page.assignee_member_id)
+    scope = _scope(member, assignee_ids)
     if page.status_code is not None:
         scope.append(SupportRequest.status_code.in_(tuple(dict.fromkeys(page.status_code))))
     if page.q is not None:

--- a/backend/app/schemas/customers.py
+++ b/backend/app/schemas/customers.py
@@ -189,3 +189,13 @@ class CustomerPageParams(BaseModel):
     q: SearchQuery | None = None
     skip: int = Field(default=0, ge=0)
     limit: int = Field(default=30, ge=1, le=100)
+
+
+class CustomerContactPageParams(CustomerPageParams):
+    """고객 목록만 담당자를 좁힐 수 있다.
+
+    회사 목록은 팀 공용이라 담당자가 없다. 같은 모델을 쓰면 회사 쪽이 파라미터를 받고도
+    조용히 무시하게 되므로 나눠 둔다.
+    """
+
+    owner_member_id: list[UUID] | None = None

--- a/backend/app/schemas/support.py
+++ b/backend/app/schemas/support.py
@@ -79,5 +79,6 @@ class SupportRequestPageParams(BaseModel):
 
     q: SearchQuery | None = None
     status_code: list[SupportStatus] | None = None
+    assignee_member_id: list[UUID] | None = None
     skip: int = Field(default=0, ge=0, le=9_223_372_036_854_775_807)
     limit: int = Field(default=30, ge=1, le=100)

--- a/backend/tests/test_customers.py
+++ b/backend/tests/test_customers.py
@@ -813,3 +813,118 @@ def test_company_write_round_trips_business_no_and_rejects_other_shapes():
     assert created.json()["business_no"] == "1234567890"
     assert db.added[0].business_no == "1234567890"
     assert rejected.status_code == 422
+
+
+def test_manager_contact_owner_filter_covers_owner_and_assignees():
+    """팀장이 고른 팀원의 고객에는 그 팀원이 담당자로만 지정된 고객도 들어간다."""
+    manager = _member(role="manager")
+    teammate = _member(team_id=manager.team_id)
+    company = _company(manager.team_id)
+    contact = _contact(company.id, teammate.id)
+    contact_status = _contact_status(manager.team_id, status_id=contact.customer_contact_status_id)
+    db = _Db(
+        _Result(scalar_values=[teammate.id]),
+        _Result(scalar=1),
+        _Result(rows=[_contact_row(contact, company, teammate, contact_status)]),
+        _assignee_result((contact, teammate)),
+    )
+
+    with _client(db, manager) as client:
+        response = client.get(
+            "/api/customer-contacts",
+            params={"owner_member_id": [str(teammate.id)]},
+        )
+
+    assert response.status_code == 200
+    # 첫 문장은 범위 검증이고, 그 다음이 개수와 목록이다.
+    sql = str(db.statements[1])
+    assert "customer_contact_assignee" in sql
+    assert "EXISTS" in sql
+    assert teammate.id in db.statements[1].compile().params.values()
+
+
+def test_manager_contact_owner_filter_uses_in_for_several_members():
+    manager = _member(role="manager")
+    first = _member(team_id=manager.team_id)
+    second = _member(team_id=manager.team_id)
+    db = _Db(
+        _Result(scalar_values=[first.id, second.id]),
+        _Result(scalar=0),
+        _Result(rows=[]),
+    )
+
+    with _client(db, manager) as client:
+        response = client.get(
+            "/api/customer-contacts",
+            params={"owner_member_id": [str(first.id), str(second.id)]},
+        )
+
+    assert response.status_code == 200
+    params = db.statements[1].compile().params.values()
+    assert [first.id, second.id] in params
+
+
+def test_member_contact_owner_filter_is_denied_before_any_query():
+    member = _member()
+    db = _Db()
+
+    with _client(db, member) as client:
+        response = client.get(
+            "/api/customer-contacts",
+            params={"owner_member_id": [str(uuid4())]},
+        )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "scope_not_allowed"
+    assert not db.statements
+
+
+def test_manager_contact_owner_filter_rejects_a_member_outside_the_team():
+    manager = _member(role="manager")
+    db = _Db(_Result(scalar_values=[]))
+
+    with _client(db, manager) as client:
+        response = client.get(
+            "/api/customer-contacts",
+            params={"owner_member_id": [str(uuid4())]},
+        )
+
+    # 빈 목록이 아니라 거절이다. 조용히 비우면 화면은 "실적 0" 으로 읽는다.
+    assert response.status_code == 403
+    assert response.json()["detail"] == "scope_not_allowed"
+    assert len(db.statements) == 1
+
+
+def test_company_list_does_not_take_an_owner_filter():
+    """회사는 팀 공용이라 담당자가 없다. 받고도 무시하지 않고 거절해야 한다."""
+    manager = _member(role="manager")
+    db = _Db()
+
+    with _client(db, manager) as client:
+        response = client.get(
+            "/api/customer-companies",
+            params={"owner_member_id": [str(uuid4())]},
+        )
+
+    assert response.status_code == 422
+    assert not db.statements
+
+
+def test_manager_contact_owner_filter_accepts_the_manager_themselves():
+    """'내 현황 + 팀원' 을 함께 보는 경우다. 팀장 자신도 같은 팀의 활성 구성원이다."""
+    manager = _member(role="manager")
+    teammate = _member(team_id=manager.team_id)
+    db = _Db(
+        _Result(scalar_values=[manager.id, teammate.id]),
+        _Result(scalar=0),
+        _Result(rows=[]),
+    )
+
+    with _client(db, manager) as client:
+        response = client.get(
+            "/api/customer-contacts",
+            params={"owner_member_id": [str(manager.id), str(teammate.id)]},
+        )
+
+    assert response.status_code == 200
+    assert [manager.id, teammate.id] in db.statements[1].compile().params.values()

--- a/backend/tests/test_support.py
+++ b/backend/tests/test_support.py
@@ -23,10 +23,19 @@ NOW = datetime(2026, 8, 17, 9, tzinfo=UTC)
 _MISSING = object()
 
 
+class _Scalars:
+    def __init__(self, values):
+        self.values = values
+
+    def all(self):
+        return self.values
+
+
 class _Result:
-    def __init__(self, *, scalar=_MISSING, rows=None):
+    def __init__(self, *, scalar=_MISSING, rows=None, scalar_values=None):
         self.scalar = scalar
         self.rows = [] if rows is None else rows
+        self.scalar_values = [] if scalar_values is None else scalar_values
 
     def scalar_one(self):
         assert self.scalar is not _MISSING
@@ -42,6 +51,9 @@ class _Result:
 
     def all(self):
         return self.rows
+
+    def scalars(self):
+        return _Scalars(self.scalar_values)
 
 
 class _Db:
@@ -430,3 +442,54 @@ def test_response_creation_uses_current_member_and_hides_invisible_request():
     assert hidden.json() == {"detail": "support_request_not_found"}
     assert hidden_db.added == []
     assert hidden_db.rollback_count == 1
+
+
+def test_manager_support_assignee_filter_narrows_to_the_chosen_members():
+    manager = _member(role="manager")
+    first = _member(team_id=manager.team_id)
+    second = _member(team_id=manager.team_id)
+    db = _Db(
+        _Result(scalar_values=[first.id, second.id]),
+        _Result(scalar=0),
+        _Result(rows=[]),
+    )
+
+    with _client(db, manager) as client:
+        response = client.get(
+            "/api/support-requests",
+            params={"assignee_member_id": [str(first.id), str(second.id)]},
+        )
+
+    assert response.status_code == 200
+    # 첫 문장은 범위 검증이고, 그 다음이 개수와 목록이다.
+    assert [first.id, second.id] in db.statements[1].compile().params.values()
+
+
+def test_member_support_assignee_filter_is_denied_before_any_query():
+    member = _member()
+    db = _Db()
+
+    with _client(db, member) as client:
+        response = client.get(
+            "/api/support-requests",
+            params={"assignee_member_id": [str(uuid4())]},
+        )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "scope_not_allowed"
+    assert not db.statements
+
+
+def test_manager_support_assignee_filter_rejects_a_member_outside_the_team():
+    manager = _member(role="manager")
+    db = _Db(_Result(scalar_values=[]))
+
+    with _client(db, manager) as client:
+        response = client.get(
+            "/api/support-requests",
+            params={"assignee_member_id": [str(uuid4())]},
+        )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "scope_not_allowed"
+    assert len(db.statements) == 1

--- a/frontend/src/auth/SessionProvider.tsx
+++ b/frontend/src/auth/SessionProvider.tsx
@@ -3,6 +3,7 @@ import { isAxiosError } from 'axios'
 
 import { client } from '@/api/client'
 import { subscribeSessionExpired } from '@/api/connectionState'
+import { initScope, resetScope } from '@/shared/scope'
 
 import { type Session, SessionContext, type SessionStatus } from './sessionContext'
 import { clearSignedInHint, hasSignedInHint } from './signedInHint'
@@ -23,6 +24,16 @@ const toSession = ({ id, display_name, role_code, job_title, is_admin }: AuthUse
   isAdmin: is_admin,
 })
 
+/**
+ * 보기 범위는 세션이 정해지는 자리에서 함께 세웁니다.
+ *
+ * AppShell 의 effect 로 미루면 자식 화면의 첫 요청이 범위를 놓칩니다. effect 는
+ * 자식이 먼저 돌기 때문입니다.
+ */
+function applyScope(next: Session) {
+  initScope(next.memberId, next.role === 'manager')
+}
+
 export default function SessionProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<Session | null>(null)
   const [status, setStatus] = useState<SessionStatus>('loading')
@@ -40,7 +51,9 @@ export default function SessionProvider({ children }: { children: ReactNode }) {
       .get<AuthUser>('/auth/me')
       .then(({ data }) => {
         if (!active) return
-        setSession(toSession(data))
+        const next = toSession(data)
+        setSession(next)
+        applyScope(next)
         setStatus('authenticated')
       })
       .catch((error: unknown) => {
@@ -72,6 +85,7 @@ export default function SessionProvider({ children }: { children: ReactNode }) {
       subscribeSessionExpired(() => {
         clearSignedInHint()
         setSession(null)
+        resetScope()
         setStatus('unauthenticated')
       }),
     [],
@@ -81,7 +95,9 @@ export default function SessionProvider({ children }: { children: ReactNode }) {
     // 로그인 응답이 세션 표시 쿠키까지 함께 설정하므로, 아래 reload 를 타도
     // 다시 뜬 앱이 세션을 되찾을 수 있습니다.
     const { data } = await client.post<AuthUser>('/auth/login', { email, password })
-    setSession(toSession(data))
+    const next = toSession(data)
+    setSession(next)
+    applyScope(next)
     setStatus('authenticated')
   }, [])
 
@@ -91,6 +107,7 @@ export default function SessionProvider({ children }: { children: ReactNode }) {
     await client.post('/auth/logout').catch(() => undefined)
     clearSignedInHint()
     setSession(null)
+    resetScope()
     setStatus('unauthenticated')
   }, [])
 

--- a/frontend/src/components/layout/Topbar/ScopeSwitcher/ScopeSwitcher.module.scss
+++ b/frontend/src/components/layout/Topbar/ScopeSwitcher/ScopeSwitcher.module.scss
@@ -1,0 +1,132 @@
+// 모양은 FilterSelect 를 따릅니다. Topbar 줄에 맞춰 높이만 낮춥니다.
+.root {
+  position: relative;
+  flex: none;
+}
+
+.fixed {
+  flex: none;
+  padding: 0 10px;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: var(--control-h);
+  white-space: nowrap;
+}
+
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s2);
+  max-width: 200px;
+  height: var(--control-h);
+  padding: 0 10px;
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.5;
+  text-align: left;
+  cursor: pointer;
+
+  &:hover,
+  &.isOpen {
+    border-color: var(--blue);
+  }
+
+  &.isOpen {
+    box-shadow: 0 0 0 3px var(--blue-ring);
+  }
+
+  &:active {
+    transform: none;
+  }
+}
+
+.triggerLabel {
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.chevron {
+  flex: none;
+  color: var(--muted);
+  transition: transform var(--t-fast) var(--ease-out);
+}
+
+.isOpen .chevron {
+  color: var(--blue);
+  transform: rotate(180deg);
+}
+
+.menu {
+  position: absolute;
+  top: calc(100% + var(--s1));
+  left: 0;
+  z-index: 30;
+  min-width: 100%;
+  width: max-content;
+  max-height: 60vh;
+  overflow-y: auto;
+  padding: var(--s1);
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  background: var(--surface);
+  box-shadow: var(--sh-pop);
+  animation: appear var(--t-fast) var(--ease-out);
+}
+
+// 체크가 왼쪽이라 여러 개를 고른 상태를 세로로 훑어보기 좋습니다.
+.option {
+  display: flex;
+  align-items: center;
+  gap: var(--s2);
+  width: 100%;
+  min-width: 140px;
+  padding: 7px var(--s2);
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  font-size: 13px;
+  line-height: 1.4;
+  text-align: left;
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:active {
+    transform: none;
+  }
+}
+
+.isActive {
+  background: var(--blue-tint);
+  color: var(--blue);
+}
+
+// 모드 두 줄과 팀원 목록을 가릅니다.
+.isDivided {
+  margin-top: var(--s1);
+  border-top: 1px solid var(--line);
+  border-radius: 0 0 7px 7px;
+  padding-top: calc(7px + var(--s1));
+}
+
+.check {
+  flex: 0 0 14px;
+  color: var(--blue);
+}
+
+.isHidden {
+  visibility: hidden;
+}
+
+@keyframes appear {
+  from {
+    opacity: 0;
+    transform: translateY(-3px);
+  }
+}

--- a/frontend/src/components/layout/Topbar/ScopeSwitcher/ScopeSwitcher.tsx
+++ b/frontend/src/components/layout/Topbar/ScopeSwitcher/ScopeSwitcher.tsx
@@ -1,0 +1,242 @@
+/**
+ * 화면 전체가 누구의 현황을 보고 있는지 고르는 스위처입니다.
+ *
+ * 팀원에게는 고를 것이 없어 글자만 둡니다. 목록을 감추는 것이 권한은 아니고, 실제
+ * 차단은 백엔드가 합니다. 여기서는 팀원에게 고를 수 없는 것을 보여 주지 않을 뿐입니다.
+ *
+ * 여러 명을 동시에 고를 수 있어야 해서 FilterSelect(단일 선택, 고르면 닫힘)를 그대로
+ * 쓰지 못했습니다. 대신 그 파일의 바깥 클릭·Escape·화살표 이동 처리를 옮겨 왔고,
+ * 다른 점은 Enter/Space 가 닫지 않고 토글한다는 것뿐입니다.
+ */
+import { useEffect, useId, useRef, useState, type KeyboardEvent } from 'react'
+
+import { useCurrentUser } from '@/auth/sessionContext'
+import { CheckIcon, ChevronDownIcon } from '@/components/icons'
+import useTeamMembers from '@/hooks/useTeamMembers'
+import { reconcileScope, type Scope, setScopeAll, setScopeMembers, useScope } from '@/shared/scope'
+
+import styles from './ScopeSwitcher.module.scss'
+
+const ALL_LABEL = '팀 전체'
+const ME_LABEL = '내 현황'
+
+interface Row {
+  key: string
+  label: string
+  selected: boolean
+  choose: () => void
+  /** 팀원 목록 첫 줄 위에 구분선을 둡니다. */
+  divided?: boolean
+}
+
+export default function ScopeSwitcher() {
+  const { isManager, memberId } = useCurrentUser()
+
+  if (!isManager) {
+    // 팀원은 언제나 본인 것만 봅니다. 누를 수 없는 표시로 지금 범위만 알립니다.
+    return <span className={styles.fixed}>{ME_LABEL}</span>
+  }
+
+  return <ManagerScopeSwitcher ownMemberId={memberId} />
+}
+
+function ManagerScopeSwitcher({ ownMemberId }: { ownMemberId: string }) {
+  const scope = useScope()
+  const [open, setOpen] = useState(false)
+  // 닫혀 있어도 고른 사람이 있으면 이름을 보여 줘야 하므로 미리 받아 둡니다.
+  const { members } = useTeamMembers(open || scope.mode === 'users')
+
+  const rootRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([])
+  const listboxId = `scope-${useId().replaceAll(':', '')}`
+  const [activeIndex, setActiveIndex] = useState(0)
+
+  // 팀에서 빠진 사람이 선택에 남아 있으면 서버가 목록 전체를 거절합니다.
+  useEffect(() => {
+    if (members.length > 0) reconcileScope(members.map((member) => member.id))
+  }, [members])
+
+  const teamIds = members.map((member) => member.id)
+  // '팀 전체' 는 명부 전체를 고른 것과 같습니다. 거기서 한 명만 빼려면 나머지가 이름으로
+  // 남아 있어야 하므로, 계산할 때는 팀 전체를 명부로 펼쳐 둡니다.
+  const chosen = scope.mode === 'all' ? teamIds : scope.memberIds
+  // 명부가 아직 오지 않았어도 팀 전체면 체크로 보입니다. 뜨는 순간 깜빡이지 않게 합니다.
+  const picked = (id: string) => scope.mode === 'all' || chosen.includes(id)
+  const coversTeam = scope.mode === 'all' || (teamIds.length > 0 && teamIds.every(picked))
+
+  const toggle = (id: string) => {
+    if (!chosen.includes(id)) {
+      setScopeMembers([...chosen, id])
+      return
+    }
+    // 마지막 한 명까지 끄면 볼 것이 없어집니다. 팀 전체로 튕겨 보내는 대신 그 클릭을
+    // 받지 않습니다. 한 사람만 보려던 의도가 전체 보기로 뒤집히지 않게 합니다.
+    if (chosen.length <= 1) return
+    setScopeMembers(chosen.filter((memberId) => memberId !== id))
+  }
+
+  const rows: Row[] = [
+    // 전체 선택 체크박스입니다. 누르면 아래 줄이 모두 켜집니다.
+    { key: 'all', label: ALL_LABEL, selected: coversTeam, choose: setScopeAll },
+    // 본인은 '내 현황' 한 줄로만 둡니다. 아래 팀원 목록에 또 넣으면 같은 사람이 두 줄이 됩니다.
+    {
+      key: ownMemberId,
+      label: ME_LABEL,
+      selected: picked(ownMemberId),
+      choose: () => toggle(ownMemberId),
+      divided: true,
+    },
+    ...members
+      .filter((member) => member.id !== ownMemberId)
+      .map((member) => ({
+        key: member.id,
+        label: member.display_name,
+        selected: picked(member.id),
+        choose: () => toggle(member.id),
+      })),
+  ]
+
+  // 열 때 맨 위로 잡습니다. 여러 명을 이어서 고르는 동안에는 포커스를 다시 옮기지 않으므로
+  // 이 effect 는 open 에만 반응하면 됩니다.
+  useEffect(() => {
+    if (!open) return
+
+    setActiveIndex(0)
+    const frame = requestAnimationFrame(() => optionRefs.current[0]?.focus())
+
+    const onPointerDown = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false)
+    }
+
+    document.addEventListener('pointerdown', onPointerDown)
+    return () => {
+      cancelAnimationFrame(frame)
+      document.removeEventListener('pointerdown', onPointerDown)
+    }
+  }, [open])
+
+  const focusOption = (index: number) => {
+    setActiveIndex(index)
+    optionRefs.current[index]?.focus()
+  }
+
+  const closeAndFocusTrigger = () => {
+    setOpen(false)
+    requestAnimationFrame(() => triggerRef.current?.focus())
+  }
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Tab' && open) {
+      setOpen(false)
+      return
+    }
+
+    if (event.key === 'Escape' && open) {
+      event.preventDefault()
+      closeAndFocusTrigger()
+      return
+    }
+
+    if (!open) {
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        event.preventDefault()
+        setOpen(true)
+      }
+      return
+    }
+
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault()
+      const delta = event.key === 'ArrowDown' ? 1 : -1
+      focusOption((activeIndex + delta + rows.length) % rows.length)
+      return
+    }
+
+    if (event.key === 'Home' || event.key === 'End') {
+      event.preventDefault()
+      focusOption(event.key === 'Home' ? 0 : rows.length - 1)
+      return
+    }
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      // 여러 명을 이어서 고를 수 있어야 하므로 닫지 않습니다.
+      rows[activeIndex]?.choose()
+    }
+  }
+
+  const label = coversTeam ? ALL_LABEL : triggerLabel(scope, ownMemberId, members)
+
+  return (
+    <div className={styles.root} ref={rootRef} onKeyDown={onKeyDown}>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={`${styles.trigger} ${open ? styles.isOpen : ''}`}
+        aria-label={`보기 범위: ${label}`}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        onClick={() => setOpen(!open)}
+      >
+        <span className={styles.triggerLabel}>{label}</span>
+        <ChevronDownIcon className={styles.chevron} width={14} height={14} />
+      </button>
+
+      {open && (
+        <div
+          id={listboxId}
+          className={styles.menu}
+          role="listbox"
+          aria-multiselectable="true"
+          aria-label="보기 범위"
+        >
+          {rows.map((row, index) => (
+            <button
+              key={row.key}
+              ref={(node) => {
+                optionRefs.current[index] = node
+              }}
+              type="button"
+              role="option"
+              aria-selected={row.selected}
+              tabIndex={index === activeIndex ? 0 : -1}
+              className={`${styles.option} ${index === activeIndex ? styles.isActive : ''} ${row.divided ? styles.isDivided : ''}`}
+              onFocus={() => setActiveIndex(index)}
+              onPointerMove={() => setActiveIndex(index)}
+              onClick={row.choose}
+            >
+              <CheckIcon
+                className={`${styles.check} ${row.selected ? '' : styles.isHidden}`}
+                width={14}
+                height={14}
+              />
+              <span>{row.label}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function triggerLabel(
+  scope: Scope,
+  ownMemberId: string,
+  members: readonly { id: string; display_name: string }[],
+): string {
+  if (scope.mode === 'all') return ALL_LABEL
+  // 본인이 섞여 있으면 앞에 세웁니다. 목록에서 보이는 순서와 맞춥니다.
+  const ordered = [...scope.memberIds].sort(
+    (a, b) => Number(b === ownMemberId) - Number(a === ownMemberId),
+  )
+  const names = ordered
+    .map((id) =>
+      id === ownMemberId ? ME_LABEL : members.find((member) => member.id === id)?.display_name,
+    )
+    .filter((name): name is string => name !== undefined)
+  // 이름을 아직 못 받았으면 인원수로 말합니다. 빈 칸보다는 낫습니다.
+  if (names.length === 0) return `${scope.memberIds.length}명`
+  return names.length === 1 ? names[0] : `${names[0]} 외 ${names.length - 1}명`
+}

--- a/frontend/src/components/layout/Topbar/ScopeSwitcher/index.ts
+++ b/frontend/src/components/layout/Topbar/ScopeSwitcher/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ScopeSwitcher'

--- a/frontend/src/components/layout/Topbar/Topbar.tsx
+++ b/frontend/src/components/layout/Topbar/Topbar.tsx
@@ -6,6 +6,7 @@ import { buttonClass } from '@/components/Button'
 import { BellIcon, MenuIcon } from '@/components/icons'
 import { useSidebar } from '@/components/layout/AppShell/sidebarContext'
 import { SIDEBAR_ID } from '@/components/layout/Sidebar/Sidebar'
+import ScopeSwitcher from '@/components/layout/Topbar/ScopeSwitcher'
 import { findNavLabel } from '@/constants/navigation'
 import { ROUTES } from '@/constants/routes'
 
@@ -45,6 +46,9 @@ export default function Topbar() {
       <p className={styles.pageName}>{pageLabel}</p>
 
       <div className={styles.spacer} />
+
+      {/* 화면 전체가 누구의 현황을 보는지 정합니다. 페이지마다 따로 두지 않습니다. */}
+      <ScopeSwitcher />
 
       {/* 알림 조회 API가 없어 읽지 않음 여부는 표시하지 않습니다. */}
       <Link

--- a/frontend/src/pages/Complaints/useSupportRequests.ts
+++ b/frontend/src/pages/Complaints/useSupportRequests.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { isAxiosError } from 'axios'
 
 import { client } from '@/api/client'
+import { useScopeOwnerIds } from '@/shared/scope'
 import type {
   CustomerContactResponse,
   PageResponse,
@@ -19,14 +20,18 @@ export interface ContactOption {
   label: string
 }
 
-async function fetchAll<T>(path: string, signal: AbortSignal): Promise<T[]> {
+async function fetchAll<T>(
+  path: string,
+  signal: AbortSignal,
+  extraParams?: Record<string, unknown>,
+): Promise<T[]> {
   // ponytail: 탭 건수는 전건 기준입니다. 데이터가 커지면 서버 집계 API로 바꿉니다.
   const items: T[] = []
   let skip = 0
 
   while (!signal.aborted) {
     const { data } = await client.get<PageResponse<T>>(path, {
-      params: { skip, limit: PAGE_LIMIT },
+      params: { skip, limit: PAGE_LIMIT, ...extraParams },
       signal,
     })
     items.push(...data.items)
@@ -74,6 +79,7 @@ export default function useSupportRequests(openId: string | null) {
   const [pendingKey, setPendingKey] = useState<string | null>(null)
   const pendingRef = useRef(false)
   const [mutationError, setMutationError] = useState<string | null>(null)
+  const assigneeIds = useScopeOwnerIds()
 
   useEffect(() => {
     const controller = new AbortController()
@@ -81,7 +87,11 @@ export default function useSupportRequests(openId: string | null) {
     setError(null)
 
     void Promise.all([
-      fetchAll<SupportRequestResponse>('/support-requests', controller.signal),
+      fetchAll<SupportRequestResponse>('/support-requests', controller.signal, {
+        assignee_member_id: assigneeIds,
+      }),
+      // 고객은 불만을 등록할 때 고르는 목록입니다. 보기 범위로 좁히면 팀원이 맡은
+      // 고객의 불만을 접수할 수 없게 됩니다.
       fetchAll<CustomerContactResponse>('/customer-contacts', controller.signal),
     ])
       .then(([requestItems, contactItems]) => {
@@ -102,7 +112,7 @@ export default function useSupportRequests(openId: string | null) {
       })
 
     return () => controller.abort()
-  }, [reloadKey])
+  }, [reloadKey, assigneeIds])
 
   useEffect(() => {
     setDetail(null)

--- a/frontend/src/pages/Customers/Customers.tsx
+++ b/frontend/src/pages/Customers/Customers.tsx
@@ -5,6 +5,7 @@ import { client } from '@/api/client'
 import { useCurrentUser } from '@/auth/sessionContext'
 import Button from '@/components/Button'
 import Pagination from '@/components/Pagination'
+import { useScopeOwnerIds } from '@/shared/scope'
 import type {
   Customer,
   CustomerContactResponse,
@@ -94,6 +95,7 @@ export default function Customers() {
   const { isManager } = useCurrentUser()
   const hiddenColumns = useMemo(() => (isManager ? [] : ['owner']), [isManager])
   const deferredQuery = useDeferredValue(query)
+  const ownerIds = useScopeOwnerIds()
 
   // 정렬 API가 붙기 전에 현재 페이지만 정렬하면 전체 순서를 오해하게 됩니다.
   const columns = useMemo(
@@ -120,6 +122,7 @@ export default function Customers() {
           q: needle === '' ? undefined : needle.slice(0, 100),
           skip: (page - 1) * pageSize,
           limit: pageSize,
+          owner_member_id: ownerIds,
         },
         signal: controller.signal,
       })
@@ -139,11 +142,17 @@ export default function Customers() {
       })
 
     return () => controller.abort()
-  }, [deferredQuery, page, pageSize, reloadKey])
+  }, [deferredQuery, page, pageSize, reloadKey, ownerIds])
 
   const pageCount = Math.max(1, Math.ceil(total / pageSize))
   const openCustomer = useMemo(() => rows.find((row) => row.id === openId) ?? null, [rows, openId])
   const resetPage = useCallback(() => setPage(1), [])
+
+  // 서버가 페이지를 나눠 주는 유일한 화면입니다. 팀 전체의 3페이지가 한 사람의 3페이지일
+  // 리 없으므로 범위가 바뀌면 첫 장으로 돌아갑니다.
+  useEffect(() => {
+    resetPage()
+  }, [ownerIds, resetPage])
 
   const onQueryChange = useCallback(
     (next: string) => {

--- a/frontend/src/pages/Daily/MeetingPick.tsx
+++ b/frontend/src/pages/Daily/MeetingPick.tsx
@@ -32,7 +32,7 @@ export default function MeetingPick() {
     loading: agendaLoading,
     error: agendaError,
     reload: reloadAgenda,
-  } = useAgendaState()
+  } = useAgendaState(undefined, undefined, true)
   const agenda = items.filter((item) => item.date === dateISO)
   const {
     findByAgenda,

--- a/frontend/src/pages/Daily/useDailyDraft.ts
+++ b/frontend/src/pages/Daily/useDailyDraft.ts
@@ -44,7 +44,7 @@ export default function useDailyDraft(
     loading: agendaLoading,
     error: agendaError,
     reload: reloadAgenda,
-  } = useAgendaState(dateISO, dateISO)
+  } = useAgendaState(dateISO, dateISO, true)
   const {
     byDate,
     loading: meetingLoading,

--- a/frontend/src/pages/Daily/useDailyReports.ts
+++ b/frontend/src/pages/Daily/useDailyReports.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { client } from '@/api/client'
+import { useScopeOwnerIds } from '@/shared/scope'
 import { errorMessage } from '@/api/errorMessage'
 import { fallbackDailyReports } from '@/mocks/reports'
 import { reportTemplateFromSnapshot } from '@/shared/reports'
@@ -93,12 +94,20 @@ function toReport(item: ReportResponse): DailyReport {
   }
 }
 
-async function fetchReports(signal: AbortSignal): Promise<ReportResponse[]> {
+async function fetchReports(
+  signal: AbortSignal,
+  authorIds?: readonly string[],
+): Promise<ReportResponse[]> {
   const result: ReportResponse[] = []
   let skip = 0
   while (!signal.aborted) {
     const { data } = await client.get<PageResponse<ReportResponse>>('/reports', {
-      params: { report_kind: ['daily', 'weekly', 'monthly'], skip, limit: PAGE_LIMIT },
+      params: {
+        report_kind: ['daily', 'weekly', 'monthly'],
+        author_member_id: authorIds,
+        skip,
+        limit: PAGE_LIMIT,
+      },
       signal,
     })
     result.push(...data.items)
@@ -153,17 +162,20 @@ export default function useDailyReports() {
   const [error, setError] = useState<string | null>(null)
   const [pending, setPending] = useState(false)
   const [reloadKey, setReloadKey] = useState(0)
+  const authorIds = useScopeOwnerIds()
 
   useEffect(() => {
     const controller = new AbortController()
     setLoading(true)
     setError(null)
-    void fetchReports(controller.signal)
+    void fetchReports(controller.signal, authorIds)
       .then((items) => {
         if (!controller.signal.aborted) setReports(items.map(toReport))
       })
       // 목록을 못 받아 오면 화면을 에러로 덮지 않고 시연 데이터로 채웁니다.
       // 저장·제출 실패는 아래 save 에서 그대로 알립니다.
+      // 이 시연 데이터는 보기 범위를 따르지 않습니다. 원래도 서버 없이 화면을 띄우기
+      // 위한 것이라 그대로 둡니다.
       .catch(() => {
         if (!controller.signal.aborted) setReports(fallbackDailyReports)
       })
@@ -171,7 +183,7 @@ export default function useDailyReports() {
         if (!controller.signal.aborted) setLoading(false)
       })
     return () => controller.abort()
-  }, [reloadKey])
+  }, [reloadKey, authorIds])
 
   const byDate = useMemo(() => {
     const map = new Map<string, DailyReport[]>()

--- a/frontend/src/pages/Deals/useSalesDeals.ts
+++ b/frontend/src/pages/Deals/useSalesDeals.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { isAxiosError } from 'axios'
 
 import { client } from '@/api/client'
+import { useScopeOwnerIds } from '@/shared/scope'
 import type {
   CustomerCompanyResponse,
   PageResponse,
@@ -170,7 +171,7 @@ function toSalesDeal(deal: SalesDealResponse): SalesDeal {
 async function fetchAllPage<T>(
   path: string,
   signal?: AbortSignal,
-  params?: Record<string, string>,
+  params?: Record<string, unknown>,
 ): Promise<T[]> {
   // ponytail: 현재 UI의 건수·정렬은 전건 기준입니다. 데이터가 커지면 서버 집계·정렬로 바꿉니다.
   const items: T[] = []
@@ -194,10 +195,12 @@ async function fetchAllSalesDeals(
   signal?: AbortSignal,
   pipelineId?: string | null,
   phaseCode?: SalesPipelinePhaseCode,
+  ownerIds?: readonly string[],
 ): Promise<SalesDeal[]> {
   const params = {
     ...(pipelineId ? { sales_pipeline_id: pipelineId } : {}),
     ...(phaseCode ? { phase_code: phaseCode } : {}),
+    ...(ownerIds ? { owner_member_id: ownerIds } : {}),
   }
   return (await fetchAllPage<SalesDealResponse>('/sales-deals', signal, params)).map(toSalesDeal)
 }
@@ -264,6 +267,7 @@ export default function useSalesDeals(
   const pendingRef = useRef(new Set<string>())
   const [pendingKeys, setPendingKeys] = useState<ReadonlySet<string>>(() => new Set())
   const [mutationError, setMutationError] = useState<string | null>(null)
+  const ownerIds = useScopeOwnerIds()
 
   useEffect(() => {
     const controller = new AbortController()
@@ -293,7 +297,8 @@ export default function useSalesDeals(
                   )
                   .then((response) => response.data)
               : Promise.resolve([]),
-            fetchAllSalesDeals(controller.signal, filteredPipelineId, phaseCode),
+            fetchAllSalesDeals(controller.signal, filteredPipelineId, phaseCode, ownerIds),
+            // 고객사와 제품은 딜을 등록할 때 고르는 참조 목록이라 범위로 좁히지 않습니다.
             fetchAllPage<CustomerCompanyResponse>('/customer-companies', controller.signal),
             fetchAllPage<ProductResponse>('/products', controller.signal),
             client
@@ -319,7 +324,7 @@ export default function useSalesDeals(
       })
 
     return () => controller.abort()
-  }, [mode, phaseCode, reloadKey, requestedPipelineId])
+  }, [mode, phaseCode, reloadKey, requestedPipelineId, ownerIds])
 
   useEffect(() => {
     if (openId === null) {
@@ -355,11 +360,12 @@ export default function useSalesDeals(
 
   const syncSalesDeals = useCallback(async () => {
     try {
-      setCards(await fetchAllSalesDeals(undefined, dealPipelineId, phaseCode))
+      // 범위를 빠뜨리면 고치자마자 화면이 조용히 팀 전체로 되돌아갑니다.
+      setCards(await fetchAllSalesDeals(undefined, dealPipelineId, phaseCode, ownerIds))
     } catch {
       setMutationError('변경은 저장됐지만 최신 목록을 불러오지 못했습니다. 새로고침해 주세요.')
     }
-  }, [dealPipelineId, phaseCode])
+  }, [dealPipelineId, phaseCode, ownerIds])
 
   const runMutation = useCallback(
     async <T>(key: string, action: string, request: () => Promise<T>): Promise<T> => {

--- a/frontend/src/pages/Meetings/Compose.tsx
+++ b/frontend/src/pages/Meetings/Compose.tsx
@@ -33,7 +33,7 @@ export default function Compose() {
     loading: agendaLoading,
     error: agendaError,
     reload: reloadAgenda,
-  } = useAgendaState()
+  } = useAgendaState(undefined, undefined, true)
   const item = agendaId ? agenda.find((entry) => entry.id === agendaId) : undefined
 
   const { findByAgenda, saveReport, saveDraft, loading, error, pending, reload } =

--- a/frontend/src/pages/Orders/useOrderList.ts
+++ b/frontend/src/pages/Orders/useOrderList.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { isAxiosError } from 'axios'
 
 import { client } from '@/api/client'
+import { useScopeOwnerIds } from '@/shared/scope'
 import type {
   ApiPurchaseOrder,
   OrderCreateRequest,
@@ -88,14 +89,18 @@ function toOrder(order: OrderResponse): ApiPurchaseOrder {
   }
 }
 
-async function fetchAllPage<T>(path: string, signal?: AbortSignal): Promise<T[]> {
+async function fetchAllPage<T>(
+  path: string,
+  signal?: AbortSignal,
+  extraParams?: Record<string, unknown>,
+): Promise<T[]> {
   // ponytail: 현재 화면의 필터·탭 건수는 전건 기준입니다. 데이터가 커지면 서버 집계로 바꿉니다.
   const items: T[] = []
   let skip = 0
 
   while (!signal?.aborted) {
     const { data } = await client.get<PageResponse<T>>(path, {
-      params: { skip, limit: PAGE_LIMIT },
+      params: { skip, limit: PAGE_LIMIT, ...extraParams },
       signal,
     })
     items.push(...data.items)
@@ -107,8 +112,14 @@ async function fetchAllPage<T>(path: string, signal?: AbortSignal): Promise<T[]>
   return items
 }
 
-async function fetchAllOrders(signal?: AbortSignal): Promise<ApiPurchaseOrder[]> {
-  return (await fetchAllPage<OrderResponse>('/orders', signal)).map(toOrder)
+async function fetchAllOrders(
+  signal?: AbortSignal,
+  ownerIds?: readonly string[],
+): Promise<ApiPurchaseOrder[]> {
+  // 발주에는 담당자 칸이 따로 없어 서버가 딜의 담당자로 거릅니다.
+  return (await fetchAllPage<OrderResponse>('/orders', signal, { owner_member_id: ownerIds })).map(
+    toOrder,
+  )
 }
 
 function toWriteRequest(draft: OrderDraft): OrderPatchRequest {
@@ -164,6 +175,7 @@ export default function useOrderList(detailNo?: string) {
   const pendingRef = useRef(new Set<string>())
   const [pendingKeys, setPendingKeys] = useState<ReadonlySet<string>>(() => new Set())
   const [mutationError, setMutationError] = useState<string | null>(null)
+  const ownerIds = useScopeOwnerIds()
 
   useEffect(() => {
     const controller = new AbortController()
@@ -171,7 +183,9 @@ export default function useOrderList(detailNo?: string) {
     setError(null)
 
     void Promise.all([
-      fetchAllOrders(controller.signal),
+      fetchAllOrders(controller.signal, ownerIds),
+      // 제품과 딜은 발주를 등록할 때 고르는 목록입니다. 보기 범위로 좁히면 팀원이 맡은
+      // 딜의 발주를 넣을 수 없게 됩니다.
       fetchAllPage<ProductResponse>('/products', controller.signal),
       fetchAllPage<SalesDealResponse>('/sales-deals', controller.signal),
       client
@@ -203,7 +217,7 @@ export default function useOrderList(detailNo?: string) {
       })
 
     return () => controller.abort()
-  }, [reloadKey])
+  }, [reloadKey, ownerIds])
 
   useEffect(() => {
     setDetail(null)

--- a/frontend/src/shared/agenda.ts
+++ b/frontend/src/shared/agenda.ts
@@ -17,6 +17,8 @@ import type {
 } from '@/types'
 import { parseISO, TODAY } from '@/utils/date'
 
+import { getOwnMemberIds, getScopeKey, getScopeOwnerIds, useScopeKey } from './scope'
+
 export const KIND_LABEL: Record<AgendaKind, string> = {
   visit: '방문',
   demo: '데모',
@@ -194,7 +196,7 @@ export function agendaToActivity(event: CalendarEvent): ActivityCreateRequest {
 let items: AgendaItem[] = []
 let loading = true
 let loadError: string | null = null
-let loadedRange: string | null = null
+let loadedKey: string | null = null
 let loadPromise: Promise<void> | null = null
 let revision = 0
 const listeners = new Set<() => void>()
@@ -219,6 +221,10 @@ export function agendaSnapshot(): AgendaItem[] {
   return items
 }
 
+/**
+ * 보기 범위를 좁혀 둔 채로 자기 일정을 만들면 필터 밖인데도 목록에 붙습니다.
+ * 범위 밖 날짜에서 이미 같은 일이 일어나므로 그대로 둡니다. 다시 불러오면 정리됩니다.
+ */
 export function addAgenda(item: AgendaItem) {
   commit([...items, item])
 }
@@ -231,13 +237,23 @@ export function removeAgenda(id: string) {
   commit(items.filter((item) => item.id !== id))
 }
 
-async function fetchAgenda(startDate: string, endDate: string): Promise<AgendaItem[]> {
+async function fetchAgenda(
+  startDate: string,
+  endDate: string,
+  ownerIds?: readonly string[],
+): Promise<AgendaItem[]> {
   // ponytail: 현재 소비 화면은 전건 집계가 필요합니다. 커지면 서버 요약 API로 바꿉니다.
   const result: AgendaItem[] = []
   let skip = 0
   while (true) {
     const { data } = await client.get<PageResponse<ActivityRead>>('/activities', {
-      params: { start_date: startDate, end_date: endDate, skip, limit: PAGE_LIMIT },
+      params: {
+        start_date: startDate,
+        end_date: endDate,
+        owner_member_id: ownerIds,
+        skip,
+        limit: PAGE_LIMIT,
+      },
     })
     result.push(...data.items.map(activityToAgenda))
     if (!data.has_more || data.next_skip === null) return result
@@ -246,19 +262,27 @@ async function fetchAgenda(startDate: string, endDate: string): Promise<AgendaIt
   }
 }
 
-export function loadAgenda(startDate: string, endDate: string, force = false): Promise<void> {
-  const rangeKey = `${startDate}:${endDate}`
+export function loadAgenda(
+  startDate: string,
+  endDate: string,
+  force = false,
+  ownScopeOnly = false,
+): Promise<void> {
+  // 범위를 매번 여기서 읽습니다. 아래 재진입 가드가 자기를 다시 부르므로, 요청이
+  // 날아가는 사이에 범위가 바뀌면 그 재귀 호출이 새 범위를 봐야 합니다.
+  const ownerIds = ownScopeOnly ? getOwnMemberIds() : getScopeOwnerIds()
+  const key = `${ownScopeOnly ? 'own' : getScopeKey()}|${startDate}:${endDate}`
   if (loadPromise) {
-    return loadPromise.then(() => loadAgenda(startDate, endDate, force))
+    return loadPromise.then(() => loadAgenda(startDate, endDate, force, ownScopeOnly))
   }
-  if (loadedRange === rangeKey && !force) return Promise.resolve()
+  if (loadedKey === key && !force) return Promise.resolve()
   commit([])
   loading = true
   loadError = null
   notify()
-  loadPromise = fetchAgenda(startDate, endDate)
+  loadPromise = fetchAgenda(startDate, endDate, ownerIds)
     .then((next) => {
-      loadedRange = rangeKey
+      loadedKey = key
       commit(next)
     })
     .catch((error: unknown) => {
@@ -312,16 +336,28 @@ const DEFAULT_START_DATE = '2000-01-01'
 const DEFAULT_END_DATE = '2099-12-31'
 
 export function useAgenda(): AgendaItem[] {
+  const scopeKey = useScopeKey()
   useEffect(() => {
     void loadAgenda(DEFAULT_START_DATE, DEFAULT_END_DATE)
-  }, [])
+  }, [scopeKey])
   return useSyncExternalStore(subscribeAgenda, agendaSnapshot, agendaSnapshot)
 }
 
-export function useAgendaState(startDate = DEFAULT_START_DATE, endDate = DEFAULT_END_DATE) {
+/**
+ * `ownScopeOnly` 는 보기 범위를 무시하고 본인 일정만 봅니다.
+ *
+ * 보고서를 쓰는 화면이 씁니다. 보고는 "내가 한 일" 을 적는 일이라 팀 전체를 보고 있어도
+ * 후보에 남의 일정이 섞이면 안 됩니다. 조회하는 화면과 성격이 다릅니다.
+ */
+export function useAgendaState(
+  startDate = DEFAULT_START_DATE,
+  endDate = DEFAULT_END_DATE,
+  ownScopeOnly = false,
+) {
+  const scopeKey = useScopeKey()
   useEffect(() => {
-    void loadAgenda(startDate, endDate)
-  }, [endDate, startDate])
+    void loadAgenda(startDate, endDate, false, ownScopeOnly)
+  }, [endDate, startDate, ownScopeOnly, scopeKey])
   useSyncExternalStore(
     subscribeAgenda,
     () => revision,
@@ -331,7 +367,7 @@ export function useAgendaState(startDate = DEFAULT_START_DATE, endDate = DEFAULT
     items,
     loading,
     error: loadError,
-    reload: () => loadAgenda(startDate, endDate, true),
+    reload: () => loadAgenda(startDate, endDate, true, ownScopeOnly),
   }
 }
 

--- a/frontend/src/shared/scope.ts
+++ b/frontend/src/shared/scope.ts
@@ -1,0 +1,197 @@
+/**
+ * 앱 전체가 공유하는 보기 범위입니다. Topbar 의 스위처가 고르고 모든 목록 화면이 따릅니다.
+ *
+ * 페이지마다 따로 들면 메뉴를 옮길 때마다 범위가 풀리므로 모듈 한 곳에 둡니다.
+ * agenda.ts, connectionState.ts 와 같은 방식이고 상태 관리 라이브러리를 새로 넣지 않습니다.
+ *
+ * 여기서 정하는 것은 "무엇을 보여줄지" 뿐입니다. "무엇을 볼 수 있는지" 는 백엔드가
+ * 정합니다. 화면이 보낸 담당자 목록은 서버가 매번 같은 팀인지 다시 확인합니다.
+ */
+import { useSyncExternalStore } from 'react'
+
+/**
+ * `users` 는 고른 사람들입니다. 본인도 그 안에 들어갑니다.
+ *
+ * '내 현황' 을 따로 둔 모드로 만들면 본인과 팀원을 함께 볼 수 없습니다. 화면의 '내 현황'
+ * 은 본인을 가리키는 한 줄일 뿐이고, 팀원 줄과 똑같이 켜고 끕니다. 배타적인 것은
+ * '팀 전체' 하나뿐입니다.
+ */
+export type ScopeMode = 'all' | 'users'
+
+export interface Scope {
+  mode: ScopeMode
+  memberIds: readonly string[]
+}
+
+interface StoredScope {
+  mode: ScopeMode
+  memberIds: string[]
+}
+
+type Listener = () => void
+
+const STORAGE_PREFIX = 'salesluv.scope.'
+const NO_MEMBERS: readonly string[] = []
+
+const ALL: Scope = { mode: 'all', memberIds: NO_MEMBERS }
+
+let scope: Scope = ALL
+let ownMemberId: string | null = null
+let isManager = false
+
+// 커밋할 때마다 다시 계산해 둡니다. useSyncExternalStore 는 렌더마다 같은 참조를
+// 돌려받아야 하므로 getSnapshot 안에서 새 배열을 만들면 안 됩니다.
+let ownerIds: readonly string[] | undefined
+let scopeKey = 'all'
+
+const listeners = new Set<Listener>()
+
+function storageKey(memberId: string): string {
+  return `${STORAGE_PREFIX}${memberId}`
+}
+
+/**
+ * 서버로 보낼 담당자 목록입니다. undefined 는 "담당자를 좁히지 않는다" 는 뜻이고,
+ * axios 가 알아서 파라미터를 뺍니다.
+ *
+ * 팀원이면 모드와 상관없이 언제나 undefined 입니다. 백엔드는 팀원이 담당자 파라미터를
+ * 보내는 것 자체를 거절하므로(scope_not_allowed), 하나라도 실어 보내면 모든 목록이
+ * 403 이 됩니다. 저장소를 손으로 고쳐도 여기서 역할을 다시 보기 때문에 통과하지 못합니다.
+ */
+function computeOwnerIds(): readonly string[] | undefined {
+  if (!isManager || ownMemberId === null) return undefined
+  return scope.mode === 'all' ? undefined : scope.memberIds
+}
+
+function computeScopeKey(): string {
+  if (!isManager || ownMemberId === null) return 'all'
+  return scope.mode === 'all' ? 'all' : `users:${scope.memberIds.join(',')}`
+}
+
+function persist() {
+  // 팀원의 범위는 고정이라 남길 것이 없습니다.
+  if (!isManager || ownMemberId === null) return
+  const value: StoredScope = { mode: scope.mode, memberIds: [...scope.memberIds] }
+  try {
+    localStorage.setItem(storageKey(ownMemberId), JSON.stringify(value))
+  } catch {
+    // 사파리 비공개 모드처럼 저장이 막힌 환경입니다. 이번 세션 안에서는 그대로 동작합니다.
+  }
+}
+
+function read(memberId: string): Scope | null {
+  try {
+    const raw = localStorage.getItem(storageKey(memberId))
+    if (raw === null) return null
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null) return null
+    const { mode, memberIds } = parsed as Partial<StoredScope>
+    if (mode === 'all') return ALL
+    if (mode !== 'users') return null
+    if (!Array.isArray(memberIds)) return null
+    const ids = memberIds.filter((id): id is string => typeof id === 'string')
+    return ids.length === 0 ? null : { mode: 'users', memberIds: ids }
+  } catch {
+    return null
+  }
+}
+
+function commit(next: Scope, { save = true } = {}) {
+  scope = next
+  ownerIds = computeOwnerIds()
+  scopeKey = computeScopeKey()
+  if (save) persist()
+  for (const listener of listeners) listener()
+}
+
+/**
+ * 로그인한 사람에 맞춰 범위를 세웁니다.
+ *
+ * 저장 키가 구성원마다 다르므로 다른 계정으로 로그인해도 앞 사람의 선택을 물려받지
+ * 않습니다. 기본값은 팀장이 팀 전체, 팀원이 내 현황입니다.
+ */
+export function initScope(memberId: string, manager: boolean) {
+  ownMemberId = memberId
+  isManager = manager
+  // 팀원은 늘 본인 것만 봅니다. 서버가 그렇게 좁히므로 여기서는 좁히지 않는 상태로 둡니다.
+  commit(manager ? (read(memberId) ?? ALL) : ALL, { save: false })
+}
+
+/** 로그아웃. 저장 키는 구성원별이라 지우지 않고 메모리 상태만 내립니다. */
+export function resetScope() {
+  ownMemberId = null
+  isManager = false
+  commit(ALL, { save: false })
+}
+
+export function subscribeScope(listener: Listener): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+export function scopeSnapshot(): Scope {
+  return scope
+}
+
+/** agenda.ts 처럼 훅 밖에서 읽어야 하는 곳을 위한 통로입니다. */
+export function getScopeOwnerIds(): readonly string[] | undefined {
+  return ownerIds
+}
+
+export function getScopeKey(): string {
+  return scopeKey
+}
+
+export function getOwnMemberIds(): readonly string[] | undefined {
+  return isManager && ownMemberId !== null ? [ownMemberId] : undefined
+}
+
+export function setScopeAll() {
+  if (scope.mode !== 'all') commit(ALL)
+}
+
+/**
+ * 고른 사람을 통째로 바꿉니다.
+ *
+ * 어떤 집합이 되어야 하는지는 팀 명부를 아는 화면이 정합니다. 스토어는 명부를 들고
+ * 있지 않아서 '팀 전체에서 한 명만 빼기' 같은 계산을 여기서 할 수 없습니다.
+ * 빈 목록은 보여 줄 것이 없다는 뜻이라 팀 전체로 되돌립니다.
+ */
+export function setScopeMembers(memberIds: readonly string[]) {
+  const next = [...new Set(memberIds)]
+  commit(next.length === 0 ? ALL : { mode: 'users', memberIds: next })
+}
+
+/**
+ * 팀에서 빠지거나 비활성화된 사람을 선택에서 덜어냅니다.
+ *
+ * 저장해 둔 선택을 그대로 보내면 서버가 "지금 팀에 없는 사람" 이라며 목록 전체를
+ * 거절합니다. 팀원 목록을 받은 뒤 한 번 맞춰 둡니다.
+ */
+export function reconcileScope(availableIds: readonly string[]) {
+  if (scope.mode !== 'users') return
+  const next = scope.memberIds.filter((id) => availableIds.includes(id))
+  if (next.length === scope.memberIds.length) return
+  commit(next.length === 0 ? ALL : { mode: 'users', memberIds: next })
+}
+
+export function useScope(): Scope {
+  return useSyncExternalStore(subscribeScope, scopeSnapshot, scopeSnapshot)
+}
+
+/** 목록을 부르는 모든 훅이 쓰는 하나뿐인 입구입니다. */
+export function useScopeOwnerIds(): readonly string[] | undefined {
+  return useSyncExternalStore(subscribeScope, getScopeOwnerIds, getScopeOwnerIds)
+}
+
+/**
+ * 범위가 바뀐 것을 effect 가 알아채는 값입니다.
+ *
+ * 배열이 아니라 문자열에 기대는 까닭은, 같은 선택인데 참조만 달라져서 effect 가
+ * 다시 도는 일을 막기 위해서입니다. 화면마다 쓰던 reloadKey 와 같은 역할입니다.
+ */
+export function useScopeKey(): string {
+  return useSyncExternalStore(subscribeScope, getScopeKey, getScopeKey)
+}


### PR DESCRIPTION
## 변경 요약

- Topbar 에 전역 보기 범위 스위처(`ScopeSwitcher`)를 추가하고, 팀장이 '팀 전체' 또는 담당자 다중 선택으로 보기 범위를 고를 수 있게 했습니다.
- 선택한 범위를 `frontend/src/shared/scope.ts` 스토어 한 곳에 두어 고객·주문·영업기회·일일보고·상담(문의) 목록과 대시보드가 페이지를 옮겨도 같은 범위를 따르게 했습니다. 범위는 구성원별 키로 localStorage 에 저장하고, 팀 명부를 받은 뒤 빠진 구성원은 선택에서 덜어냅니다.
- 백엔드에 `owner_scope` 의존성을 추가해 담당자 파라미터를 검증합니다. 팀장만 사용할 수 있고, 요청된 담당자가 같은 팀의 활성 구성원인지 매번 다시 확인해 아니면 `403 scope_not_allowed` 로 거절합니다(조용히 빈 결과를 주지 않습니다).
- activities / customers / dashboard / orders / reports / sales_deals / support 라우터가 이 담당자 조건을 적용하도록 조회를 수정했고, 관련 스키마에 담당자 정보를 노출했습니다.
- `backend/tests/test_customers.py`, `backend/tests/test_support.py` 에 범위 필터와 권한 거절 케이스 테스트를 추가했습니다.

## 검증

- `cd frontend && npm run lint` 통과
- `cd frontend && npm run typecheck` 통과
- `cd backend && uv run pytest -q`: 178 passed, 2 failed. 실패한 `tests/test_health.py::test_health_db_connects`, `tests/test_models.py::test_models_match_configured_database` 는 실제 DB 접속이 필요한 테스트로, 로컬에서 DB 호스트를 찾지 못해(`asyncpg ... nxdomain`) 실패했습니다. 이번 변경과 무관합니다.
- `npm run build`(vite 빌드)와 브라우저 수동 확인은 실행하지 않았습니다.

## 영향 및 주의 사항

- 목록 조회 API 가 담당자 파라미터를 받습니다. 팀원이 담당자 파라미터를 보내면 `403 scope_not_allowed` 이므로, 프런트는 팀원일 때 파라미터를 보내지 않습니다.
- 팀장의 기본 보기 범위가 '팀 전체' 입니다. 기존에 본인 데이터만 보였던 화면의 기본 표시 범위가 넓어집니다.
- 보기 범위는 브라우저 localStorage 에 구성원별로 저장되므로 별도 마이그레이션은 없습니다.
