### PR TITLE
팀장 전용 상품관리 화면과 상품 등록 추가

### DIFF
--- a/backend/app/api/sales_deals.py
+++ b/backend/app/api/sales_deals.py
@@ -3,20 +3,24 @@ from typing import Annotated
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
-from fastapi import APIRouter, HTTPException, Query, Response, status
+from fastapi import APIRouter, File, HTTPException, Query, Response, UploadFile, status
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
 from app.api.deps import CurrentMember, DbSession, owner_scope
+from app.core.config import settings
 from app.models.configuration import SalesDealType
 from app.models.crm import CustomerCompany, CustomerContact
 from app.models.sales import Product, SalesDeal, SalesPipeline, SalesPipelineStage
 from app.models.workspace import Member, Team
 from app.schemas.sales_deals import (
+    ProductCreate,
+    ProductImageRead,
     ProductPage,
     ProductPageParams,
+    ProductRead,
     SalesDealCreate,
     SalesDealMove,
     SalesDealPage,
@@ -27,8 +31,15 @@ from app.schemas.sales_deals import (
     SalesPipelineRead,
     SalesPipelineStageRead,
 )
+from app.services import storage
+from app.services.storage import StorageError
+from app.services.upload_guard import UploadRejected, check_image_upload, check_size
 
 router = APIRouter(tags=["sales-deals"])
+
+# 상품 사진 한 장의 상한. 자료실 문서용 upload_max_bytes(50MB)는 사진에 맞지 않는다.
+PRODUCT_IMAGE_MAX_BYTES = 5 * 1024 * 1024
+PRODUCT_IMAGE_EXPIRES_IN = 300
 
 _SEOUL = ZoneInfo("Asia/Seoul")
 _owner = aliased(Member)
@@ -579,6 +590,149 @@ async def list_products(
         has_more=has_more,
         next_skip=page.skip + len(products) if has_more else None,
     )
+
+
+def _require_manager(member: Member) -> None:
+    """상품 마스터는 팀장이 관리한다. 목록 조회는 팀원도 그대로 쓴다."""
+    if member.role_code != "manager":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="manager_required")
+
+
+def _require_storage() -> None:
+    if not settings.storage_configured:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="storage_not_configured",
+        )
+
+
+async def _team_product_for_update(db: AsyncSession, member: Member, product_id: UUID) -> Product:
+    product = (
+        await db.execute(
+            select(Product)
+            .where(Product.id == product_id, Product.team_id == member.team_id)
+            .with_for_update(of=Product)
+        )
+    ).scalar_one_or_none()
+    if product is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="product_not_found")
+    return product
+
+
+@router.post("/products", response_model=ProductRead, status_code=status.HTTP_201_CREATED)
+async def create_product(
+    payload: ProductCreate,
+    response: Response,
+    member: CurrentMember,
+    db: DbSession,
+) -> Product:
+    _require_manager(member)
+    product = Product(
+        id=uuid4(),
+        team_id=member.team_id,
+        # DB 기본값에 기대지 않고 넣는다. 넣은 객체를 그대로 응답으로 쓰기 때문이다.
+        active=True,
+        name=payload.name,
+        category_code=payload.category_code,
+        unit_price=payload.unit_price,
+        shelf_life_months=payload.shelf_life_months,
+        memo=payload.memo,
+        image_storage_key=None,
+    )
+    try:
+        db.add(product)
+        await db.flush()
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    response.headers["Location"] = f"/api/products/{product.id}"
+    return product
+
+
+@router.put("/products/{product_id}/image", response_model=ProductRead)
+async def upload_product_image(
+    product_id: UUID,
+    member: CurrentMember,
+    db: DbSession,
+    upload: Annotated[UploadFile, File()],
+) -> Product:
+    _require_manager(member)
+    _require_storage()
+    content = await upload.read()
+
+    try:
+        check_size(len(content), PRODUCT_IMAGE_MAX_BYTES)
+        allowed = check_image_upload(
+            file_name=upload.filename or "",
+            declared_media_type=upload.content_type,
+            content=content,
+        )
+    except UploadRejected as rejected:
+        raise HTTPException(status_code=rejected.status_code, detail=rejected.detail) from rejected
+
+    storage_key = storage.build_storage_key(member.team_id, allowed.extension)
+    try:
+        await storage.upload(
+            storage_key=storage_key,
+            content=content,
+            media_type=allowed.media_type,
+        )
+    except StorageError as error:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(error),
+        ) from error
+
+    try:
+        product = await _team_product_for_update(db, member, product_id)
+        replaced_key = product.image_storage_key
+        product.image_storage_key = storage_key
+        await db.flush()
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        # DB 기록이 실패하면 올린 객체를 지워 고아를 남기지 않는다.
+        await storage.remove(storage_key=storage_key)
+        raise
+    if replaced_key is not None:
+        await storage.remove(storage_key=replaced_key)
+    return product
+
+
+@router.get("/products/{product_id}/image", response_model=ProductImageRead)
+async def get_product_image(
+    product_id: UUID,
+    member: CurrentMember,
+    db: DbSession,
+) -> ProductImageRead:
+    """짧게 사는 사진 주소. 요청마다 팀 권한을 다시 확인한다.
+
+    ponytail: 목록이 행마다 한 번씩 부르므로 저장소 호출이 N번이다.
+    상품 수가 커지면 한 번에 여러 건을 발급하는 방식으로 바꾼다.
+    """
+    _require_storage()
+    product = (
+        await db.execute(
+            select(Product).where(Product.id == product_id, Product.team_id == member.team_id)
+        )
+    ).scalar_one_or_none()
+    if product is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="product_not_found")
+    if product.image_storage_key is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="product_image_not_found")
+
+    try:
+        url = await storage.signed_url(
+            storage_key=product.image_storage_key,
+            expires_in=PRODUCT_IMAGE_EXPIRES_IN,
+        )
+    except StorageError as error:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(error),
+        ) from error
+    return ProductImageRead(url=url, expires_in=PRODUCT_IMAGE_EXPIRES_IN)
 
 
 @router.get("/sales-deals", response_model=SalesDealPage)

--- a/backend/app/models/sales.py
+++ b/backend/app/models/sales.py
@@ -14,6 +14,16 @@ class Product(Base):
     team_id: Mapped[UUID] = mapped_column(ForeignKey("public.team.id"))
     name: Mapped[str]
     active: Mapped[bool] = mapped_column(server_default=text("true"))
+    category_code: Mapped[str]
+    unit_price: Mapped[int] = mapped_column(BigInteger)
+    shelf_life_months: Mapped[int | None]
+    memo: Mapped[str | None]
+    image_storage_key: Mapped[str | None]
+
+    @property
+    def has_image(self) -> bool:
+        """사진이 있는지만 알린다. storage_key 자체는 내부 주소라 응답에 넣지 않는다."""
+        return self.image_storage_key is not None
 
 
 class SalesPipeline(Base):

--- a/backend/app/schemas/sales_deals.py
+++ b/backend/app/schemas/sales_deals.py
@@ -96,12 +96,37 @@ class SalesDealTypeRead(BaseModel):
     position: int
 
 
+ProductCategoryCode = Literal["system", "probe", "consumable"]
+
+
 class ProductRead(BaseModel):
+    """image_storage_key 는 내부 저장소 주소라 내보내지 않고 유무만 알린다."""
+
     model_config = ConfigDict(from_attributes=True)
 
     id: UUID
     name: str
     active: bool
+    category_code: str
+    unit_price: int
+    shelf_life_months: int | None
+    memo: str | None
+    has_image: bool
+
+
+class ProductCreate(_WriteModel):
+    name: Text
+    category_code: ProductCategoryCode
+    unit_price: StrictInt = Field(ge=0, le=9_223_372_036_854_775_807)
+    shelf_life_months: StrictInt | None = Field(default=None, gt=0, le=1_200)
+    memo: LongText | None = None
+
+
+class ProductImageRead(BaseModel):
+    """짧게 사는 사진 주소. 매 요청마다 팀 권한을 확인한 뒤에만 발급한다."""
+
+    url: str
+    expires_in: int
 
 
 class ProductPage(BaseModel):

--- a/backend/app/services/upload_guard.py
+++ b/backend/app/services/upload_guard.py
@@ -32,7 +32,9 @@ class AllowedType:
 
 
 @dataclass(frozen=True)
-class AllowedAudioType:
+class AllowedMediaType:
+    """확장자 하나에 선언 MIME 이 여럿 붙는 형식. 음성과 이미지가 이 모양이다."""
+
     extension: str
     media_type: str
     declared_media_types: frozenset[str]
@@ -75,26 +77,26 @@ def _is_webm(content: bytes) -> bool:
     return content.startswith(b"\x1aE\xdf\xa3")
 
 
-_AUDIO_ALLOWED: tuple[AllowedAudioType, ...] = (
-    AllowedAudioType(
+_AUDIO_ALLOWED: tuple[AllowedMediaType, ...] = (
+    AllowedMediaType(
         ".mp3",
         "audio/mpeg",
         frozenset(("audio/mpeg", "audio/mp3")),
         _is_mpeg_audio,
     ),
-    AllowedAudioType(
+    AllowedMediaType(
         ".m4a",
         "audio/mp4",
         frozenset(("audio/mp4", "audio/m4a", "audio/x-m4a")),
         _is_m4a,
     ),
-    AllowedAudioType(
+    AllowedMediaType(
         ".wav",
         "audio/wav",
         frozenset(("audio/wav", "audio/wave", "audio/x-wav")),
         _is_wav,
     ),
-    AllowedAudioType(
+    AllowedMediaType(
         ".webm",
         "audio/webm",
         frozenset(("audio/webm",)),
@@ -102,6 +104,31 @@ _AUDIO_ALLOWED: tuple[AllowedAudioType, ...] = (
     ),
 )
 _AUDIO_BY_EXTENSION = {allowed.extension: allowed for allowed in _AUDIO_ALLOWED}
+
+
+def _is_png(content: bytes) -> bool:
+    return content.startswith(b"\x89PNG\r\n\x1a\n")
+
+
+def _is_jpeg(content: bytes) -> bool:
+    return content.startswith(b"\xff\xd8\xff")
+
+
+def _is_webp(content: bytes) -> bool:
+    return len(content) >= 12 and content.startswith(b"RIFF") and content[8:12] == b"WEBP"
+
+
+# 상품 사진이 쓴다. 자료실(_ALLOWED)과 섞지 않는다. 브라우저가 그대로 그리는 형식만 두고
+# SVG 는 스크립트를 품을 수 있어 받지 않는다.
+_IMAGE_ALLOWED: tuple[AllowedMediaType, ...] = (
+    AllowedMediaType(".png", "image/png", frozenset(("image/png",)), _is_png),
+    AllowedMediaType(".jpg", "image/jpeg", frozenset(("image/jpeg", "image/jpg")), _is_jpeg),
+    AllowedMediaType(".jpeg", "image/jpeg", frozenset(("image/jpeg", "image/jpg")), _is_jpeg),
+    AllowedMediaType(".webp", "image/webp", frozenset(("image/webp",)), _is_webp),
+)
+_IMAGE_BY_EXTENSION = {allowed.extension: allowed for allowed in _IMAGE_ALLOWED}
+
+ALLOWED_IMAGE_EXTENSIONS = tuple(sorted(_IMAGE_BY_EXTENSION))
 
 
 def _extension_of(file_name: str) -> str:
@@ -135,15 +162,18 @@ def check_upload(*, file_name: str, declared_media_type: str | None, content: by
     return allowed
 
 
-def check_audio_upload(
-    *, file_name: str, declared_media_type: str | None, content: bytes
-) -> AllowedAudioType:
-    """STT가 받을 음성인지 확장자·MIME·signature를 함께 확인한다."""
+def _check_media_upload(
+    by_extension: dict[str, AllowedMediaType],
+    *,
+    file_name: str,
+    declared_media_type: str | None,
+    content: bytes,
+) -> AllowedMediaType:
     name = file_name.strip()
     if not name or "/" in name or "\\" in name or name in {".", ".."}:
         raise UploadRejected("invalid_file_name", 422)
 
-    allowed = _AUDIO_BY_EXTENSION.get(_extension_of(name))
+    allowed = by_extension.get(_extension_of(name))
     if allowed is None:
         raise UploadRejected("unsupported_file_extension", 415)
 
@@ -157,6 +187,30 @@ def check_audio_upload(
     if not allowed.has_signature(content):
         raise UploadRejected("file_signature_mismatch", 415)
     return allowed
+
+
+def check_audio_upload(
+    *, file_name: str, declared_media_type: str | None, content: bytes
+) -> AllowedMediaType:
+    """STT가 받을 음성인지 확장자·MIME·signature를 함께 확인한다."""
+    return _check_media_upload(
+        _AUDIO_BY_EXTENSION,
+        file_name=file_name,
+        declared_media_type=declared_media_type,
+        content=content,
+    )
+
+
+def check_image_upload(
+    *, file_name: str, declared_media_type: str | None, content: bytes
+) -> AllowedMediaType:
+    """상품 사진으로 받을 이미지인지 확장자·MIME·signature를 함께 확인한다."""
+    return _check_media_upload(
+        _IMAGE_BY_EXTENSION,
+        file_name=file_name,
+        declared_media_type=declared_media_type,
+        content=content,
+    )
 
 
 def check_size(byte_size: int, limit: int) -> None:

--- a/backend/sql/20260824_0004_product_fields.sql
+++ b/backend/sql/20260824_0004_product_fields.sql
@@ -1,0 +1,32 @@
+-- 상품 마스터에 등록 화면이 받는 항목을 더한다.
+--
+-- 지금까지 product 는 이름 하나뿐이었고 행을 넣을 화면이 없어 seed 로만 만들었다.
+-- 팀장이 /products 화면에서 직접 등록하게 되면서 분류·단가·유효기간·메모·사진이 붙는다.
+--
+-- 기존 행은 이름만 있으므로 백필용 default 로 채운 뒤 default 를 뗀다. 앱은 두 값을
+-- 항상 함께 보내므로 DB 기본값에 기대지 않는다.
+
+BEGIN;
+
+ALTER TABLE public.product
+    ADD COLUMN category_code text NOT NULL DEFAULT 'system'
+        CHECK (category_code IN ('system', 'probe', 'consumable')),
+    ADD COLUMN unit_price bigint NOT NULL DEFAULT 0 CHECK (unit_price >= 0),
+    ADD COLUMN shelf_life_months integer
+        CHECK (shelf_life_months IS NULL OR shelf_life_months > 0),
+    ADD COLUMN memo text,
+    ADD COLUMN image_storage_key text;
+
+ALTER TABLE public.product ALTER COLUMN category_code DROP DEFAULT;
+ALTER TABLE public.product ALTER COLUMN unit_price DROP DEFAULT;
+
+COMMENT ON COLUMN public.product.category_code IS
+    '제품 분류. system(시스템) / probe(프로브) / consumable(소모품).';
+COMMENT ON COLUMN public.product.unit_price IS
+    '제품 단가. 원 단위 정수로 저장한다. purchase_order_item.unit_price 와 같은 규칙이다.';
+COMMENT ON COLUMN public.product.shelf_life_months IS
+    '유효기간(개월). 로트별 만료일이 아니라 제품 자체의 기간이다. 없으면 NULL.';
+COMMENT ON COLUMN public.product.image_storage_key IS
+    '제품 사진의 저장소 객체 키. notice.image_storage_key 와 같은 뜻이며 응답에 내보내지 않는다.';
+
+COMMIT;

--- a/backend/sql/README.md
+++ b/backend/sql/README.md
@@ -46,6 +46,14 @@
   기존 행은 `owner_member_id`로 등록자와 담당자를 백필합니다.
   `customer_company`에는 `business_no`(하이픈 없는 10자리)를 더해 같은 이름의 고객사를 구분합니다.
 
+- `20260824_0004_product_fields.sql`: 상품 등록 화면(`/products`, 팀장 전용)이 받는 항목을
+  `product`에 더합니다. `category_code`(system/probe/consumable), `unit_price`(원 단위 정수),
+  `shelf_life_months`(유효기간 개월), `memo`, `image_storage_key`입니다. 기존 행은 백필용
+  default로 채운 뒤 default를 떼므로 이후 INSERT는 앱이 값을 직접 넣어야 합니다.
+  `image_storage_key`는 `notice.image_storage_key`와 같은 뜻이며 API 응답에 나가지 않습니다.
+  상품 목록(`GET /api/products`)은 발주·영업 화면이 함께 쓰므로 팀원에게도 그대로 열려 있고,
+  쓰기(`POST /api/products`, 사진 업로드)만 팀장으로 제한합니다.
+
 `20260819_0001`은 빈 `public` 스키마에 처음부터 만드는 것을 전제로 합니다. 되돌리는 마이그레이션이
 아니므로 적용 전에 아래 런북의 1~2단계를 먼저 수행합니다.
 

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -19,7 +19,9 @@ EXPECTED_COLUMN_COUNTS = {
     "customer_contact": 13,
     "customer_contact_assignee": 3,
     "customer_contact_status": 9,
-    "product": 4,
+    # 20260824_0004 로 product 에 category_code/unit_price/shelf_life_months/memo/
+    # image_storage_key 가 늘었다.
+    "product": 9,
     "notice": 12,
     "activity": 22,
     "activity_category": 10,
@@ -50,7 +52,7 @@ def test_all_database_tables_are_mapped():
     assert {
         table.name: len(table.columns) for table in Base.metadata.sorted_tables
     } == EXPECTED_COLUMN_COUNTS
-    assert sum(len(table.columns) for table in Base.metadata.tables.values()) == 273
+    assert sum(len(table.columns) for table in Base.metadata.tables.values()) == 278
 
     foreign_key_constraints = [
         foreign_key

--- a/backend/tests/test_products.py
+++ b/backend/tests/test_products.py
@@ -1,0 +1,184 @@
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from app.api.deps import get_current_member
+from app.core.config import settings
+from app.db.session import get_db
+from app.main import app
+from app.models.sales import Product
+from app.models.workspace import Member
+from app.schemas.sales_deals import ProductCreate
+
+ORIGIN = settings.cors_origin_list[0]
+PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 8
+_MISSING = object()
+
+
+class _Result:
+    def __init__(self, *, scalar=_MISSING):
+        self.scalar = scalar
+
+    def scalar_one_or_none(self):
+        assert self.scalar is not _MISSING
+        return self.scalar
+
+
+class _Db:
+    def __init__(self, *results: _Result):
+        self.results = list(results)
+        self.added = []
+        self.commit_count = 0
+        self.rollback_count = 0
+
+    async def execute(self, statement):
+        assert self.results, "예상보다 많은 쿼리가 실행되었습니다."
+        return self.results.pop(0)
+
+    def add(self, value):
+        self.added.append(value)
+
+    async def flush(self):
+        return None
+
+    async def commit(self):
+        self.commit_count += 1
+
+    async def rollback(self):
+        self.rollback_count += 1
+
+
+@pytest.fixture(autouse=True)
+def reset_dependency_overrides():
+    app.dependency_overrides.clear()
+    yield
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def storage_ready(monkeypatch):
+    monkeypatch.setattr(type(settings), "storage_configured", property(lambda self: True))
+    yield
+
+
+def _member(*, role: str = "member") -> Member:
+    return Member(
+        id=uuid4(),
+        team_id=uuid4(),
+        display_name="합성 영업 담당자",
+        role_code=role,
+        job_title="영업 담당자",
+        active=True,
+    )
+
+
+def _product(member: Member, *, image_storage_key: str | None = None) -> Product:
+    return Product(
+        id=uuid4(),
+        team_id=member.team_id,
+        name="합성 초음파 시스템",
+        active=True,
+        category_code="system",
+        unit_price=12_000_000,
+        shelf_life_months=24,
+        memo=None,
+        image_storage_key=image_storage_key,
+    )
+
+
+def _client(db: _Db, member: Member) -> TestClient:
+    async def override_db():
+        yield db
+
+    async def override_member():
+        return member
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_member] = override_member
+    return TestClient(app)
+
+
+PAYLOAD = {
+    "name": "합성 초음파 시스템",
+    "category_code": "system",
+    "unit_price": 12_000_000,
+    "shelf_life_months": 24,
+    "memo": "데모 장비",
+}
+
+
+def test_product_request_rejects_unsafe_values():
+    with pytest.raises(ValidationError):
+        # 팀과 활성 여부는 요청으로 정할 수 없다.
+        ProductCreate(**PAYLOAD, team_id=uuid4())
+    with pytest.raises(ValidationError):
+        ProductCreate(**{**PAYLOAD, "category_code": "probe_x"})
+    with pytest.raises(ValidationError):
+        ProductCreate(**{**PAYLOAD, "unit_price": -1})
+    with pytest.raises(ValidationError):
+        ProductCreate(**{**PAYLOAD, "shelf_life_months": 0})
+    with pytest.raises(ValidationError):
+        ProductCreate(**{**PAYLOAD, "name": ""})
+
+
+def test_member_cannot_create_product():
+    db = _Db()
+    with _client(db, _member()) as client:
+        response = client.post("/api/products", headers={"Origin": ORIGIN}, json=PAYLOAD)
+    assert response.status_code == 403
+    assert response.json()["detail"] == "manager_required"
+    assert db.added == []
+    assert db.commit_count == 0
+
+
+def test_manager_creates_product_without_leaking_storage_key():
+    member = _member(role="manager")
+    db = _Db()
+    with _client(db, member) as client:
+        response = client.post("/api/products", headers={"Origin": ORIGIN}, json=PAYLOAD)
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["name"] == "합성 초음파 시스템"
+    assert body["unit_price"] == 12_000_000
+    assert body["shelf_life_months"] == 24
+    assert body["active"] is True
+    assert body["has_image"] is False
+    assert "image_storage_key" not in body
+    assert response.headers["Location"] == f"/api/products/{body['id']}"
+
+    assert db.commit_count == 1
+    created = db.added[0]
+    assert created.team_id == member.team_id
+
+
+def test_member_cannot_upload_product_image(storage_ready):
+    db = _Db()
+    with _client(db, _member()) as client:
+        response = client.put(
+            f"/api/products/{uuid4()}/image",
+            headers={"Origin": ORIGIN},
+            files={"upload": ("제품.png", PNG, "image/png")},
+        )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "manager_required"
+    assert db.commit_count == 0
+
+
+def test_product_without_image_has_no_download_url(storage_ready):
+    member = _member()
+    db = _Db(_Result(scalar=_product(member)))
+    with _client(db, member) as client:
+        response = client.get(f"/api/products/{uuid4()}/image", headers={"Origin": ORIGIN})
+    assert response.status_code == 404
+    assert response.json()["detail"] == "product_image_not_found"
+
+
+def test_other_team_product_image_is_not_found(storage_ready):
+    db = _Db(_Result(scalar=None))
+    with _client(db, _member()) as client:
+        response = client.get(f"/api/products/{uuid4()}/image", headers={"Origin": ORIGIN})
+    assert response.status_code == 404
+    assert response.json()["detail"] == "product_not_found"

--- a/backend/tests/test_upload_guard.py
+++ b/backend/tests/test_upload_guard.py
@@ -2,7 +2,9 @@ import pytest
 
 from app.services.upload_guard import (
     ALLOWED_EXTENSIONS,
+    ALLOWED_IMAGE_EXTENSIONS,
     UploadRejected,
+    check_image_upload,
     check_size,
     check_upload,
 )
@@ -72,6 +74,53 @@ def test_rejects_empty_content():
         check_upload(file_name="a.pdf", declared_media_type=None, content=b"")
     assert caught.value.detail == "empty_file"
     assert caught.value.status_code == 422
+
+
+def test_image_guard_accepts_only_renderable_images():
+    """상품 사진용 목록. 자료실(check_upload)과 서로 섞이지 않는다."""
+    assert (
+        check_image_upload(
+            file_name="제품.png", declared_media_type="image/png", content=PNG
+        ).media_type
+        == "image/png"
+    )
+    # 일부 브라우저가 보내는 image/jpg 도 받는다.
+    for name in ("a.jpg", "b.jpeg"):
+        assert (
+            check_image_upload(
+                file_name=name, declared_media_type="image/jpg", content=JPEG
+            ).media_type
+            == "image/jpeg"
+        )
+    assert (
+        check_image_upload(
+            file_name="c.webp", declared_media_type=None, content=b"RIFF\x00\x00\x00\x00WEBP"
+        ).extension
+        == ".webp"
+    )
+
+    # SVG 는 스크립트를 품을 수 있어 넣지 않았다. 문서 형식도 여기로 들어오지 않는다.
+    assert ".svg" not in ALLOWED_IMAGE_EXTENSIONS
+    assert ".pdf" not in ALLOWED_IMAGE_EXTENSIONS
+    assert ".png" not in ALLOWED_EXTENSIONS
+
+
+def test_image_guard_rejects_disguised_and_mismatched_files():
+    with pytest.raises(UploadRejected) as caught:
+        check_image_upload(file_name="악성.png", declared_media_type="image/png", content=PDF)
+    assert caught.value.detail == "file_signature_mismatch"
+
+    with pytest.raises(UploadRejected) as caught:
+        check_image_upload(file_name="a.png", declared_media_type="image/jpeg", content=PNG)
+    assert caught.value.detail == "media_type_mismatch"
+
+    with pytest.raises(UploadRejected) as caught:
+        check_image_upload(file_name="a.exe", declared_media_type=None, content=PNG)
+    assert caught.value.detail == "unsupported_file_extension"
+
+    with pytest.raises(UploadRejected) as caught:
+        check_image_upload(file_name="../a.png", declared_media_type=None, content=PNG)
+    assert caught.value.detail == "invalid_file_name"
 
 
 def test_size_limit_uses_413():

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ import MyPage from '@/pages/MyPage'
 import NotFound from '@/pages/NotFound'
 import Notifications from '@/pages/Notifications'
 import Orders, { OrderDetail, OrderNew } from '@/pages/Orders'
+import Products from '@/pages/Products'
 import Quotes from '@/pages/Quotes'
 import Sales from '@/pages/Sales'
 import SetPassword from '@/pages/SetPassword'
@@ -49,6 +50,7 @@ export default function App() {
               {/* 팀장만 들어갈 수 있는 화면. 팀원이 주소를 직접 치면 대시보드로 돌아갑니다. */}
               <Route element={<ManagerRoute />}>
                 <Route path={ROUTES.TEAM} element={<Team />} />
+                <Route path={ROUTES.PRODUCTS} element={<Products />} />
               </Route>
 
               {/* 계정 발급. 사이드바에 없고 어드민만 들어갑니다. */}

--- a/frontend/src/api/errorMessage.ts
+++ b/frontend/src/api/errorMessage.ts
@@ -48,6 +48,17 @@ const MESSAGE_BY_DETAIL: Record<string, string> = {
   customer_company_not_found: '고객사를 찾지 못했습니다. 다시 시도해 주세요.',
   customer_contact_not_found: '고객을 찾지 못했습니다. 목록을 새로 불러와 주세요.',
   customer_contact_status_code_not_found: '고객 상태 설정을 확인해 주세요.',
+  // 상품 (/products)
+  product_not_found: '상품을 찾을 수 없습니다. 목록을 새로 불러와 주세요.',
+  product_image_not_found: '등록된 사진이 없습니다.',
+  // 파일 업로드 (상품 사진, 자료실)
+  invalid_file_name: '파일 이름을 확인해 주세요.',
+  unsupported_file_extension: '올릴 수 없는 파일 형식입니다.',
+  media_type_mismatch: '파일 형식과 내용이 맞지 않습니다.',
+  file_signature_mismatch: '파일 형식과 내용이 맞지 않습니다.',
+  empty_file: '빈 파일은 올릴 수 없습니다.',
+  file_too_large: '파일 용량이 너무 큽니다.',
+  storage_not_configured: '파일 저장소 설정이 완료되지 않았습니다. 서버 설정을 확인해 주세요.',
 }
 
 const MESSAGE_BY_STATUS: Record<number, string> = {

--- a/frontend/src/components/icons/index.tsx
+++ b/frontend/src/components/icons/index.tsx
@@ -140,6 +140,16 @@ export function DocumentsIcon(props: IconProps) {
   )
 }
 
+// 상품. 발주(OrdersIcon)가 이미 상자라 값표 모양으로 구분합니다.
+export function ProductIcon(props: IconProps) {
+  return (
+    <Icon {...props}>
+      <path d="M3 11V4a1 1 0 0 1 1-1h7l10 10-8 8z" />
+      <circle cx="7.5" cy="7.5" r="1.4" />
+    </Icon>
+  )
+}
+
 export function SettingsIcon(props: IconProps) {
   return (
     <Icon {...props}>

--- a/frontend/src/constants/navigation.ts
+++ b/frontend/src/constants/navigation.ts
@@ -12,6 +12,7 @@ import {
   DocumentsIcon,
   type IconProps,
   OrdersIcon,
+  ProductIcon,
   QuoteIcon,
   SalesReportIcon,
   TeamIcon,
@@ -77,12 +78,16 @@ export const NAV_SECTIONS: NavSection[] = [
     items: [{ to: ROUTES.DOCUMENTS, label: '자료실', icon: DocumentsIcon }],
   },
   {
-    // 팀 실적 조회는 Topbar 의 보기 범위 스위처가 맡습니다. 여기 남는 것은
-    // 화면 전체가 팀장 것인 '팀 관리' 하나뿐입니다.
+    // 화면 전체가 팀장 것인 관리 메뉴를 한 섹션으로 묶습니다. 상품은 팀원이
+    // 발주·영업 등록에서 고르기만 하므로 목록 화면이 필요하지 않고, 팀 실적
+    // 조회는 Topbar 의 보기 범위 스위처가 맡습니다.
     id: 'manager',
-    ariaLabel: '팀 관리',
+    title: '관리',
     managerOnly: true,
-    items: [{ to: ROUTES.TEAM, label: '팀 관리', icon: TeamIcon }],
+    items: [
+      { to: ROUTES.PRODUCTS, label: '상품관리', icon: ProductIcon },
+      { to: ROUTES.TEAM, label: '팀 관리', icon: TeamIcon },
+    ],
   },
   // 설정 메뉴는 두지 않습니다. 바꿀 수 있는 값이 없어 마이페이지로 대체했고,
   // 진입은 사이드바 하단 이름과 헤더 아바타에서 합니다.

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -23,6 +23,7 @@ export const ROUTES = {
   CONTRACTS: '/contracts',
   ORDERS: '/orders',
   DOCUMENTS: '/documents',
+  PRODUCTS: '/products', // 상품관리 (팀장 전용). 상품 목록 조회 자체는 팀원도 씁니다.
   // 마이페이지. 진입은 사이드바 하단 이름과 헤더 아바타에서 합니다.
   // 바꿀 수 있는 설정이 없어 '설정' 대신 내 정보·약관을 보는 화면 하나만 둡니다.
   MYPAGE: '/mypage',

--- a/frontend/src/pages/Products/Products.module.scss
+++ b/frontend/src/pages/Products/Products.module.scss
@@ -1,0 +1,244 @@
+// 고객불만 목록(pages/Complaints)의 툴바·표·모달을 여섯 열짜리 상품 목록에 맞게 줄여 씁니다.
+// 폰용 카드 목록은 두지 않습니다. 열이 적어 카드 안 가로 스크롤로 충분합니다.
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s3);
+}
+
+/* ---- 툴바 ---- */
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--s2);
+  flex-wrap: wrap;
+}
+
+.search {
+  flex: 1 1 320px;
+  max-width: 640px;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: var(--s2);
+  margin-left: auto;
+
+  @include sm {
+    margin-left: 0;
+    width: 100%;
+    justify-content: flex-end;
+  }
+}
+
+/* ---- 표 ---- */
+
+.card {
+  @include card;
+  overflow: hidden;
+}
+
+.scroller {
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+}
+
+.table {
+  min-width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  table-layout: fixed;
+
+  th,
+  td {
+    height: 52px; // 썸네일이 들어가는 줄이라 목록 기본보다 조금 높습니다
+    padding: 0 var(--s3);
+    text-align: left;
+    vertical-align: middle;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  thead th {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    height: 40px;
+    background: var(--surface-2);
+    border-bottom: 1px solid var(--line);
+    color: var(--ink-2);
+    font-size: 12px;
+    font-weight: 600;
+  }
+
+  tbody td {
+    border-bottom: 1px solid var(--line);
+    color: var(--ink-2);
+    font-size: 13px;
+  }
+
+  tbody td.name {
+    color: var(--ink);
+    font-weight: 600;
+  }
+
+  tbody td.memo {
+    color: var(--muted);
+  }
+
+  tbody tr:last-child td {
+    border-bottom: 0;
+  }
+
+  tbody tr:hover td {
+    background: var(--fill-2);
+  }
+}
+
+.badge {
+  @include tag-pill;
+  background: var(--fill-2);
+  color: var(--ink-2);
+}
+
+/* ---- 썸네일 ---- */
+
+.thumb,
+.thumbEmpty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+}
+
+.thumb {
+  object-fit: cover;
+}
+
+.thumbEmpty {
+  color: var(--muted);
+}
+
+/* ---- 빈 상태 ---- */
+
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--s3);
+  padding: var(--s8) var(--s5);
+  color: var(--muted);
+  text-align: center;
+
+  p {
+    font-size: 13px;
+  }
+}
+
+.loadState {
+  display: flex;
+  align-items: center;
+  gap: var(--s3);
+  color: var(--muted);
+  font-size: 13px;
+}
+
+/* ---- 등록 모달 (components/ProductFormModal.tsx) ---- */
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--s3);
+
+  @include sm {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.field {
+  @include form-field;
+}
+
+.isWide {
+  grid-column: 1 / -1;
+}
+
+.label {
+  color: var(--ink-2);
+  font-size: 12px;
+  font-weight: 600;
+
+  b {
+    margin-left: 3px;
+    color: var(--red);
+  }
+}
+
+.error {
+  color: var(--red-ink);
+  font-size: 11px;
+}
+
+.hint {
+  color: var(--muted);
+  font-size: 11px;
+}
+
+/* ---- 사진 고르기 ---- */
+
+.imagePicker {
+  display: flex;
+  align-items: center;
+  gap: var(--s3);
+  flex-wrap: wrap;
+}
+
+.preview {
+  width: 64px;
+  height: 64px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  object-fit: cover;
+}
+
+.imageActions {
+  display: flex;
+  align-items: center;
+  gap: var(--s2);
+  min-width: 0;
+}
+
+.fileName {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.removeImage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: none;
+  color: var(--muted);
+  cursor: pointer;
+
+  &:hover {
+    background: var(--fill-2);
+    color: var(--ink);
+  }
+}

--- a/frontend/src/pages/Products/Products.tsx
+++ b/frontend/src/pages/Products/Products.tsx
@@ -1,0 +1,172 @@
+import { useDeferredValue, useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router'
+
+import Button from '@/components/Button'
+import { PlusIcon, ProductIcon, SearchIcon } from '@/components/icons'
+import SearchInput from '@/components/SearchInput'
+import { InlineLoader, ListPageSkeleton } from '@/components/Skeleton'
+import { wonFull } from '@/utils/format'
+
+import { categoryLabel, shelfLifeLabel } from './catalog'
+import ProductFormModal from './components/ProductFormModal'
+import ProductThumb from './components/ProductThumb'
+import useProducts from './useProducts'
+
+import styles from './Products.module.scss'
+
+const COLUMNS = [
+  { id: 'image', header: '사진', width: 72 },
+  { id: 'name', header: '제품명', width: 220 },
+  { id: 'category', header: '분류', width: 96 },
+  { id: 'price', header: '제품단가', width: 132 },
+  { id: 'shelfLife', header: '유효기간', width: 96 },
+  { id: 'memo', header: '메모', width: 420 },
+]
+
+const TABLE_WIDTH = COLUMNS.reduce((sum, column) => sum + column.width, 0)
+
+export default function Products() {
+  const [params, setParams] = useSearchParams()
+  const query = params.get('q') ?? ''
+  const deferredQuery = useDeferredValue(query)
+  const [adding, setAdding] = useState(false)
+
+  const { products, loading, error, reload, addProduct } = useProducts()
+
+  const rows = useMemo(() => {
+    const needle = deferredQuery.trim().toLowerCase()
+    if (needle === '') return products
+    return products.filter((product) =>
+      [product.name, categoryLabel(product.category_code), product.memo ?? '']
+        .join(' ')
+        .toLowerCase()
+        .includes(needle),
+    )
+  }, [products, deferredQuery])
+
+  const setQuery = (value: string) => {
+    const next = new URLSearchParams(params)
+    if (value === '') next.delete('q')
+    else next.set('q', value)
+    setParams(next, { replace: true })
+  }
+
+  // 고객불만 목록과 같은 처리입니다. 첫 진입에서 툴바·표가 따로 들어오면
+  // 화면이 두 번 들썩이므로 한 장을 통째로 자리표시자로 둡니다.
+  if (loading && products.length === 0 && !error) {
+    return (
+      <section className={styles.page} aria-busy={loading}>
+        <h1 className="sr-only">상품관리</h1>
+        <ListPageSkeleton label="상품 목록을 불러오는 중입니다." />
+      </section>
+    )
+  }
+
+  return (
+    <section className={styles.page} aria-busy={loading}>
+      <h1 className="sr-only">상품관리</h1>
+
+      <div className={styles.toolbar}>
+        <SearchInput
+          className={styles.search}
+          value={query}
+          placeholder="제품명·분류·메모 검색"
+          label="상품 검색"
+          onChange={setQuery}
+        />
+        <div className={styles.actions}>
+          <Button disabled={loading} onClick={() => setAdding(true)}>
+            <PlusIcon width={15} height={15} />
+            상품 등록
+          </Button>
+        </div>
+      </div>
+
+      {!error && loading && products.length > 0 && (
+        <InlineLoader label="상품 목록을 새로고침하는 중입니다." />
+      )}
+
+      {error ? (
+        <div className={styles.loadState} role="alert">
+          <p>{error}</p>
+          <Button variant="outline" onClick={reload}>
+            다시 시도
+          </Button>
+        </div>
+      ) : rows.length === 0 ? (
+        <div className={styles.card}>
+          <div className={styles.empty}>
+            {query.trim() !== '' ? (
+              <>
+                <SearchIcon width={34} height={34} strokeWidth={1.5} />
+                <p>조건에 맞는 상품이 없습니다.</p>
+                <Button variant="outline" onClick={() => setQuery('')}>
+                  검색 초기화
+                </Button>
+              </>
+            ) : (
+              <>
+                <ProductIcon width={34} height={34} strokeWidth={1.5} />
+                <p>등록된 상품이 없습니다.</p>
+                <Button onClick={() => setAdding(true)}>상품 등록</Button>
+              </>
+            )}
+          </div>
+        </div>
+      ) : (
+        <div className={styles.card}>
+          {/* 좁은 화면에서는 표가 카드 안에서만 옆으로 흐릅니다. */}
+          <div className={styles.scroller}>
+            <table className={styles.table} style={{ width: TABLE_WIDTH }}>
+              <caption className="sr-only">등록된 상품 목록</caption>
+              <colgroup>
+                {COLUMNS.map((column) => (
+                  <col key={column.id} style={{ width: column.width }} />
+                ))}
+              </colgroup>
+              <thead>
+                <tr>
+                  {COLUMNS.map((column) => (
+                    <th key={column.id} scope="col">
+                      {column.header}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((product) => (
+                  <tr key={product.id}>
+                    <td>
+                      <ProductThumb product={product} />
+                    </td>
+                    <td className={styles.name} title={product.name}>
+                      {product.name}
+                    </td>
+                    <td>
+                      <i className={styles.badge}>{categoryLabel(product.category_code)}</i>
+                    </td>
+                    <td className="tnum">{wonFull(product.unit_price)}</td>
+                    <td className="tnum">{shelfLifeLabel(product.shelf_life_months)}</td>
+                    <td className={styles.memo} title={product.memo ?? ''}>
+                      {product.memo ?? '-'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {adding && (
+        <ProductFormModal
+          onClose={() => setAdding(false)}
+          onSubmit={async (payload, image) => {
+            await addProduct(payload, image)
+            setAdding(false)
+          }}
+        />
+      )}
+    </section>
+  )
+}

--- a/frontend/src/pages/Products/catalog.ts
+++ b/frontend/src/pages/Products/catalog.ts
@@ -1,0 +1,18 @@
+import type { ProductCategoryCode } from '@/types'
+
+export const CATEGORIES: { code: ProductCategoryCode; label: string }[] = [
+  { code: 'system', label: '시스템' },
+  { code: 'probe', label: '프로브' },
+  { code: 'consumable', label: '소모품' },
+]
+
+const LABEL_BY_CODE = new Map(CATEGORIES.map(({ code, label }) => [code, label]))
+
+/** 백엔드가 아직 모르는 코드를 보내도 화면이 비지 않게 코드를 그대로 씁니다. */
+export function categoryLabel(code: string): string {
+  return LABEL_BY_CODE.get(code as ProductCategoryCode) ?? code
+}
+
+export function shelfLifeLabel(months: number | null): string {
+  return months === null ? '-' : `${months}개월`
+}

--- a/frontend/src/pages/Products/components/ProductFormModal.tsx
+++ b/frontend/src/pages/Products/components/ProductFormModal.tsx
@@ -1,0 +1,265 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+
+import { errorMessage } from '@/api/errorMessage'
+import Button from '@/components/Button'
+import { CloseIcon, UploadIcon } from '@/components/icons'
+import Modal from '@/components/Modal'
+import type { ProductCategoryCode, ProductCreateRequest } from '@/types'
+import { sizeLabel } from '@/utils/attachment'
+
+import { CATEGORIES } from '../catalog'
+
+import styles from '../Products.module.scss'
+
+// 서버(upload_guard._IMAGE_ALLOWED)가 받는 형식과 같게 둡니다.
+const IMAGE_ACCEPT = 'image/png,image/jpeg,image/webp'
+const IMAGE_MAX_BYTES = 5 * 1024 * 1024
+
+interface Props {
+  onClose: () => void
+  onSubmit: (payload: ProductCreateRequest, image: File | null) => Promise<void>
+}
+
+type Errors = Partial<Record<'name' | 'unitPrice' | 'shelfLife' | 'image', string>>
+
+export default function ProductFormModal({ onClose, onSubmit }: Props) {
+  const [name, setName] = useState('')
+  const [categoryCode, setCategoryCode] = useState<ProductCategoryCode>('system')
+  const [unitPrice, setUnitPrice] = useState('')
+  const [shelfLife, setShelfLife] = useState('')
+  const [memo, setMemo] = useState('')
+  const [image, setImage] = useState<File | null>(null)
+  const [errors, setErrors] = useState<Errors>({})
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const fileRef = useRef<HTMLInputElement>(null)
+
+  // 미리보기 주소는 브라우저 메모리를 잡고 있으므로 사진이 바뀌면 놓아 줍니다.
+  const [preview, setPreview] = useState<string | null>(null)
+  useEffect(() => {
+    if (image === null) {
+      setPreview(null)
+      return
+    }
+    const objectUrl = URL.createObjectURL(image)
+    setPreview(objectUrl)
+    return () => URL.revokeObjectURL(objectUrl)
+  }, [image])
+
+  const pickImage = (file: File | undefined) => {
+    if (file === undefined) return
+    if (file.size > IMAGE_MAX_BYTES) {
+      setErrors((previous) => ({ ...previous, image: '사진은 5MB까지 올릴 수 있습니다.' }))
+      return
+    }
+    setImage(file)
+    setErrors((previous) => ({ ...previous, image: undefined }))
+  }
+
+  const submit = async () => {
+    if (submitting) return
+
+    const found: Errors = {}
+    if (name.trim() === '') found.name = '제품명을 입력하세요.'
+    const price = Number(unitPrice)
+    if (unitPrice.trim() === '' || !Number.isInteger(price) || price < 0) {
+      found.unitPrice = '0 이상의 정수로 입력하세요.'
+    }
+    const months = shelfLife.trim() === '' ? null : Number(shelfLife)
+    if (months !== null && (!Number.isInteger(months) || months < 1 || months > 1_200)) {
+      found.shelfLife = '1~1200 사이의 정수로 입력하세요.'
+    }
+    setErrors(found)
+    if (Object.keys(found).length > 0) return
+
+    setSubmitting(true)
+    setSubmitError(null)
+    try {
+      await onSubmit(
+        {
+          name: name.trim(),
+          category_code: categoryCode,
+          unit_price: price,
+          shelf_life_months: months,
+          memo: memo.trim() === '' ? null : memo.trim(),
+        },
+        image,
+      )
+    } catch (caught: unknown) {
+      setSubmitError(errorMessage(caught, '상품을 등록하지 못했습니다.'))
+      setSubmitting(false)
+    }
+  }
+
+  const close = () => {
+    if (!submitting) onClose()
+  }
+
+  return (
+    <Modal
+      title="상품 등록"
+      onClose={close}
+      onSubmit={submit}
+      footer={
+        <>
+          <Button type="button" variant="outline" disabled={submitting} onClick={close}>
+            취소
+          </Button>
+          <Button type="submit" disabled={submitting}>
+            {submitting ? '등록 중…' : '상품 등록'}
+          </Button>
+        </>
+      }
+    >
+      <div className={styles.grid} aria-busy={submitting}>
+        <Field label="제품명" required error={errors.name} wide>
+          <input
+            value={name}
+            maxLength={254}
+            disabled={submitting}
+            placeholder="예: CardioView X7"
+            onChange={(event) => {
+              setName(event.target.value)
+              setErrors((previous) => ({ ...previous, name: undefined }))
+            }}
+          />
+        </Field>
+
+        <Field label="분류" required>
+          <select
+            value={categoryCode}
+            disabled={submitting}
+            onChange={(event) => setCategoryCode(event.target.value as ProductCategoryCode)}
+          >
+            {CATEGORIES.map((category) => (
+              <option key={category.code} value={category.code}>
+                {category.label}
+              </option>
+            ))}
+          </select>
+        </Field>
+
+        <Field label="제품단가 (원)" required error={errors.unitPrice}>
+          <input
+            type="number"
+            inputMode="numeric"
+            min={0}
+            step={1}
+            value={unitPrice}
+            disabled={submitting}
+            placeholder="12000000"
+            onChange={(event) => {
+              setUnitPrice(event.target.value)
+              setErrors((previous) => ({ ...previous, unitPrice: undefined }))
+            }}
+          />
+        </Field>
+
+        <Field label="유효기간 (개월)" error={errors.shelfLife}>
+          <input
+            type="number"
+            inputMode="numeric"
+            min={1}
+            max={1200}
+            step={1}
+            value={shelfLife}
+            disabled={submitting}
+            placeholder="24"
+            onChange={(event) => {
+              setShelfLife(event.target.value)
+              setErrors((previous) => ({ ...previous, shelfLife: undefined }))
+            }}
+          />
+        </Field>
+
+        <div className={`${styles.field} ${styles.isWide}`}>
+          <span className={styles.label}>사진</span>
+          <div className={styles.imagePicker}>
+            {preview !== null && (
+              <img className={styles.preview} src={preview} alt="고른 사진 미리보기" />
+            )}
+            <div className={styles.imageActions}>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={submitting}
+                onClick={() => fileRef.current?.click()}
+              >
+                <UploadIcon width={15} height={15} />
+                {image === null ? '사진 고르기' : '다른 사진 고르기'}
+              </Button>
+              {image !== null && (
+                <>
+                  <span className={styles.fileName}>
+                    {image.name} · {sizeLabel(image.size)}
+                  </span>
+                  <button
+                    type="button"
+                    className={styles.removeImage}
+                    disabled={submitting}
+                    aria-label="고른 사진 빼기"
+                    onClick={() => setImage(null)}
+                  >
+                    <CloseIcon width={14} height={14} />
+                  </button>
+                </>
+              )}
+            </div>
+            <input
+              ref={fileRef}
+              type="file"
+              className="sr-only"
+              accept={IMAGE_ACCEPT}
+              disabled={submitting}
+              onChange={(event) => {
+                pickImage(event.target.files?.[0])
+                // 같은 파일을 다시 골라도 change 가 울리게 비웁니다.
+                event.target.value = ''
+              }}
+            />
+          </div>
+          <span className={styles.hint}>PNG·JPG·WEBP, 5MB까지. 선택입니다.</span>
+          {errors.image && <span className={styles.error}>{errors.image}</span>}
+        </div>
+
+        <Field label="메모" wide>
+          <textarea
+            rows={4}
+            value={memo}
+            maxLength={5_000}
+            disabled={submitting}
+            placeholder="사양·재고·주의사항 등을 남겨 주세요"
+            onChange={(event) => setMemo(event.target.value)}
+          />
+        </Field>
+
+        {submitError && (
+          <p className={`${styles.error} ${styles.isWide}`} role="alert">
+            {submitError}
+          </p>
+        )}
+      </div>
+    </Modal>
+  )
+}
+
+interface FieldProps {
+  label: string
+  required?: boolean
+  error?: string
+  wide?: boolean
+  children: ReactNode
+}
+
+function Field({ label, required, error, wide, children }: FieldProps) {
+  return (
+    <label className={`${styles.field} ${wide ? styles.isWide : ''}`}>
+      <span className={styles.label}>
+        {label}
+        {required && <b aria-hidden="true">*</b>}
+      </span>
+      {children}
+      {error && <span className={styles.error}>{error}</span>}
+    </label>
+  )
+}

--- a/frontend/src/pages/Products/components/ProductThumb.tsx
+++ b/frontend/src/pages/Products/components/ProductThumb.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react'
+
+import { client } from '@/api/client'
+import { ProductIcon } from '@/components/icons'
+import type { ProductImageResponse, ProductResponse } from '@/types'
+
+import styles from '../Products.module.scss'
+
+/**
+ * 상품 사진 한 장. 저장소 주소는 내보내지 않으므로 짧게 사는 서명 URL 을 따로 받습니다.
+ *
+ * ponytail: 사진이 있는 줄마다 한 번씩 부릅니다. 상품이 많아지면 한 번에 여러 건을
+ * 발급받는 방식으로 바꿉니다. 주소는 5분이면 만료하므로 화면을 오래 열어 두면
+ * 사진 자리가 빕니다. 그때는 새로고침이 답입니다.
+ */
+export default function ProductThumb({ product }: { product: ProductResponse }) {
+  const [url, setUrl] = useState<string | null>(null)
+
+  useEffect(() => {
+    setUrl(null)
+    if (!product.has_image) return
+
+    const controller = new AbortController()
+    void client
+      .get<ProductImageResponse>(`/products/${product.id}/image`, { signal: controller.signal })
+      .then(({ data }) => {
+        if (!controller.signal.aborted) setUrl(data.url)
+      })
+      .catch(() => {
+        // 사진 한 장을 못 받았다고 목록 전체가 실패하지는 않습니다. 자리표시자로 둡니다.
+      })
+
+    return () => controller.abort()
+  }, [product.id, product.has_image])
+
+  if (url === null) {
+    return (
+      <span className={styles.thumbEmpty} aria-hidden="true">
+        <ProductIcon width={16} height={16} strokeWidth={1.5} />
+      </span>
+    )
+  }
+  return <img className={styles.thumb} src={url} alt={`${product.name} 사진`} loading="lazy" />
+}

--- a/frontend/src/pages/Products/index.ts
+++ b/frontend/src/pages/Products/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Products'

--- a/frontend/src/pages/Products/useProducts.ts
+++ b/frontend/src/pages/Products/useProducts.ts
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import { client } from '@/api/client'
+import { errorMessage } from '@/api/errorMessage'
+import type { PageResponse, ProductCreateRequest, ProductResponse } from '@/types'
+
+const PAGE_LIMIT = 100
+
+const byName = (a: ProductResponse, b: ProductResponse) => a.name.localeCompare(b.name, 'ko')
+
+async function fetchAll(signal: AbortSignal): Promise<ProductResponse[]> {
+  // ponytail: 상품 마스터는 팀당 수십 건이라 전건을 받습니다. 늘어나면 서버 페이지로 바꿉니다.
+  const items: ProductResponse[] = []
+  let skip = 0
+
+  while (!signal.aborted) {
+    const { data } = await client.get<PageResponse<ProductResponse>>('/products', {
+      params: { skip, limit: PAGE_LIMIT },
+      signal,
+    })
+    items.push(...data.items)
+    if (!data.has_more || data.next_skip === null) break
+    if (data.next_skip <= skip) throw new Error('invalid_pagination')
+    skip = data.next_skip
+  }
+
+  return items
+}
+
+export default function useProducts() {
+  const [products, setProducts] = useState<ProductResponse[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [reloadKey, setReloadKey] = useState(0)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    setLoading(true)
+    setError(null)
+
+    void fetchAll(controller.signal)
+      .then((items) => {
+        if (!controller.signal.aborted) setProducts(items)
+      })
+      .catch((caught: unknown) => {
+        if (!controller.signal.aborted) {
+          setError(errorMessage(caught, '상품 목록을 불러오지 못했습니다.'))
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false)
+      })
+
+    return () => controller.abort()
+  }, [reloadKey])
+
+  const reload = useCallback(() => setReloadKey((previous) => previous + 1), [])
+
+  /**
+   * 자료실(useDocuments.addDocument)과 같은 2단계입니다. 상품을 먼저 만들고
+   * 사진이 있으면 그 뒤에 붙입니다. 사진 업로드가 실패해도 상품은 남습니다.
+   */
+  const addProduct = useCallback(async (payload: ProductCreateRequest, image: File | null) => {
+    const { data: created } = await client.post<ProductResponse>('/products', payload)
+    let product = created
+    if (image !== null) {
+      const form = new FormData()
+      form.append('upload', image)
+      const { data } = await client.put<ProductResponse>(`/products/${created.id}/image`, form)
+      product = data
+    }
+    setProducts((previous) => [...previous, product].sort(byName))
+    return product
+  }, [])
+
+  return { products, loading, error, reload, addProduct }
+}

--- a/frontend/src/types/deals.ts
+++ b/frontend/src/types/deals.ts
@@ -35,10 +35,33 @@ export interface SalesDealTypeResponse {
   position: number
 }
 
+export type ProductCategoryCode = 'system' | 'probe' | 'consumable'
+
 export interface ProductResponse {
   id: string
   name: string
   active: boolean
+  category_code: ProductCategoryCode
+  /** 원 단위 정수 */
+  unit_price: number
+  /** 유효기간(개월). 없으면 null */
+  shelf_life_months: number | null
+  memo: string | null
+  /** 사진 주소는 GET /products/{id}/image 로 따로 받습니다. */
+  has_image: boolean
+}
+
+export interface ProductCreateRequest {
+  name: string
+  category_code: ProductCategoryCode
+  unit_price: number
+  shelf_life_months: number | null
+  memo: string | null
+}
+
+export interface ProductImageResponse {
+  url: string
+  expires_in: number
 }
 
 export interface SalesDealCreateRequest {


### PR DESCRIPTION
## 변경 요약

- 팀장이 팀의 상품 마스터를 직접 등록하는 `/products` 화면을 추가합니다. 지금까지는 상품을 넣을 화면이 없어 seed 나 SQL 로만 행을 만들 수 있었습니다.
- 도메인을 새로 만들지 않았습니다. `public.product` 테이블과 `GET /api/products` 는 이미 있었고, 등록 화면이 받는 항목만 더했습니다.
  - `category_code`(시스템/프로브/소모품) · `unit_price`(원 단위 정수) · `shelf_life_months`(유효기간, 개월) · `memo` · `image_storage_key`
- **`GET /api/products` 의 권한은 그대로 둡니다.** 이 목록은 발주(`purchase_order_item.product_id`)와 영업(`activity.product_id`, `sales_deal`) 화면에서 팀원도 상품을 고르는 데 씁니다. 여기를 막으면 팀원의 발주·영업 등록이 깨집니다. 팀장 제한은 새로 만든 쓰기 엔드포인트와 프론트 화면에만 걸었습니다.
- 사진은 저장소 객체 키만 DB 에 남기고(`notice.image_storage_key` 와 같은 규칙) 응답에는 `has_image` 만 내보냅니다. 조회는 요청마다 팀 권한을 다시 확인하고 5분짜리 서명 URL 을 발급합니다.
- 이미지 허용 목록(`_IMAGE_ALLOWED`)을 자료실용 목록(`_ALLOWED`)과 분리했습니다. 자료실은 계속 PDF·DOCX·PPTX 만 받습니다. SVG 는 스크립트를 품을 수 있어 넣지 않았습니다.
- 사이드바 마지막 섹션을 `관리` 캡션 하나로 묶어 상품관리·팀 관리를 담았습니다. `managerOnly` 라 팀원에게는 섹션 전체가 보이지 않습니다.

### 엔드포인트

| 메서드 | 경로 | 권한 |
|---|---|---|
| GET | `/api/products` | 팀 구성원 (기존 그대로, 응답 필드만 추가) |
| POST | `/api/products` | 팀장만 |
| PUT | `/api/products/{id}/image` | 팀장만 |
| GET | `/api/products/{id}/image` | 팀 구성원 (서명 URL) |

## 검증

- `uv run pytest` — 188개 통과 (`tests/test_models.py` 제외)
- `uv run ruff check .` / `ruff format --check .` — 통과
- `npm run typecheck` / `npm run lint` / `npm run build` — 통과
- **`tests/test_models.py` 는 실행하면 실패합니다.** ORM 과 물리 스키마를 대조하는 테스트라 아래 SQL 을 개발 DB 에 적용하기 전까지는 `product` 의 새 컬럼 5개가 없다고 나옵니다. 적용 후 통과 여부를 다시 확인해야 합니다.
- 수동 확인(로그인 2계정, 발주·영업 화면 회귀)은 아직 하지 않았습니다.

## 영향 및 주의 사항

- **수동 적용 작업**: `backend/sql/20260824_0004_product_fields.sql` 을 개발 DB 에 적용해야 합니다. `sql/README.md` 규약상 원격 DB 적용은 명시 요청이 있을 때만 하므로 아직 적용하지 않았고, 적용 이력 표에도 행을 넣지 않았습니다. 적용 뒤 이력 표를 채워야 합니다.
- 적용 전에는 `product` 관련 API 가 500 으로 떨어집니다. 배포 순서는 SQL 먼저입니다.
- 사진 업로드는 Supabase Storage 설정(`supabase_secret_key`, `supabase_storage_bucket`)이 있어야 동작합니다. 없으면 503 `storage_not_configured` 입니다.
- `upload_guard.AllowedAudioType` 을 `AllowedMediaType` 으로 이름만 바꿨습니다(이미지가 같은 구조를 씁니다). 참조는 해당 파일 안에만 있었습니다.
- 상품 수정·비활성(PATCH), 검색·페이지네이션 UI, 사진 여러 장은 넣지 않았습니다. `product_id` 가 발주·활동에서 FK 로 걸려 있어 삭제는 어차피 불가능하고 비활성만 가능합니다.
- 이 브랜치는 `develop` 이 `632ecb1` 로 올라가기 전 `773edc9` 에서 갈라졌습니다. 규칙상 자동으로 pull·rebase 하지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)