### PR TITLE
로컬 로그인 실패 원인 수정: DB 연결 풀 상한과 JWKS 재조회

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -175,9 +175,23 @@ async def login(
             email=payload.email,
             password=payload.password,
         )
-        member_id = await supabase_auth.verify_access_token(session.access_token)
     except supabase_auth.AuthError as error:
         raise auth_http_error(error) from error
+    except BaseException:
+        _release_login_attempt(client_host)
+        raise
+
+    try:
+        member_id = await supabase_auth.verify_access_token(session.access_token)
+    except supabase_auth.AuthError as error:
+        # 비밀번호는 맞았고 Supabase 도 토큰을 줬다. 그 토큰을 우리가 못 읽는 것이므로
+        # 자격증명 문제가 아니라 서버 문제다. 401 로 알리면 원인이 비밀번호에 있는 줄 알고
+        # 같은 비밀번호를 계속 다시 치게 된다. 시도 슬롯도 서버 잘못으로 채우지 않는다.
+        _release_login_attempt(client_host)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="auth_unavailable",
+        ) from error
     except BaseException:
         _release_login_attempt(client_host)
         raise

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -26,10 +26,24 @@ def get_engine() -> AsyncEngine:
     if not settings.database_url:
         raise RuntimeError("DATABASE_URL 이 설정되지 않았습니다. backend/.env 를 확인하세요.")
 
+    # session pooler 는 클라이언트 하나가 Postgres 연결 하나를 통째로 붙잡고 있고,
+    # 한도 15 는 머신이 아니라 Supabase 프로젝트 단위다. 배포 서버, 팀원들의 로컬
+    # 서버, pytest 가 모두 같은 15 를 나눠 쓴다.
+    #
+    # SQLAlchemy 기본값(pool_size 5 + max_overflow 10)이면 프로세스 하나가 그 15 를
+    # 혼자 다 가져갈 수 있어, 다른 누군가가 붙는 순간 EMAXCONNSESSION 이 난다.
+    #
+    # max_overflow 를 0 으로 두어 한도를 넘기는 대신 기다리게 한다. 밖에서 거절당하는
+    # 것보다 안에서 줄 서는 편이 낫다.
+    #
+    # ponytail: 2 는 프로젝트 한도 15 를 참여자 수로 나눈 값이다. uvicorn worker 를
+    # 늘리거나 참여자가 늘면 pool_size × 프로세스 수가 15 를 넘지 않는지 다시 계산한다.
     return create_async_engine(
         settings.async_database_url,
         echo=settings.debug,
         pool_pre_ping=True,
+        pool_size=2,
+        max_overflow=0,
     )
 
 

--- a/backend/app/services/supabase_auth.py
+++ b/backend/app/services/supabase_auth.py
@@ -9,6 +9,7 @@ secret 키는 사용자를 만들고 지울 수 있으므로 admin 경로에서�
 비밀번호와 토큰은 예외 메시지나 로그에 남기지 않는다.
 """
 
+import logging
 import time
 from dataclasses import dataclass
 from urllib.parse import quote
@@ -16,15 +17,24 @@ from uuid import UUID
 
 import httpx
 import jwt
-from jwt import PyJWKSet
+from jwt import PyJWK, PyJWKSet
 
 from app.core.config import settings
+
+# 실패 원인을 서버 쪽에 남긴다. 응답은 원인을 구분하지 않으므로 여기가 유일한 단서다.
+# 비밀번호·토큰·이메일은 절대 싣지 않는다.
+logger = logging.getLogger(__name__)
 
 # Supabase access token 의 고정 audience.
 _AUDIENCE = "authenticated"
 # 비대칭 서명만 받는다. 대칭키(HS*)는 검증 키를 서버가 들고 있어야 하므로 쓰지 않는다.
 _ALGORITHMS = ("ES256", "RS256")
 _JWKS_TTL_SECONDS = 600.0
+# 모르는 kid 를 만났을 때 JWKS 를 다시 받는 최소 간격. 아무 kid 나 담은 토큰으로
+# 요청마다 JWKS 를 때리지 못하게 막는다.
+_JWKS_MIN_REFETCH_SECONDS = 30.0
+# 로컬 시계가 조금 밀려도 방금 받은 토큰을 거절하지 않는다.
+_CLOCK_SKEW_LEEWAY_SECONDS = 30.0
 _HTTP_TIMEOUT = 10.0
 
 
@@ -109,6 +119,21 @@ def _session_from(payload: object) -> SupabaseSession:
     )
 
 
+def _error_code(response: httpx.Response) -> str:
+    """로그에 남길 Supabase 오류 코드. 본문의 나머지는 옮기지 않는다.
+
+    본문 전체를 남기면 요청에 실린 이메일이 메시지에 섞여 나올 수 있다.
+    """
+    try:
+        payload = response.json()
+    except ValueError:
+        return "unparseable"
+    if not isinstance(payload, dict):
+        return "unparseable"
+    code = payload.get("error_code") or payload.get("error")
+    return code if isinstance(code, str) else "unknown"
+
+
 async def _token_grant(grant_type: str, body: dict[str, str]) -> SupabaseSession:
     """`/token` 은 grant_type 만 다르고 오류 처리가 같아 한 곳에서 다룬다."""
     _require_config()
@@ -125,6 +150,14 @@ async def _token_grant(grant_type: str, body: dict[str, str]) -> SupabaseSession
         raise AuthUnavailable(f"auth_upstream_failed:{response.status_code}")
     if response.status_code >= 400:
         # 400/401/403 은 모두 자격증명 문제로 모은다. 계정 존재 여부를 구분하지 않는다.
+        # 응답에서 지운 구분은 로그에만 남긴다. 이게 없으면 비밀번호 오류와
+        # email_not_confirmed 같은 설정 문제를 서버 운영자도 구분할 수 없다.
+        logger.warning(
+            "supabase token grant rejected: grant_type=%s status=%s error_code=%s",
+            grant_type,
+            response.status_code,
+            _error_code(response),
+        )
         raise InvalidCredentials("invalid_credentials")
 
     try:
@@ -242,10 +275,12 @@ def reset_jwks_cache() -> None:
     _jwks_cache = None
 
 
-async def _jwks(*, now: float | None = None) -> PyJWKSet:
+async def _jwks(*, now: float | None = None, force: bool = False) -> PyJWKSet:
+    """`force` 는 TTL 을 무시하지만 최소 재조회 간격은 지킨다."""
     global _jwks_cache
     current = time.monotonic() if now is None else now
-    if _jwks_cache is not None and current - _jwks_cache[1] < _JWKS_TTL_SECONDS:
+    age_limit = _JWKS_MIN_REFETCH_SECONDS if force else _JWKS_TTL_SECONDS
+    if _jwks_cache is not None and current - _jwks_cache[1] < age_limit:
         return _jwks_cache[0]
 
     _require_config()
@@ -268,6 +303,30 @@ async def _jwks(*, now: float | None = None) -> PyJWKSet:
     return keys
 
 
+async def _signing_key(kid: str) -> PyJWK:
+    """캐시에 없는 kid 는 키 교체 신호다. TTL 이 끝나기를 기다리지 않고 한 번 다시 받는다.
+
+    이걸 하지 않으면 Supabase 가 서명 키를 바꾼 뒤 캐시가 늙어 죽을 때까지
+    (최대 `_JWKS_TTL_SECONDS`) 모든 로그인이 실패한다.
+    """
+    keys = await _jwks()
+    try:
+        return keys[kid]
+    except KeyError:
+        pass
+
+    # 최소 간격이 지나지 않았거나 방금 받아온 목록이면 같은 객체가 돌아온다.
+    # 그때는 다시 볼 것이 없다.
+    refreshed = await _jwks(force=True)
+    if refreshed is not keys:
+        try:
+            return refreshed[kid]
+        except KeyError:
+            pass
+    logger.warning("access token signed by an unknown key: kid=%s", kid)
+    raise InvalidCredentials("unknown_signing_key")
+
+
 async def verify_access_token(token: str) -> UUID:
     """서명을 로컬에서 검증하고 Supabase 사용자 UUID(= public.member.id)를 돌려준다.
 
@@ -278,18 +337,26 @@ async def verify_access_token(token: str) -> UUID:
     if not isinstance(token, str) or not token:
         raise InvalidCredentials("invalid_token")
 
-    keys = await _jwks()
     try:
-        header = jwt.get_unverified_header(token)
-        key = keys[header["kid"]]
+        kid = jwt.get_unverified_header(token)["kid"]
+    except (jwt.PyJWTError, KeyError, TypeError, ValueError) as error:
+        raise InvalidCredentials("invalid_token") from error
+
+    key = await _signing_key(kid)
+    try:
         payload = jwt.decode(
             token,
             key=key,
             algorithms=list(_ALGORITHMS),
             audience=_AUDIENCE,
+            leeway=_CLOCK_SKEW_LEEWAY_SECONDS,
             options={"require": ["exp", "sub", "aud"]},
         )
     except (jwt.PyJWTError, KeyError, TypeError, ValueError) as error:
+        # 서명·만료·audience 중 무엇이 틀렸는지는 응답에 남지 않는다. 여기에만 남긴다.
+        logger.warning(
+            "access token verification failed: kid=%s reason=%s", kid, type(error).__name__
+        )
         raise InvalidCredentials("invalid_token") from error
 
     subject = payload.get("sub")

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -76,9 +76,17 @@ class _Response:
 class _SupabaseStub:
     """`/token`, `/logout`, JWKS 세 경로만 흉내낸다."""
 
-    def __init__(self, *, token: _Response | Exception, logout: _Response | Exception):
+    def __init__(
+        self,
+        *,
+        token: _Response | Exception,
+        logout: _Response | Exception,
+        jwks: list[object] | None = None,
+    ):
         self.token = token
         self.logout = logout
+        # 키 교체를 흉내내려면 JWKS 응답이 호출마다 달라야 한다. 비우면 늘 같은 키다.
+        self.jwks = list(jwks or [])
         self.calls: list[tuple[str, str]] = []
 
     async def __aenter__(self):
@@ -89,7 +97,7 @@ class _SupabaseStub:
 
     async def get(self, url: str, **_kwargs) -> _Response:
         self.calls.append(("GET", url))
-        return _Response(200, _JWKS)
+        return _Response(200, self.jwks.pop(0) if self.jwks else _JWKS)
 
     async def post(self, url: str, **_kwargs) -> _Response:
         self.calls.append(("POST", url))
@@ -145,11 +153,13 @@ def _client(
     *,
     token: _Response | Exception | None = None,
     logout: _Response | Exception | None = None,
+    jwks: list[object] | None = None,
 ) -> tuple[TestClient, _SupabaseStub]:
     """member 는 DB 조회 결과, token/logout 은 Supabase 응답을 정한다."""
     stub = _SupabaseStub(
         token=_Response(200, session_payload()) if token is None else token,
         logout=_Response(204) if logout is None else logout,
+        jwks=jwks,
     )
     monkeypatch.setattr(supabase_auth.httpx, "AsyncClient", lambda **_kwargs: stub)
 
@@ -228,6 +238,105 @@ def test_invalid_credentials_are_rejected_with_401(monkeypatch):
     assert not response.headers.get_list("set-cookie")
 
 
+def test_rotated_signing_key_is_fetched_without_waiting_for_the_cache(monkeypatch):
+    """Supabase 가 서명 키를 바꿔도 로그인은 즉시 이어져야 한다.
+
+    예전에는 캐시에 없는 kid 를 만나면 그대로 실패했다. JWKS 캐시 TTL 이 10분이라
+    키가 교체되면 그동안 모든 로그인이 401 invalid_credentials 로 막혔고,
+    캐시가 만료되면 아무것도 하지 않아도 저절로 풀렸다.
+    """
+    rotated_key = ec.generate_private_key(ec.SECP256R1())
+    rotated_kid = "rotated-signing-key"
+    rotated_jwks = {
+        "keys": [
+            {
+                **json.loads(jwt.algorithms.ECAlgorithm.to_jwk(rotated_key.public_key())),
+                "kid": rotated_kid,
+                "alg": "ES256",
+                "use": "sig",
+            }
+        ]
+    }
+    rotated_token = jwt.encode(
+        {"sub": str(AUTH_USER_ID), "aud": "authenticated", "exp": int(time.time()) + 3_600},
+        rotated_key,
+        algorithm="ES256",
+        headers={"kid": rotated_kid},
+    )
+
+    # 옛 키만 담긴 캐시가 아직 살아 있는 상태에서 시작한다. TTL 이 지나 버리면
+    # 평범한 재조회가 새 키를 물어와, 정작 확인하려는 경로를 타지 않는다.
+    monkeypatch.setattr(
+        supabase_auth, "_jwks_cache", (jwt.PyJWKSet.from_dict(_JWKS), time.monotonic())
+    )
+    monkeypatch.setattr(supabase_auth, "_JWKS_MIN_REFETCH_SECONDS", 0.0)
+
+    client, stub = _client(
+        _member(),
+        monkeypatch,
+        token=_Response(
+            200,
+            {
+                "access_token": rotated_token,
+                "refresh_token": secrets.token_urlsafe(24),
+                "expires_in": 3_600,
+            },
+        ),
+        jwks=[rotated_jwks],
+    )
+
+    with client:
+        response = client.post(
+            "/api/auth/login",
+            headers={"Origin": ORIGIN},
+            json={"email": "manager@salesluv.demo", "password": secrets.token_urlsafe(16)},
+        )
+
+    assert response.status_code == 200
+    # 캐시가 아직 유효했는데도 JWKS 를 다시 받아 새 키를 찾았다.
+    assert [call for call in stub.calls if call[0] == "GET"]
+
+
+def test_unknown_signing_key_is_a_server_problem_not_a_wrong_password(monkeypatch):
+    """다시 받아온 JWKS 에도 없는 키라면 비밀번호 문제가 아니다.
+
+    401 로 알리면 사용자는 원인이 비밀번호에 있는 줄 알고 같은 값을 계속 다시 친다.
+    """
+    stranger_key = ec.generate_private_key(ec.SECP256R1())
+    stranger_token = jwt.encode(
+        {"sub": str(AUTH_USER_ID), "aud": "authenticated", "exp": int(time.time()) + 3_600},
+        stranger_key,
+        algorithm="ES256",
+        headers={"kid": "unknown-signing-key"},
+    )
+
+    client, _stub = _client(
+        _member(),
+        monkeypatch,
+        token=_Response(
+            200,
+            {
+                "access_token": stranger_token,
+                "refresh_token": secrets.token_urlsafe(24),
+                "expires_in": 3_600,
+            },
+        ),
+    )
+
+    with client:
+        response = client.post(
+            "/api/auth/login",
+            headers={"Origin": ORIGIN},
+            json={"email": "manager@salesluv.demo", "password": secrets.token_urlsafe(16)},
+        )
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "auth_unavailable"}
+    assert not response.headers.get_list("set-cookie")
+    # 서버 잘못으로 로그인 시도 슬롯을 채우지 않는다.
+    assert not _login_attempts
+
+
 def test_verified_token_resolves_the_linked_member(monkeypatch):
     member = _member()
     client, _stub = _client(member, monkeypatch)
@@ -270,7 +379,8 @@ def test_expired_access_token_recovers_after_refresh(monkeypatch):
     client, _stub = _client(member, monkeypatch)
 
     with client:
-        client.cookies.set("salesluv_access", access_token(expires_in=-10), path="/api")
+        # 시계 오차 허용치보다 확실히 오래 지난 토큰이어야 만료로 걸린다.
+        client.cookies.set("salesluv_access", access_token(expires_in=-600), path="/api")
         client.cookies.set("salesluv_refresh", secrets.token_urlsafe(24), path="/api/auth")
 
         expired = client.get("/api/auth/me")


### PR DESCRIPTION
## 변경 요약

로컬에서만 로그인이 간헐적으로 실패하던 문제를 다룹니다. 원인이 둘로 나뉘어 커밋도 둘로 나눴습니다.

**1. DB 연결 풀 상한 (`fix(db)`)** — 이번 증상의 실제 원인

- SQLAlchemy 기본값(`pool_size 5` + `max_overflow 10`)은 프로세스당 최대 15개 연결을 엽니다. Supabase session pooler 의 클라이언트 한도도 15 인데, 이 한도는 머신이 아니라 **프로젝트 단위**라 배포 서버·팀원 로컬 서버·pytest 가 모두 같은 15 를 나눠 씁니다.
- 그래서 프로세스 하나가 통을 통째로 가져갈 수 있었고, 늦게 붙는 쪽이 `EMAXCONNSESSION` 으로 막혔습니다. 로컬에서 DB 를 쓰는 요청이 전부 실패해 로그인도 되지 않았습니다. 배포는 이미 연결을 쥐고 있어 영향이 없었고, 이것이 "배포는 되는데 로컬만 안 되는" 이유입니다.
- `pool_size=2`, `max_overflow=0` 으로 낮춰, 한도를 넘기는 대신 풀 안에서 기다리게 합니다.

**2. 인증 실패 원인 구분과 JWKS 재조회 (`fix(auth)`)**

- 로그인 실패가 모두 `401 invalid_credentials` 로 보여 원인을 가릴 수 없었고, 백엔드에 로그가 한 줄도 없어 서버 쪽에서도 구분되지 않았습니다.
- 캐시에 없는 `kid` 를 만나면 JWKS 를 한 번 다시 받습니다. 예전에는 그대로 실패해, Supabase 가 서명 키를 바꾸면 캐시 TTL(10분) 동안 모든 로그인이 막혔다가 저절로 풀렸습니다. 최소 재조회 간격을 두어 아무 `kid` 나 담은 토큰으로 JWKS 를 요청마다 때리지 못하게 막습니다.
- `jwt.decode` 에 30초 leeway 를 줍니다.
- Supabase 오류 코드와 토큰 검증 실패 사유를 로그로 남깁니다. 응답은 지금처럼 뭉뚱그려 계정 존재 여부를 흘리지 않으며, 비밀번호·토큰·이메일은 로그에 남기지 않습니다.
- 방금 받은 토큰의 검증 실패는 자격증명 문제가 아니라 서버 문제이므로 401 이 아니라 `503 auth_unavailable` 로 알리고, 로그인 시도 슬롯도 서버 잘못으로 채우지 않습니다.

## 검증

- `pytest` 전체 **182 passed** (DB 연결이 회복된 뒤 실행, `test_health_db_connects`·`test_models_match_configured_database` 포함).
- `ruff check`, `ruff format --check` 통과.
- 키 교체 재조회 테스트는 수정 코드를 임시로 비활성화해 실패하는 것을 확인한 뒤 되돌렸습니다(테스트가 헛돌지 않음을 확인).
- `test_expired_access_token_recovers_after_refresh` 의 만료 토큰을 `-10초`에서 `-600초`로 바꿨습니다. 새로 추가한 30초 leeway 안에 들어가 만료로 걸리지 않았기 때문입니다.
- **미실행**: 프론트엔드 변경이 없어 프론트 검사는 돌리지 않았습니다. 실제 로그인 재현을 통한 `invalid_credentials` 원인 확정은 아직 못 했습니다(아래 참고).

## 영향 및 주의 사항

- **수동 적용 필요**: 풀 상한은 새로 만들어지는 엔진에만 적용됩니다. 이미 연결을 쥐고 있는 프로세스의 슬롯은 회수하지 못합니다. 병합 후 **팀원 각자 dev 서버 재시작**과 **배포 서버 재배포**가 있어야 예산이 맞습니다(배포 2 + 인원수 × 2).
- 그래도 15 가 빠듯하면 transaction pooler(6543) 로 옮기는 편이 맞습니다. 포트는 열려 있고, asyncpg 는 `statement_cache_size=0` 이 필요합니다. 이번 PR 범위 밖입니다.
- 남은 과제: `401 invalid_credentials` 자체는 아직 원인이 확정되지 않았습니다. DB 고갈은 500 이 되지 401 이 될 수 없습니다. 이번에 추가한 로그가 다음 재현 때 원인을 지목할 것입니다.
- 별건으로 확인만 하고 두었습니다: `frontend/src/api/client.ts` 의 `NO_REFRESH_PATHS` 에 `/auth/me` 가 있어, 로그인 1시간 뒤 새로고침하면 30일짜리 refresh 쿠키가 있는데도 로그아웃됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)