### PR TITLE
feat: 목록 화면을 서버 페이지네이션으로 전환

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -4,7 +4,7 @@ from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, File, Form, HTTPException, Query, Response, UploadFile, status
-from sqlalchemy import func, or_, select
+from sqlalchemy import Text, cast, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
@@ -22,6 +22,7 @@ from app.schemas.documents import (
     DocumentPageParams,
     DocumentPatch,
     DocumentRead,
+    DocumentUploaderRead,
     DownloadRead,
 )
 from app.services import storage
@@ -114,6 +115,42 @@ def _document_read(
         files=files,
         latest_version_no=max((f.version_no for f in files), default=None),
     )
+
+
+def _latest_file_id():
+    """문서의 최신 버전 파일 id. 화면이 version_no 가 가장 큰 파일을 최신으로 봅니다."""
+    latest = aliased(FileRow)
+    return (
+        select(latest.id)
+        .where(latest.document_id == Document.id)
+        .order_by(latest.version_no.desc(), latest.uploaded_at.desc(), latest.id.desc())
+        .limit(1)
+        .correlate(Document)
+        .scalar_subquery()
+    )
+
+
+def _latest_file_is(*conditions):
+    """최신 버전 파일이 조건에 맞는 문서인지.
+
+    화면의 담당자·올린 날짜 필터가 최신 버전 파일을 봅니다. 아무 버전이나 맞으면 되게
+    하면 예전 버전을 올린 사람이나 예전 날짜로도 걸립니다.
+    """
+    match = aliased(FileRow)
+    return (
+        select(1)
+        .select_from(match)
+        .where(match.id == _latest_file_id(), *[condition(match) for condition in conditions])
+        .exists()
+    )
+
+
+def _latest_uploader_is(member_ids: tuple[UUID, ...]):
+    return _latest_file_is(lambda match: match.uploaded_by_member_id.in_(member_ids))
+
+
+def _latest_uploaded_from(moment: datetime):
+    return _latest_file_is(lambda match: match.uploaded_at >= moment)
 
 
 async def _files_by_document_ids(
@@ -214,23 +251,38 @@ async def list_documents(
         if page.created_by_member_id is None
         else tuple(dict.fromkeys(page.created_by_member_id))
     )
-    scope = _scope(member, creator_ids)
-    if page.category_code is not None:
-        scope.append(Document.category_code.in_(tuple(dict.fromkeys(page.category_code))))
+    # 분류를 뺀 나머지 조건. 분류 탭 옆 건수와 담당자 선택지가 이 범위를 본다.
+    shared = _scope(member, creator_ids)
     if page.customer_company_id is not None:
-        scope.append(Document.customer_company_id == page.customer_company_id)
+        shared.append(Document.customer_company_id == page.customer_company_id)
     if page.sales_deal_id is not None:
-        scope.append(Document.sales_deal_id == page.sales_deal_id)
+        shared.append(Document.sales_deal_id == page.sales_deal_id)
+    if page.latest_uploader_member_id is not None:
+        shared.append(_latest_uploader_is(tuple(dict.fromkeys(page.latest_uploader_member_id))))
+    if page.latest_uploaded_from is not None:
+        shared.append(_latest_uploaded_from(page.latest_uploaded_from))
     if page.q is not None:
         pattern = _contains(page.q)
-        scope.append(
+        shared.append(
             or_(
                 Document.title.ilike(pattern, escape="\\"),
                 Document.description.ilike(pattern, escape="\\"),
                 Document.document_no.ilike(pattern, escape="\\"),
                 _company.name.ilike(pattern, escape="\\"),
+                # 화면 검색은 표에 안 보이는 값까지 훑는다. 태그와 최신 버전 파일 이름으로도
+                # 찾을 수 있어야 예전과 같은 결과가 나온다. 태그는 JSONB 배열이라 통째로
+                # 글자로 바꿔 훑는다.
+                cast(Document.tags, Text).ilike(pattern, escape="\\"),
+                _latest_file_is(lambda match: match.file_name.ilike(pattern, escape="\\")),
             )
         )
+
+    by_category = (
+        []
+        if page.category_code is None
+        else [Document.category_code.in_(tuple(dict.fromkeys(page.category_code)))]
+    )
+    scope = [*shared, *by_category]
 
     total = (await db.execute(_joined_select(func.count(Document.id)).where(*scope))).scalar_one()
     rows = (
@@ -242,6 +294,33 @@ async def list_documents(
             .limit(page.limit)
         )
     ).all()
+    # 분류 탭 옆 건수. 고른 분류만 빼고 센다.
+    counts = {
+        code: count
+        for code, count in (
+            await db.execute(
+                _joined_select(Document.category_code, func.count(Document.id))
+                .where(*shared)
+                .group_by(Document.category_code)
+            )
+        ).all()
+    }
+    # 담당자 선택지. 최신 버전을 올린 사람 기준이다.
+    _option = aliased(Member)
+    _option_file = aliased(FileRow)
+    uploaders = [
+        DocumentUploaderRead(member_id=member_id, display_name=display_name)
+        for member_id, display_name in (
+            await db.execute(
+                _joined_select(_option.id, _option.display_name)
+                .join(_option_file, _option_file.id == _latest_file_id())
+                .join(_option, _option_file.uploaded_by_member_id == _option.id)
+                .where(*shared)
+                .group_by(_option.id, _option.display_name)
+                .order_by(_option.display_name)
+            )
+        ).all()
+    ]
     file_map = await _files_by_document_ids(db, [row[0].id for row in rows])
     items = [_document_read(*row, file_map[row[0].id]) for row in rows]
     has_more = page.skip + len(items) < total
@@ -252,6 +331,8 @@ async def list_documents(
         total=total,
         has_more=has_more,
         next_skip=page.skip + len(items) if has_more else None,
+        counts=counts,
+        uploaders=uploaders,
     )
 
 

--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -466,20 +466,18 @@ async def list_orders(
     db: DbSession,
 ) -> OrderPage:
     owner_ids = await owner_scope(db, member, page.owner_member_id)
-    scope = _scope(member, owner_ids)
-    scope.append(_sales_stage.phase_code == "order")
+    # 상태 탭과 공급처를 뺀 나머지 조건. 탭 건수와 공급처 목록이 이 범위를 본다. 자기
+    # 조건까지 넣고 집계하면 고른 항목만 남고 나머지가 사라져 고를 수가 없어진다.
+    shared = _scope(member, owner_ids)
+    shared.append(_sales_stage.phase_code == "order")
     if page.order_no is not None:
-        scope.append(PurchaseOrder.order_no == page.order_no)
-    if page.supplier_name is not None:
-        scope.append(PurchaseOrder.supplier_name == page.supplier_name)
-    if page.stage_code is not None:
-        scope.append(_order_status.code.in_(tuple(dict.fromkeys(page.stage_code))))
+        shared.append(PurchaseOrder.order_no == page.order_no)
     if page.sales_deal_id is not None:
-        scope.append(PurchaseOrder.sales_deal_id.in_(tuple(dict.fromkeys(page.sales_deal_id))))
+        shared.append(PurchaseOrder.sales_deal_id.in_(tuple(dict.fromkeys(page.sales_deal_id))))
     if page.start_date is not None:
-        scope.append(PurchaseOrder.ordered_on >= page.start_date)
+        shared.append(PurchaseOrder.ordered_on >= page.start_date)
     if page.end_date is not None:
-        scope.append(PurchaseOrder.ordered_on <= page.end_date)
+        shared.append(PurchaseOrder.ordered_on <= page.end_date)
     if page.q is not None:
         pattern = _contains(page.q)
         product_match = (
@@ -493,7 +491,7 @@ async def list_orders(
             )
             .exists()
         )
-        scope.append(
+        shared.append(
             or_(
                 PurchaseOrder.order_no.ilike(pattern, escape="\\"),
                 PurchaseOrder.supplier_name.ilike(pattern, escape="\\"),
@@ -505,6 +503,16 @@ async def list_orders(
             )
         )
 
+    by_supplier = (
+        [] if page.supplier_name is None else [PurchaseOrder.supplier_name == page.supplier_name]
+    )
+    by_stage = (
+        []
+        if page.stage_code is None
+        else [_order_status.code.in_(tuple(dict.fromkeys(page.stage_code)))]
+    )
+    scope = [*shared, *by_supplier, *by_stage]
+
     total_result = await db.execute(_joined_select(func.count(PurchaseOrder.id)).where(*scope))
     total = total_result.scalar_one()
     rows_result = await db.execute(
@@ -515,6 +523,23 @@ async def list_orders(
         .limit(page.limit)
     )
     rows = rows_result.all()
+    # 탭 옆 건수. 고른 상태만 빼고 나머지 조건은 그대로 둔다. 상태까지 넣고 세면 고른
+    # 탭에만 숫자가 남아 다른 탭에 무엇이 얼마나 있는지 알 수 없다.
+    counts_result = await db.execute(
+        _joined_select(_order_status.code, func.count(PurchaseOrder.id))
+        .where(*shared, *by_supplier)
+        .group_by(_order_status.code)
+    )
+    counts = {code: count for code, count in counts_result.all()}
+    # 공급처 고르는 칸. 쪽에 담긴 발주만 보면 지금 쪽에 없는 공급처를 고를 수 없다.
+    # 자기 조건만 빼고 상태는 적용해, 골랐을 때 0건이 되는 공급처는 아예 내놓지 않는다.
+    suppliers_result = await db.execute(
+        _joined_select(PurchaseOrder.supplier_name)
+        .where(*shared, *by_stage)
+        .group_by(PurchaseOrder.supplier_name)
+        .order_by(PurchaseOrder.supplier_name)
+    )
+    suppliers = [name for (name,) in suppliers_result.all()]
     item_map = await _items_by_order_ids(db, member, [row[0].id for row in rows])
     items = [_order_read(*row, item_map[row[0].id]) for row in rows]
     has_more = page.skip + len(items) < total
@@ -525,6 +550,8 @@ async def list_orders(
         total=total,
         has_more=has_more,
         next_skip=page.skip + len(items) if has_more else None,
+        counts=counts,
+        suppliers=suppliers,
     )
 
 

--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -468,6 +468,8 @@ async def list_orders(
     owner_ids = await owner_scope(db, member, page.owner_member_id)
     scope = _scope(member, owner_ids)
     scope.append(_sales_stage.phase_code == "order")
+    if page.order_no is not None:
+        scope.append(PurchaseOrder.order_no == page.order_no)
     if page.supplier_name is not None:
         scope.append(PurchaseOrder.supplier_name == page.supplier_name)
     if page.stage_code is not None:

--- a/backend/app/api/reports.py
+++ b/backend/app/api/reports.py
@@ -250,6 +250,8 @@ async def list_reports(
         scope.append(Report.report_date >= page.start_date)
     if page.end_date is not None:
         scope.append(Report.report_date <= page.end_date)
+    if page.source_activity_id is not None:
+        scope.append(Report.source_activity_id == page.source_activity_id)
     if page.q is not None:
         pattern = _contains(page.q)
         scope.append(

--- a/backend/app/api/sales_deals.py
+++ b/backend/app/api/sales_deals.py
@@ -570,7 +570,14 @@ async def list_products(
 ) -> ProductPage:
     scope = [Product.team_id == member.team_id, Product.active.is_(True)]
     if page.q is not None:
-        scope.append(Product.name.ilike(_contains(page.q), escape="\\"))
+        pattern = _contains(page.q)
+        matches = [
+            Product.name.ilike(pattern, escape="\\"),
+            Product.memo.ilike(pattern, escape="\\"),
+        ]
+        if page.q_category_code is not None:
+            matches.append(Product.category_code.in_(tuple(dict.fromkeys(page.q_category_code))))
+        scope.append(or_(*matches))
     total_result = await db.execute(select(func.count(Product.id)).where(*scope))
     total = total_result.scalar_one()
     products_result = await db.execute(

--- a/backend/app/api/sales_deals.py
+++ b/backend/app/api/sales_deals.py
@@ -753,11 +753,11 @@ async def list_sales_deals(
     if page.sales_pipeline_id is not None:
         await _team_pipeline(db, member, page.sales_pipeline_id)
 
+    # 단계를 뺀 나머지 조건. 단계 탭 옆 건수가 이 범위를 센다. 단계까지 넣고 세면
+    # 고른 탭에만 숫자가 남아 다른 단계에 무엇이 얼마나 있는지 알 수 없다.
     scope = _scope(member, owner_ids)
     if page.sales_pipeline_id is not None:
         scope.append(SalesDeal.sales_pipeline_id == page.sales_pipeline_id)
-    if stage_ids is not None:
-        scope.append(SalesDeal.sales_pipeline_stage_id.in_(stage_ids))
     if page.phase_code is not None:
         scope.append(_stage.phase_code.in_(tuple(dict.fromkeys(page.phase_code))))
     if page.outcome_code is not None:
@@ -768,15 +768,24 @@ async def list_sales_deals(
         scope.append(SalesDeal.contract_ends_on >= page.contract_ends_from)
     if page.contract_ends_to is not None:
         scope.append(SalesDeal.contract_ends_on <= page.contract_ends_to)
+    basis = {
+        "opened": SalesDeal.opened_on,
+        "quote_issued": func.coalesce(SalesDeal.quote_issued_on, SalesDeal.opened_on),
+        "contract_signed": func.coalesce(SalesDeal.contract_signed_on, SalesDeal.opened_on),
+    }[page.date_basis]
     if page.start_date is not None:
-        scope.append(SalesDeal.opened_on >= page.start_date)
+        scope.append(basis >= page.start_date)
     if page.end_date is not None:
-        scope.append(SalesDeal.opened_on <= page.end_date)
+        scope.append(basis <= page.end_date)
     if page.q is not None:
         pattern = _contains(page.q)
         scope.append(
             or_(
                 SalesDeal.deal_no.ilike(pattern, escape="\\"),
+                # 견적·계약 화면은 그 국면의 번호로 찾는다. 번호가 아직 없으면 딜 번호를
+                # 쓰므로 둘 다 본다.
+                SalesDeal.quote_no.ilike(pattern, escape="\\"),
+                SalesDeal.contract_no.ilike(pattern, escape="\\"),
                 SalesDeal.title.ilike(pattern, escape="\\"),
                 SalesDeal.memo.ilike(pattern, escape="\\"),
                 _company.name.ilike(pattern, escape="\\"),
@@ -789,16 +798,26 @@ async def list_sales_deals(
             )
         )
 
-    total_result = await db.execute(_joined_select(func.count(SalesDeal.id)).where(*scope))
+    by_stage = [] if stage_ids is None else [SalesDeal.sales_pipeline_stage_id.in_(stage_ids)]
+    rows_scope = [*scope, *by_stage]
+
+    total_result = await db.execute(_joined_select(func.count(SalesDeal.id)).where(*rows_scope))
     total = total_result.scalar_one()
     rows_result = await db.execute(
         _joined_select(*_read_entities())
-        .where(*scope)
+        .where(*rows_scope)
         .order_by(SalesDeal.opened_on.desc(), SalesDeal.id)
         .offset(page.skip)
         .limit(page.limit)
     )
     items = [_sales_deal_read(*row) for row in rows_result.all()]
+    # 단계 탭 옆 건수. 고른 단계만 빼고 센다.
+    counts_result = await db.execute(
+        _joined_select(SalesDeal.sales_pipeline_stage_id, func.count(SalesDeal.id))
+        .where(*scope)
+        .group_by(SalesDeal.sales_pipeline_stage_id)
+    )
+    counts = {str(stage_id): count for stage_id, count in counts_result.all()}
     has_more = page.skip + len(items) < total
     return SalesDealPage(
         items=items,
@@ -807,6 +826,7 @@ async def list_sales_deals(
         total=total,
         has_more=has_more,
         next_skip=page.skip + len(items) if has_more else None,
+        counts=counts,
     )
 
 

--- a/backend/app/api/support.py
+++ b/backend/app/api/support.py
@@ -205,12 +205,11 @@ async def list_support_requests(
 ) -> SupportRequestPage:
     # 범위를 먼저 검증한다. 거절이면 데이터 쿼리가 한 건도 나가지 않아야 한다.
     assignee_ids = await owner_scope(db, member, page.assignee_member_id)
-    scope = _scope(member, assignee_ids)
-    if page.status_code is not None:
-        scope.append(SupportRequest.status_code.in_(tuple(dict.fromkeys(page.status_code))))
+    # 상태를 뺀 나머지 조건. 탭 건수가 이 범위를 센다.
+    shared = _scope(member, assignee_ids)
     if page.q is not None:
         pattern = _contains(page.q)
-        scope.append(
+        shared.append(
             or_(
                 SupportRequest.title.ilike(pattern, escape="\\"),
                 SupportRequest.body.ilike(pattern, escape="\\"),
@@ -219,6 +218,10 @@ async def list_support_requests(
                 _assignee.display_name.ilike(pattern, escape="\\"),
             )
         )
+
+    scope = [*shared]
+    if page.status_code is not None:
+        scope.append(SupportRequest.status_code.in_(tuple(dict.fromkeys(page.status_code))))
 
     total_result = await db.execute(_joined_select(func.count(SupportRequest.id)).where(*scope))
     total = total_result.scalar_one()
@@ -230,6 +233,14 @@ async def list_support_requests(
         .limit(page.limit)
     )
     rows = rows_result.all()
+    # 탭 옆 건수. 고른 상태는 빼고 센다. 상태까지 적용하면 고른 탭만 숫자가 남고 나머지가
+    # 0 이 되어, 다른 탭에 무엇이 얼마나 있는지 알 수 없다.
+    counts_result = await db.execute(
+        _joined_select(SupportRequest.status_code, func.count(SupportRequest.id))
+        .where(*shared)
+        .group_by(SupportRequest.status_code)
+    )
+    counts = {code: count for code, count in counts_result.all()}
     response_map = await _responses_by_request_ids(db, member, [row[0].id for row in rows])
     items = [_request_read(*row, response_map[row[0].id]) for row in rows]
     has_more = page.skip + len(items) < total
@@ -240,6 +251,7 @@ async def list_support_requests(
         total=total,
         has_more=has_more,
         next_skip=page.skip + len(items) if has_more else None,
+        counts=counts,
     )
 
 

--- a/backend/app/schemas/documents.py
+++ b/backend/app/schemas/documents.py
@@ -87,6 +87,11 @@ class DocumentRead(BaseModel):
     latest_version_no: int | None
 
 
+class DocumentUploaderRead(BaseModel):
+    member_id: UUID
+    display_name: str
+
+
 class DocumentPage(BaseModel):
     items: list[DocumentRead]
     skip: int
@@ -94,6 +99,11 @@ class DocumentPage(BaseModel):
     total: int
     has_more: bool
     next_skip: int | None
+    # 분류 탭 옆 건수 {분류 코드: 건수}. 고른 분류는 빼고 센 값이라 total 과 다르다.
+    counts: dict[str, int] = Field(default_factory=dict)
+    # 담당자 고르는 칸에 세울 사람. 최신 버전을 올린 사람 기준이고, 쪽에 담긴 문서만
+    # 보면 지금 쪽에 없는 사람을 고를 수 없어서 서버가 전체에서 뽑아 준다.
+    uploaders: list[DocumentUploaderRead] = Field(default_factory=list)
 
 
 class DocumentPageParams(BaseModel):
@@ -104,6 +114,10 @@ class DocumentPageParams(BaseModel):
     customer_company_id: UUID | None = None
     sales_deal_id: UUID | None = None
     created_by_member_id: list[UUID] | None = None
+    # 아래 둘은 최신 버전 파일을 본다. 화면의 담당자·기간 필터가 "마지막으로 올린 사람과
+    # 올린 날짜" 를 뜻하기 때문이다. 문서를 처음 만든 사람(created_by_member_id)과 다르다.
+    latest_uploader_member_id: list[UUID] | None = None
+    latest_uploaded_from: datetime | None = None
     skip: int = Field(default=0, ge=0, le=9_223_372_036_854_775_807)
     limit: int = Field(default=30, ge=1, le=100)
 

--- a/backend/app/schemas/orders.py
+++ b/backend/app/schemas/orders.py
@@ -148,6 +148,9 @@ class OrderPageParams(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     q: SearchQuery | None = None
+    # 발주 번호로 한 건만 집어 오는 조회에 쓴다. q 는 여러 열을 훑는 부분 일치라 번호를
+    # 아는 조회에는 맞지 않는다. 상세 화면이 주소의 번호로 바로 들어올 때 쓴다.
+    order_no: Text | None = None
     supplier_name: Text | None = None
     stage_code: list[OptionCode] | None = None
     sales_deal_id: list[UUID] | None = None

--- a/backend/app/schemas/orders.py
+++ b/backend/app/schemas/orders.py
@@ -142,6 +142,11 @@ class OrderPage(BaseModel):
     total: int
     has_more: bool
     next_skip: int | None
+    # 탭 옆 건수 {상태 코드: 건수}. 고른 상태는 빼고 센 값이라 total 과 다르다.
+    counts: dict[str, int] = Field(default_factory=dict)
+    # 공급처 고르는 칸에 세울 이름. 쪽에 담긴 발주만 보면 지금 쪽에 없는 공급처를
+    # 고를 수 없어서 서버가 전체에서 뽑아 준다.
+    suppliers: list[str] = Field(default_factory=list)
 
 
 class OrderPageParams(BaseModel):

--- a/backend/app/schemas/reports.py
+++ b/backend/app/schemas/reports.py
@@ -153,6 +153,9 @@ class ReportPageParams(BaseModel):
     start_date: date | None = None
     end_date: date | None = None
     author_member_id: list[UUID] | None = None
+    # "이 일정으로 쓴 보고서가 이미 있는가" 를 묻는 조회에 쓴다. 목록을 통째로 받아 뒤지면
+    # 페이지 밖에 있는 보고서를 못 찾고 같은 일정에 보고서를 또 만든다.
+    source_activity_id: UUID | None = None
     skip: int = Field(default=0, ge=0, le=9_223_372_036_854_775_807)
     limit: int = Field(default=30, ge=1, le=100)
 

--- a/backend/app/schemas/sales_deals.py
+++ b/backend/app/schemas/sales_deals.py
@@ -142,6 +142,10 @@ class ProductPageParams(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     q: SearchQuery | None = None
+    # 검색어가 가리키는 분류 코드. 화면은 "소모품" 처럼 분류 이름으로도 찾는데, 그 이름은
+    # 화면(catalog.ts)만 알고 DB 에는 코드만 있다. 화면이 풀어서 보내고 서버는 q 와 OR 로
+    # 묶는다. 이름 표를 여기에 한 벌 더 두면 두 곳이 어긋난다.
+    q_category_code: list[OptionCode] | None = None
     skip: int = Field(default=0, ge=0, le=9_223_372_036_854_775_807)
     limit: int = Field(default=30, ge=1, le=100)
 

--- a/backend/app/schemas/sales_deals.py
+++ b/backend/app/schemas/sales_deals.py
@@ -282,6 +282,8 @@ class SalesDealPage(BaseModel):
     total: int
     has_more: bool
     next_skip: int | None
+    # 단계 탭 옆 건수 {단계 id: 건수}. 고른 단계는 빼고 센 값이라 total 과 다르다.
+    counts: dict[str, int] = Field(default_factory=dict)
 
 
 class SalesDealPageParams(BaseModel):
@@ -290,6 +292,10 @@ class SalesDealPageParams(BaseModel):
     q: SearchQuery | None = None
     start_date: date | None = None
     end_date: date | None = None
+    # start_date·end_date 를 어느 날짜에 걸지. 견적 화면은 발행일로, 계약 화면은 체결일로
+    # 기간을 좁힌다. 둘 다 비어 있을 수 있어 시작일로 되돌린다. 기본값은 시작일이라
+    # 이미 쓰던 조회는 그대로다.
+    date_basis: Literal["opened", "quote_issued", "contract_signed"] = "opened"
     owner_member_id: list[UUID] | None = None
     sales_pipeline_id: UUID | None = None
     sales_pipeline_stage_id: list[UUID] | None = None

--- a/backend/app/schemas/support.py
+++ b/backend/app/schemas/support.py
@@ -72,6 +72,9 @@ class SupportRequestPage(BaseModel):
     total: int
     has_more: bool
     next_skip: int | None
+    # 탭 옆 건수 {상태 코드: 건수}. 고른 상태는 빼고 센 값이라 total 과 다르다.
+    # 상태까지 적용해 세면 고른 탭만 숫자가 남고 나머지가 0 이 된다.
+    counts: dict[str, int] = Field(default_factory=dict)
 
 
 class SupportRequestPageParams(BaseModel):

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import UTC, datetime
 from uuid import uuid4
 
@@ -5,6 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
+from app.api import documents as documents_api
 from app.api.deps import get_current_member
 from app.core.config import settings
 from app.db.session import get_db
@@ -273,3 +275,45 @@ def test_other_team_document_is_hidden():
     assert response.status_code == 404
     assert response.json() == {"detail": "document_not_found"}
     assert member.team_id in db.statements[0].compile().params.values()
+
+
+def test_uploader_and_date_filters_look_at_the_latest_version_only():
+    """담당자·올린 날짜 필터는 최신 버전 파일을 본다.
+
+    화면의 표가 최신 버전의 올린 사람과 날짜를 보여 주므로 필터도 같은 파일을 봐야 한다.
+    아무 버전이나 맞으면 되게 하면, 예전 버전을 올린 사람으로 걸러도 문서가 나온다.
+    """
+    member = _member()
+    db = _Db(_Result(scalar=0), _Result(rows=[]), _Result(rows=[]), _Result(rows=[]))
+
+    page = asyncio.run(
+        documents_api.list_documents(
+            DocumentPageParams(
+                latest_uploader_member_id=[member.id],
+                latest_uploaded_from=datetime(2026, 3, 1, tzinfo=UTC),
+                category_code=["proposal"],
+                q="합성",
+            ),
+            member,
+            db,
+        )
+    )
+
+    assert page.counts == {}
+    count_sql = str(db.statements[0])
+    counts_sql = str(db.statements[2])
+
+    # 최신 한 건만 보도록 상관 서브쿼리로 좁힌다. 별칭 번호는 쿼리마다 달라 이름만 본다.
+    assert "version_no DESC" in count_sql
+    assert "LIMIT" in count_sql
+    assert "document_id = public.document.id" in count_sql
+    assert "uploaded_by_member_id IN" in count_sql
+    assert "uploaded_at >=" in count_sql
+    # 검색은 태그와 최신 파일 이름까지 훑는다.
+    assert "document.tags" in count_sql
+    assert "file_name" in count_sql
+
+    # 분류 탭 옆 건수는 분류만 빼고 나머지는 그대로 둔다.
+    assert "document.category_code IN" in count_sql
+    assert "document.category_code IN" not in counts_sql
+    assert "uploaded_by_member_id IN" in counts_sql

--- a/backend/tests/test_orders.py
+++ b/backend/tests/test_orders.py
@@ -460,3 +460,34 @@ def test_orders_can_be_narrowed_to_one_sales_deal():
         assert "purchase_order.sales_deal_id IN" in sql
         # IN 절이라 값이 목록으로 묶여 들어간다.
         assert [deal.id] in statement.compile().params.values()
+
+
+def test_orders_can_be_picked_by_order_no():
+    """상세 화면이 주소의 발주 번호로 바로 들어온다. 번호로 한 건만 집어 온다.
+
+    목록에서 찾으면 그 발주가 현재 페이지 밖일 때 상세가 열리지 않는다. q 는 여러 열을
+    훑는 부분 일치라 번호를 아는 조회에는 쓸 수 없다.
+    """
+    member = _member()
+    company = _company(member)
+    pipeline = _pipeline(member)
+    stage = _stage(pipeline, code="order_in_progress", phase="order", position=6)
+    deal = _deal(member, company, pipeline, stage)
+    status = _status(member)
+    order = _order(member, deal, status)
+    product = _product(member)
+    item = _item(order, product)
+    db = _Db(
+        _Result(scalar=1),
+        _Result(rows=[_row(order, deal, company, member, status)]),
+        _Result(rows=[(item, product.name)]),
+    )
+
+    page = asyncio.run(api.list_orders(OrderPageParams(order_no=order.order_no), member, db))
+
+    assert page.total == 1
+    assert page.items[0].order_no == order.order_no
+    # 개수 쿼리와 행 쿼리가 같은 조건으로 좁혀야 총계와 목록이 어긋나지 않는다.
+    for statement in (db.statements[0], db.statements[1]):
+        assert "purchase_order.order_no = " in str(statement)
+        assert order.order_no in statement.compile().params.values()

--- a/backend/tests/test_orders.py
+++ b/backend/tests/test_orders.py
@@ -288,6 +288,8 @@ def test_order_status_options_hide_deleted_but_order_reads_preserve_deleted_stat
         _Result(scalar_values=[_status(member)]),
         _Result(scalar=1),
         _Result(rows=[_row(order, deal, company, member, current_status)]),
+        _Result(rows=[(current_status.code, 1)]),
+        _Result(rows=[(order.supplier_name,)]),
         _Result(rows=[(item, product.name)]),
         _Result(rows=[_row(order, deal, company, member, current_status)]),
         _Result(rows=[(item, product.name)]),
@@ -448,6 +450,8 @@ def test_orders_can_be_narrowed_to_one_sales_deal():
     db = _Db(
         _Result(scalar=1),
         _Result(rows=[_row(order, deal, company, member, status)]),
+        _Result(rows=[(status.code, 1)]),
+        _Result(rows=[(order.supplier_name,)]),
         _Result(rows=[(item, product.name)]),
     )
 
@@ -480,6 +484,8 @@ def test_orders_can_be_picked_by_order_no():
     db = _Db(
         _Result(scalar=1),
         _Result(rows=[_row(order, deal, company, member, status)]),
+        _Result(rows=[(status.code, 1)]),
+        _Result(rows=[(order.supplier_name,)]),
         _Result(rows=[(item, product.name)]),
     )
 
@@ -491,3 +497,52 @@ def test_orders_can_be_picked_by_order_no():
     for statement in (db.statements[0], db.statements[1]):
         assert "purchase_order.order_no = " in str(statement)
         assert order.order_no in statement.compile().params.values()
+
+
+def test_tab_counts_and_supplier_options_drop_only_their_own_filter():
+    """탭 건수와 공급처 목록은 각자 자기 조건만 빼고 센다.
+
+    자기 조건까지 넣으면 고른 항목만 남아 다른 탭·다른 공급처로 옮겨 갈 수가 없다.
+    반대로 남의 조건까지 빼면 골랐을 때 0건이 되는 항목을 내놓게 된다.
+    """
+    member = _member()
+    company = _company(member)
+    pipeline = _pipeline(member)
+    stage = _stage(pipeline, code="order_in_progress", phase="order", position=6)
+    deal = _deal(member, company, pipeline, stage)
+    status = _status(member)
+    db = _Db(
+        _Result(scalar=0),
+        _Result(rows=[]),
+        _Result(rows=[(status.code, 2), ("done", 5)]),
+        _Result(rows=[("합성 공급처",)]),
+    )
+
+    page = asyncio.run(
+        api.list_orders(
+            OrderPageParams(stage_code=[status.code], supplier_name="합성 공급처"),
+            member,
+            db,
+        )
+    )
+
+    assert page.counts == {status.code: 2, "done": 5}
+    assert page.suppliers == ["합성 공급처"]
+
+    # 상태 표는 별칭으로 조인되므로 별칭 이름으로 본다.
+    status_filter = "purchase_order_status_1.code IN"
+    supplier_filter = "purchase_order.supplier_name = "
+    rows_sql = str(db.statements[1])
+    counts_sql = str(db.statements[2])
+    suppliers_sql = str(db.statements[3])
+
+    # 목록은 두 조건을 다 적용한다. 별칭 이름이 바뀌면 아래 단언이 헛돌므로 여기서 잡는다.
+    assert status_filter in rows_sql
+    assert supplier_filter in rows_sql
+    # 건수는 상태를 빼고 공급처는 남긴다.
+    assert status_filter not in counts_sql
+    assert supplier_filter in counts_sql
+    # 공급처 목록은 그 반대다.
+    assert supplier_filter not in suppliers_sql
+    assert status_filter in suppliers_sql
+    assert deal.id is not None

--- a/backend/tests/test_products.py
+++ b/backend/tests/test_products.py
@@ -1,39 +1,59 @@
+import asyncio
 from uuid import uuid4
 
 import pytest
 from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
+from app.api import sales_deals as sales_api
 from app.api.deps import get_current_member
 from app.core.config import settings
 from app.db.session import get_db
 from app.main import app
 from app.models.sales import Product
 from app.models.workspace import Member
-from app.schemas.sales_deals import ProductCreate
+from app.schemas.sales_deals import ProductCreate, ProductPageParams
 
 ORIGIN = settings.cors_origin_list[0]
 PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 8
 _MISSING = object()
 
 
+class _Scalars:
+    def __init__(self, values):
+        self.values = values
+
+    def all(self):
+        return self.values
+
+
 class _Result:
-    def __init__(self, *, scalar=_MISSING):
+    def __init__(self, *, scalar=_MISSING, rows=None):
         self.scalar = scalar
+        self.rows = [] if rows is None else rows
 
     def scalar_one_or_none(self):
         assert self.scalar is not _MISSING
         return self.scalar
+
+    def scalar_one(self):
+        assert self.scalar is not _MISSING
+        return self.scalar
+
+    def scalars(self):
+        return _Scalars(self.rows)
 
 
 class _Db:
     def __init__(self, *results: _Result):
         self.results = list(results)
         self.added = []
+        self.statements = []
         self.commit_count = 0
         self.rollback_count = 0
 
     async def execute(self, statement):
+        self.statements.append(statement)
         assert self.results, "예상보다 많은 쿼리가 실행되었습니다."
         return self.results.pop(0)
 
@@ -182,3 +202,32 @@ def test_other_team_product_image_is_not_found(storage_ready):
         response = client.get(f"/api/products/{uuid4()}/image", headers={"Origin": ORIGIN})
     assert response.status_code == 404
     assert response.json()["detail"] == "product_not_found"
+
+
+def test_product_search_covers_memo_and_category_codes():
+    """검색이 제품명·메모·분류 이름을 함께 훑던 동작을 서버가 그대로 해야 한다.
+
+    분류 이름("소모품")은 화면(catalog.ts)만 알고 DB 에는 코드만 있으므로, 화면이 코드로
+    풀어 보내고 서버가 q 와 OR 로 묶는다. AND 로 묶이면 이름이 걸린 제품이 사라진다.
+    """
+    member = _member(role="manager")
+    product = _product(member)
+    db = _Db(_Result(scalar=1), _Result(rows=[product]))
+
+    page = asyncio.run(
+        sales_api.list_products(
+            ProductPageParams(q="소모", q_category_code=["consumable"]),
+            member,
+            db,
+        )
+    )
+
+    assert page.total == 1
+    # 개수 쿼리와 행 쿼리가 같은 조건이어야 총계와 목록이 어긋나지 않는다.
+    for statement in db.statements:
+        sql = str(statement)
+        assert "lower(public.product.name) LIKE" in sql
+        assert "lower(public.product.memo) LIKE" in sql
+        # 세 조건은 OR 이어야 한다. AND 로 묶이면 이름만 걸린 제품이 사라진다.
+        assert "OR lower(public.product.memo) LIKE" in sql
+        assert "OR public.product.category_code IN" in sql

--- a/backend/tests/test_reports.py
+++ b/backend/tests/test_reports.py
@@ -484,7 +484,7 @@ def test_write_failure_rolls_back_transaction():
 
 
 def test_source_activity_filter_reaches_the_query():
-    """"이 일정으로 쓴 보고서가 있는가" 를 서버가 직접 답해야 한다.
+    """이 일정으로 쓴 보고서가 있는지를 서버가 직접 답해야 한다.
 
     이 조건이 쿼리에 실리지 않으면 저장 화면이 목록 첫 페이지만 보고 없다고 판단해,
     이미 보고서가 있는 일정에 같은 보고서를 하나 더 만든다.

--- a/backend/tests/test_reports.py
+++ b/backend/tests/test_reports.py
@@ -481,3 +481,30 @@ def test_write_failure_rolls_back_transaction():
 
     assert db.commit_count == 0
     assert db.rollback_count == 1
+
+
+def test_source_activity_filter_reaches_the_query():
+    """"이 일정으로 쓴 보고서가 있는가" 를 서버가 직접 답해야 한다.
+
+    이 조건이 쿼리에 실리지 않으면 저장 화면이 목록 첫 페이지만 보고 없다고 판단해,
+    이미 보고서가 있는 일정에 같은 보고서를 하나 더 만든다.
+    """
+    member = _member()
+    activity_id = uuid4()
+    db = _Db(_Result(scalar=0), _Result(rows=[]))
+
+    with _client(db, member) as client:
+        response = client.get(
+            "/api/reports",
+            params={
+                "report_kind": "meeting",
+                "source_activity_id": str(activity_id),
+                "limit": 1,
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["total"] == 0
+    # 개수 쿼리와 행 쿼리 모두 같은 조건으로 좁혀야 총계와 목록이 어긋나지 않는다.
+    for statement in db.statements:
+        assert "report.source_activity_id = " in str(statement)

--- a/backend/tests/test_sales_deals.py
+++ b/backend/tests/test_sales_deals.py
@@ -323,6 +323,7 @@ def test_sales_deal_list_exposes_pipeline_stage_type_and_phase_filter():
     db = _Db(
         _Result(scalar=1),
         _Result(rows=[_row(deal, member, pipeline, stage, deal_type, company, product)]),
+        _Result(rows=[(stage.id, 1)]),
     )
 
     page = asyncio.run(
@@ -490,6 +491,7 @@ def test_renewal_filters_match_the_dashboard_card():
     db = _Db(
         _Result(scalar=1),
         _Result(rows=[_row(deal, member, pipeline, stage, deal_type, company, product)]),
+        _Result(rows=[(stage.id, 1)]),
     )
 
     page = asyncio.run(
@@ -517,3 +519,80 @@ def test_renewal_window_rejects_a_reversed_range():
         SalesDealPageParams(
             contract_ends_from=date(2026, 9, 24), contract_ends_to=date(2026, 8, 25)
         )
+
+
+def test_stage_tab_counts_ignore_the_chosen_stage():
+    """단계 탭 옆 건수는 고른 단계만 빼고 센다.
+
+    단계까지 넣고 세면 고른 탭에만 숫자가 남아 다른 단계에 무엇이 얼마나 있는지 알 수
+    없다. 반대로 파이프라인·검색어까지 빼면 탭 숫자가 실제로 열리는 목록보다 커진다.
+    """
+    member = _member()
+    pipeline = _pipeline(member)
+    stage = _stage(pipeline, code="quote_sent", phase="quote", position=2)
+    other = _stage(pipeline, code="quote_ready", phase="quote", position=1)
+    db = _Db(
+        _Result(scalar_values=[stage.id]),
+        _Result(scalar=pipeline),
+        _Result(scalar=0),
+        _Result(rows=[]),
+        _Result(rows=[(stage.id, 3), (other.id, 7)]),
+    )
+
+    page = asyncio.run(
+        api.list_sales_deals(
+            SalesDealPageParams(
+                sales_pipeline_id=pipeline.id,
+                sales_pipeline_stage_id=[stage.id],
+                q="합성",
+            ),
+            member,
+            db,
+        )
+    )
+
+    assert page.counts == {str(stage.id): 3, str(other.id): 7}
+
+    rows_sql = str(db.statements[3])
+    counts_sql = str(db.statements[4])
+    stage_filter = "sales_deal.sales_pipeline_stage_id IN"
+    # 목록은 단계를 적용한다. 이 단언이 깨지면 아래 not in 이 헛돈다.
+    assert stage_filter in rows_sql
+    # 건수는 단계를 빼고 파이프라인과 검색어는 남긴다.
+    assert stage_filter not in counts_sql
+    assert "sales_deal.sales_pipeline_id = " in counts_sql
+    assert "%합성%" in db.statements[4].compile().params.values()
+
+
+def test_date_basis_moves_the_range_to_the_phase_date():
+    """견적 화면의 기간은 발행일 기준이다. 딜 시작일로 걸면 다른 목록이 나온다.
+
+    발행일이 아직 없는 딜은 시작일로 되돌려 세야, 번호를 매기기 전 견적이 기간에서
+    통째로 사라지지 않는다.
+    """
+    member = _member()
+    db = _Db(_Result(scalar=0), _Result(rows=[]), _Result(rows=[]))
+
+    asyncio.run(
+        api.list_sales_deals(
+            SalesDealPageParams(
+                phase_code=["quote"],
+                date_basis="quote_issued",
+                start_date=date(2026, 3, 1),
+            ),
+            member,
+            db,
+        )
+    )
+
+    sql = str(db.statements[0])
+    assert "coalesce(public.sales_deal.quote_issued_on, public.sales_deal.opened_on) >=" in sql
+
+    # 기본값은 예전 그대로 시작일이다. 대시보드 등 이미 쓰던 조회가 바뀌면 안 된다.
+    default_db = _Db(_Result(scalar=0), _Result(rows=[]), _Result(rows=[]))
+    asyncio.run(
+        api.list_sales_deals(SalesDealPageParams(start_date=date(2026, 3, 1)), member, default_db)
+    )
+    default_sql = str(default_db.statements[0])
+    assert "public.sales_deal.opened_on >=" in default_sql
+    assert "coalesce" not in default_sql.lower()

--- a/backend/tests/test_support.py
+++ b/backend/tests/test_support.py
@@ -243,6 +243,7 @@ def test_member_list_and_detail_are_scoped_and_include_response_history():
     list_db = _Db(
         _Result(scalar=1),
         _Result(rows=[_row(request, contact, company, member)]),
+        _Result(rows=[("in_progress", 1)]),
         _Result(rows=[(response_item, member.display_name)]),
     )
 
@@ -285,12 +286,13 @@ def test_member_list_and_detail_are_scoped_and_include_response_history():
         "total": 1,
         "has_more": False,
         "next_skip": None,
+        "counts": {"in_progress": 1},
     }
     for statement in list_db.statements[:2]:
         assert member.id in statement.compile().params.values()
         assert member.team_id in statement.compile().params.values()
         assert "%합성%" in statement.compile().params.values()
-    assert member.team_id in list_db.statements[2].compile().params.values()
+    assert member.team_id in list_db.statements[3].compile().params.values()
 
     detail_db = _Db(
         _Result(rows=[_row(request, contact, company, member)]),
@@ -311,6 +313,7 @@ def test_manager_reads_team_request_without_member_self_filter():
     db = _Db(
         _Result(scalar=1),
         _Result(rows=[_row(request, contact, company, assignee)]),
+        _Result(rows=[("in_progress", 1)]),
         _Result(rows=[]),
     )
 
@@ -452,6 +455,7 @@ def test_manager_support_assignee_filter_narrows_to_the_chosen_members():
         _Result(scalar_values=[first.id, second.id]),
         _Result(scalar=0),
         _Result(rows=[]),
+        _Result(rows=[]),
     )
 
     with _client(db, manager) as client:
@@ -461,8 +465,10 @@ def test_manager_support_assignee_filter_narrows_to_the_chosen_members():
         )
 
     assert response.status_code == 200
-    # 첫 문장은 범위 검증이고, 그 다음이 개수와 목록이다.
-    assert [first.id, second.id] in db.statements[1].compile().params.values()
+    # 첫 문장은 범위 검증이고, 그 다음이 개수·목록·탭 건수다. 셋 다 같은 담당자로 좁혀야
+    # 목록과 탭 숫자가 어긋나지 않는다.
+    for statement in db.statements[1:]:
+        assert [first.id, second.id] in statement.compile().params.values()
 
 
 def test_member_support_assignee_filter_is_denied_before_any_query():
@@ -493,3 +499,36 @@ def test_manager_support_assignee_filter_rejects_a_member_outside_the_team():
     assert response.status_code == 403
     assert response.json()["detail"] == "scope_not_allowed"
     assert len(db.statements) == 1
+
+
+def test_tab_counts_ignore_the_chosen_status_but_keep_other_filters():
+    """탭 옆 건수는 고른 상태만 빼고 센다.
+
+    상태까지 적용해 세면 고른 탭에만 숫자가 남고 나머지 탭이 모두 0 이 되어, 다른 탭에
+    무엇이 얼마나 있는지 알 수 없다. 반대로 검색어까지 빼고 세면 탭 숫자가 실제로 열리는
+    목록보다 커진다.
+    """
+    member = _member()
+    db = _Db(
+        _Result(scalar=1),
+        _Result(rows=[]),
+        _Result(rows=[("in_progress", 1), ("completed", 4)]),
+    )
+
+    with _client(db, member) as client:
+        response = client.get(
+            "/api/support-requests",
+            params=[("q", "합성"), ("status_code", "in_progress")],
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    # 목록은 고른 상태로 좁혀 1건, 탭 건수는 상태를 빼고 세어 다른 탭도 함께 나온다.
+    assert body["total"] == 1
+    assert body["counts"] == {"in_progress": 1, "completed": 4}
+
+    counts_sql = str(db.statements[2])
+    assert "GROUP BY" in counts_sql
+    # 상태 조건은 빠지고 검색어 조건은 남아야 한다.
+    assert "support_request.status_code IN" not in counts_sql
+    assert "%합성%" in db.statements[2].compile().params.values()

--- a/frontend/src/components/Pagination/Pagination.tsx
+++ b/frontend/src/components/Pagination/Pagination.tsx
@@ -5,7 +5,7 @@ import { ChevronLeftIcon, ChevronRightIcon } from '@/components/icons'
 
 import styles from './Pagination.module.scss'
 
-const PAGE_SIZES = [25, 50, 100]
+const PAGE_SIZES = [30, 50, 100]
 
 interface PaginationProps {
   page: number

--- a/frontend/src/pages/Complaints/Complaints.tsx
+++ b/frontend/src/pages/Complaints/Complaints.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useDeferredValue, useMemo, useState } from 'react'
+import { useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react'
 import { useSearchParams } from 'react-router'
 
 import Button from '@/components/Button'
 import Drawer from '@/components/Drawer'
 import ErrorToast from '@/components/ErrorToast'
 import { ComplaintIcon, PlusIcon, SearchIcon } from '@/components/icons'
+import Pagination from '@/components/Pagination'
 import SearchInput from '@/components/SearchInput'
 import { InlineLoader, ListPageSkeleton, SkeletonDetail } from '@/components/Skeleton'
 import Tabs, { type TabItem } from '@/components/Tabs'
@@ -60,11 +61,21 @@ export default function Complaints() {
 
   const [openId, setOpenId] = useState<string | null>(null)
   const [adding, setAdding] = useState(false)
+  const [page, setPage] = useState(1)
+  const [pageSize, setPageSize] = useState(30)
   const isDesktop = useMediaQuery(`(min-width: ${BP_DESKTOP}px)`)
 
+  // 검색어나 탭이 바뀌면 결과가 줄어 지금 쪽수가 범위를 넘을 수 있습니다.
+  useEffect(() => {
+    setPage(1)
+  }, [deferredQuery, status])
+
   const {
-    requests,
+    requests: rows,
+    total,
+    counts,
     contacts,
+    loadContacts,
     loading,
     error,
     reload,
@@ -78,7 +89,14 @@ export default function Complaints() {
     createRequest,
     transition,
     addResponse,
-  } = useSupportRequests(openId)
+  } = useSupportRequests(openId, {
+    q: deferredQuery,
+    status: status as SupportStatusCode | '',
+    skip: (page - 1) * pageSize,
+    limit: pageSize,
+  })
+
+  const pageCount = Math.max(1, Math.ceil(total / pageSize))
 
   const setParam = useCallback(
     (key: string, value: string) => {
@@ -90,45 +108,26 @@ export default function Complaints() {
     [params, setParams],
   )
 
-  const beforeStatus = useMemo(() => {
-    const needle = deferredQuery.trim().toLowerCase()
-    if (needle === '') return requests
-    return requests.filter((request) =>
-      [
-        request.title,
-        request.body,
-        request.customer_company_name,
-        request.customer_contact_name,
-        request.assignee_display_name,
-      ]
-        .join(' ')
-        .toLowerCase()
-        .includes(needle),
-    )
-  }, [requests, deferredQuery])
-
-  const rows = useMemo(
-    () =>
-      status === ''
-        ? beforeStatus
-        : beforeStatus.filter((request) => request.status_code === status),
-    [beforeStatus, status],
-  )
-
+  // 탭 옆 건수는 서버가 셉니다. 고른 탭은 빼고 센 값이라, 탭을 바꿔도 다른 탭 숫자가
+  // 0 으로 죽지 않습니다.
   const statusTabs = useMemo<TabItem[]>(
     () => [
-      { value: '', label: '전체', count: beforeStatus.length },
+      {
+        value: '',
+        label: '전체',
+        count: Object.values(counts).reduce((sum, count) => sum + count, 0),
+      },
       ...STATES.map((state) => ({
         value: state.code,
         label: state.label,
-        count: beforeStatus.filter((request) => request.status_code === state.code).length,
+        count: counts[state.code] ?? 0,
         tone: state.tone,
       })),
     ],
-    [beforeStatus],
+    [counts],
   )
 
-  const summary = openId === null ? undefined : requests.find((request) => request.id === openId)
+  const summary = openId === null ? undefined : rows.find((request) => request.id === openId)
   const open = detail?.id === openId ? detail : summary
   const isFiltered = query.trim() !== '' || status !== ''
 
@@ -139,7 +138,7 @@ export default function Complaints() {
 
   // 첫 진입입니다. 툴바·탭·표가 차례로 나타나면 화면이 두세 번 들썩이므로
   // 화면 한 장을 통째로 자리표시자로 두고 다 받은 뒤 한 번에 바꿉니다.
-  if (loading && requests.length === 0 && !error) {
+  if (loading && rows.length === 0 && !error) {
     return (
       <section className={styles.page} aria-busy={loading}>
         <h1 className="sr-only">고객불만관리</h1>
@@ -162,7 +161,13 @@ export default function Complaints() {
         />
 
         <div className={styles.actions}>
-          <Button disabled={loading} onClick={() => setAdding(true)}>
+          <Button
+            disabled={loading}
+            onClick={() => {
+              setAdding(true)
+              void loadContacts()
+            }}
+          >
             <PlusIcon width={15} height={15} />
             불만 등록
           </Button>
@@ -176,7 +181,7 @@ export default function Complaints() {
         onChange={(next) => setParam('status', next)}
       />
 
-      {!error && loading && requests.length > 0 && (
+      {!error && loading && rows.length > 0 && (
         <InlineLoader label="고객불만 목록을 새로고침하는 중입니다." />
       )}
 
@@ -197,7 +202,14 @@ export default function Complaints() {
               <>
                 <ComplaintIcon width={34} height={34} strokeWidth={1.5} />
                 <p>접수된 고객불만이 없습니다.</p>
-                <Button onClick={() => setAdding(true)}>불만 등록</Button>
+                <Button
+                  onClick={() => {
+                    setAdding(true)
+                    void loadContacts()
+                  }}
+                >
+                  불만 등록
+                </Button>
               </>
             )}
           </div>
@@ -285,6 +297,21 @@ export default function Complaints() {
             </li>
           ))}
         </ul>
+      )}
+
+      {rows.length > 0 && (
+        <Pagination
+          page={page}
+          pageCount={pageCount}
+          pageSize={pageSize}
+          total={total}
+          unit="건"
+          onPage={setPage}
+          onPageSize={(size) => {
+            setPageSize(size)
+            setPage(1)
+          }}
+        />
       )}
 
       {open && (

--- a/frontend/src/pages/Complaints/useSupportRequests.ts
+++ b/frontend/src/pages/Complaints/useSupportRequests.ts
@@ -7,6 +7,7 @@ import { useScopeOwnerIds } from '@/shared/scope'
 import type {
   CustomerContactResponse,
   PageResponse,
+  TabbedPageResponse,
   SupportRequestCreateRequest,
   SupportRequestResponse,
   SupportResponseResponse,
@@ -21,12 +22,12 @@ export interface ContactOption {
   label: string
 }
 
+/** 등록 모달의 고객 선택 목록만 씁니다. 목록 자체는 서버가 쪽으로 끊어 줍니다. */
 async function fetchAll<T>(
   path: string,
   signal: AbortSignal,
   extraParams?: Record<string, unknown>,
 ): Promise<T[]> {
-  // ponytail: 탭 건수는 전건 기준입니다. 데이터가 커지면 서버 집계 API로 바꿉니다.
   const items: T[] = []
   let skip = 0
 
@@ -67,8 +68,18 @@ export function mutationErrorMessage(error: unknown, action: string): string {
   return transportMessage(error) ?? fallback
 }
 
-export default function useSupportRequests(openId: string | null) {
+export interface SupportQuery {
+  q: string
+  /** 고른 탭. 빈 문자열이면 전체입니다. */
+  status: SupportStatusCode | ''
+  skip: number
+  limit: number
+}
+
+export default function useSupportRequests(openId: string | null, query: SupportQuery) {
   const [requests, setRequests] = useState<SupportRequestResponse[]>([])
+  const [total, setTotal] = useState(0)
+  const [counts, setCounts] = useState<Record<string, number>>({})
   const [contacts, setContacts] = useState<ContactOption[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -89,23 +100,23 @@ export default function useSupportRequests(openId: string | null) {
     setLoading(true)
     setError(null)
 
-    void Promise.all([
-      fetchAll<SupportRequestResponse>('/support-requests', controller.signal, {
-        assignee_member_id: assigneeIds,
-      }),
-      // 고객은 불만을 등록할 때 고르는 목록입니다. 보기 범위로 좁히면 팀원이 맡은
-      // 고객의 불만을 접수할 수 없게 됩니다.
-      fetchAll<CustomerContactResponse>('/customer-contacts', controller.signal),
-    ])
-      .then(([requestItems, contactItems]) => {
+    const needle = query.q.trim()
+    void client
+      .get<TabbedPageResponse<SupportRequestResponse>>('/support-requests', {
+        params: {
+          q: needle === '' ? undefined : needle.slice(0, 100),
+          status_code: query.status === '' ? undefined : query.status,
+          assignee_member_id: assigneeIds,
+          skip: query.skip,
+          limit: query.limit,
+        },
+        signal: controller.signal,
+      })
+      .then(({ data }) => {
         if (controller.signal.aborted) return
-        setRequests(requestItems)
-        setContacts(
-          contactItems.map((contact) => ({
-            id: contact.id,
-            label: `${contact.company_name} · ${contact.name}`,
-          })),
-        )
+        setRequests(data.items)
+        setTotal(data.total)
+        setCounts(data.counts)
       })
       .catch((caught: unknown) => {
         if (!controller.signal.aborted) setError(loadErrorMessage(caught))
@@ -115,7 +126,7 @@ export default function useSupportRequests(openId: string | null) {
       })
 
     return () => controller.abort()
-  }, [reloadKey, assigneeIds])
+  }, [reloadKey, assigneeIds, query.q, query.status, query.skip, query.limit])
 
   useEffect(() => {
     setDetail(null)
@@ -142,9 +153,31 @@ export default function useSupportRequests(openId: string | null) {
     return () => controller.abort()
   }, [openId, detailReloadKey])
 
+  /**
+   * 등록 모달의 고객 선택 목록. 모달을 열 때만 받습니다.
+   *
+   * 보기 범위로 좁히지 않습니다. 좁히면 팀원이 맡은 고객의 불만을 접수할 수 없습니다.
+   *
+   * ponytail: 고객이 많아지면 전건을 받는 select 자체가 무겁습니다. 그때는 이 칸을
+   * ContactPicker 같은 검색 입력으로 바꿉니다. 목록 쪽 넘김과는 무관합니다.
+   */
+  const loadContacts = useCallback(async () => {
+    if (contacts.length > 0) return
+    const controller = new AbortController()
+    const items = await fetchAll<CustomerContactResponse>('/customer-contacts', controller.signal)
+    setContacts(
+      items.map((contact) => ({
+        id: contact.id,
+        label: `${contact.company_name} · ${contact.name}`,
+      })),
+    )
+  }, [contacts.length])
+
   const createRequest = useCallback(async (payload: SupportRequestCreateRequest) => {
     const { data } = await client.post<SupportRequestResponse>('/support-requests', payload)
-    setRequests((previous) => [data, ...previous])
+    // 새 불만이 이 쪽 첫 줄에 오는지는 접수 시각 순서가 정합니다. 목록에 끼워 넣지 않고
+    // 다시 받아 서버가 놓는 자리를 따릅니다.
+    setReloadKey((value) => value + 1)
     return data
   }, [])
 
@@ -206,7 +239,10 @@ export default function useSupportRequests(openId: string | null) {
 
   return {
     requests,
+    total,
+    counts,
     contacts,
+    loadContacts,
     loading,
     error,
     reload: () => setReloadKey((value) => value + 1),

--- a/frontend/src/pages/Contracts/Contracts.tsx
+++ b/frontend/src/pages/Contracts/Contracts.tsx
@@ -69,7 +69,7 @@ export default function Contracts() {
 
   const [sort, setSort] = useState<SortState>(null)
   const [page, setPage] = useState(1)
-  const [pageSize, setPageSize] = useState(25)
+  const [pageSize, setPageSize] = useState(30)
   const [openFilter, setOpenFilter] = useState<'pipeline' | 'owner' | 'range' | null>(null)
 
   const pipelineOptions = useMemo(

--- a/frontend/src/pages/Contracts/Contracts.tsx
+++ b/frontend/src/pages/Contracts/Contracts.tsx
@@ -2,9 +2,10 @@ import { useCallback, useDeferredValue, useMemo, useState } from 'react'
 import { useSearchParams } from 'react-router'
 
 import { useCurrentUser } from '@/auth/sessionContext'
+import useTeamMembers from '@/hooks/useTeamMembers'
 import Button from '@/components/Button'
 import ContractForm from '@/components/ContractForm'
-import DataTable, { compareBy, type SortState } from '@/components/DataTable'
+import DataTable from '@/components/DataTable'
 import ErrorToast from '@/components/ErrorToast'
 import FilterSelect from '@/components/FilterSelect'
 import { ContractIcon, SearchIcon } from '@/components/icons'
@@ -46,20 +47,9 @@ export default function Contracts() {
   }
 
   const requestedPipelineId = params.get('pipeline') ?? ''
-  const {
-    pipelines,
-    dealPipelineId,
-    columns: pipelineStages,
-    cards: contracts,
-    loading,
-    error,
-    reload,
-    detail,
-    detailLoading,
-    detailError,
-    reloadDetail,
-  } = useSalesDeals(openId, requestedPipelineId || null, 'list', 'contract')
   const { isManager } = useCurrentUser()
+  // 담당자 선택지. 받아 둔 목록에서 뽑으면 지금 쪽에 있는 사람만 나옵니다.
+  const { members: teamMembers } = useTeamMembers(isManager)
 
   const query = params.get('q') ?? ''
   const owner = isManager ? (params.get('owner') ?? '') : ''
@@ -67,39 +57,9 @@ export default function Contracts() {
   const stage = params.get('stage') ?? ''
   const deferredQuery = useDeferredValue(query)
 
-  const [sort, setSort] = useState<SortState>(null)
   const [page, setPage] = useState(1)
   const [pageSize, setPageSize] = useState(30)
   const [openFilter, setOpenFilter] = useState<'pipeline' | 'owner' | 'range' | null>(null)
-
-  const pipelineOptions = useMemo(
-    () => [
-      { value: '', label: '파이프라인 전체' },
-      ...pipelines.map((pipeline) => ({
-        value: pipeline.id,
-        label: pipeline.name + (pipeline.status_code === 'archived' ? ' (보관)' : ''),
-      })),
-    ],
-    [pipelines],
-  )
-
-  const contractStages = useMemo(
-    () => pipelineStages.filter((item) => item.phase === 'contract'),
-    [pipelineStages],
-  )
-  const columns = useMemo(
-    () => CONTRACT_COLUMNS.filter((column) => column.id !== 'owner' || isManager),
-    [isManager],
-  )
-  const ownerOptions = useMemo(
-    () => [
-      { value: '', label: '담당 전체' },
-      ...[...new Set(contracts.map((item) => item.owner))]
-        .sort()
-        .map((name) => ({ value: name, label: name })),
-    ],
-    [contracts],
-  )
 
   const setParam = useCallback(
     (key: string, value: string, fallback = '') => {
@@ -130,58 +90,78 @@ export default function Contracts() {
     [params, setParams],
   )
 
-  const beforeStage = useMemo(() => {
-    const needle = deferredQuery.trim().toLowerCase()
-    return contracts.filter((contract) => {
-      if (owner !== '' && contract.owner !== owner) return false
-      if (fromISO !== null && (contract.contractSignedOn ?? contract.date) < fromISO) return false
-      if (needle === '') return true
-      return [
-        contract.contractNo ?? contract.no,
-        contract.org,
-        contract.product,
-        contract.owner,
-        contract.memo ?? '',
-      ]
-        .join(' ')
-        .toLowerCase()
-        .includes(needle)
-    })
-  }, [contracts, deferredQuery, fromISO, owner])
-
-  const stageCounts = useMemo(() => {
-    const counts = new Map<string, number>()
-    for (const contract of beforeStage)
-      counts.set(contract.stageId, (counts.get(contract.stageId) ?? 0) + 1)
-    return counts
-  }, [beforeStage])
-
-  const matched = useMemo(() => {
-    const activeStage = dealPipelineId ? stage : ''
-    const rows =
-      activeStage === ''
-        ? beforeStage
-        : beforeStage.filter((contract) => contract.stageId === activeStage)
-    if (!sort) return rows
-    const sign = sort.dir === 'asc' ? 1 : -1
-    const compare = compareBy(columns, sort.id)
-    return [...rows].sort((a, b) => sign * compare(a, b))
-  }, [beforeStage, columns, dealPipelineId, sort, stage])
-
-  const pageCount = Math.max(1, Math.ceil(matched.length / pageSize))
-  const safePage = Math.min(page, pageCount)
-  const pageRows = useMemo(
-    () => matched.slice((safePage - 1) * pageSize, safePage * pageSize),
-    [matched, pageSize, safePage],
+  const dealQuery = useMemo(
+    () => ({
+      q: deferredQuery,
+      stageId: stage,
+      ownerMemberId: owner,
+      fromISO,
+      skip: (page - 1) * pageSize,
+      limit: pageSize,
+    }),
+    [deferredQuery, stage, owner, fromISO, page, pageSize],
   )
 
-  const onSort = useCallback((id: string) => {
-    setSort((previous) => {
-      if (previous?.id !== id) return { id, dir: 'asc' }
-      if (previous.dir === 'asc') return { id, dir: 'desc' }
-      return null
-    })
-  }, [])
+  const {
+    pipelines,
+    dealPipelineId,
+    columns: pipelineStages,
+    cards: pageRows,
+    total,
+    counts,
+    loading,
+    error,
+    reload,
+    detail,
+    detailLoading,
+    detailError,
+    reloadDetail,
+  } = useSalesDeals(openId, requestedPipelineId || null, 'list', 'contract', dealQuery)
+
+  const contractStages = useMemo(
+    () => pipelineStages.filter((item) => item.phase === 'contract'),
+    [pipelineStages],
+  )
+  // 정렬 API가 붙기 전에 현재 쪽만 정렬하면 전체 순서를 오해하게 됩니다.
+  const columns = useMemo(
+    () =>
+      CONTRACT_COLUMNS.filter((column) => column.id !== 'owner' || isManager).map((column) => ({
+        ...column,
+        sortable: false,
+      })),
+    [isManager],
+  )
+  const ownerOptions = useMemo(
+    () => [
+      { value: '', label: '담당 전체' },
+      ...teamMembers.map((item) => ({ value: item.id, label: item.display_name })),
+    ],
+    [teamMembers],
+  )
+
+  const pipelineOptions = useMemo(
+    () => [
+      { value: '', label: '파이프라인 전체' },
+      ...pipelines.map((pipeline) => ({
+        value: pipeline.id,
+        label: pipeline.name + (pipeline.status_code === 'archived' ? ' (보관)' : ''),
+      })),
+    ],
+    [pipelines],
+  )
+
+  // 단계 탭 옆 건수는 서버가 셉니다. 고른 단계는 빼고 센 값이라 탭을 바꿔도 다른 단계
+  // 숫자가 0 으로 죽지 않습니다.
+  const stageCounts = useMemo(() => new Map(Object.entries(counts)), [counts])
+  const stageTotal = useMemo(
+    () => [...stageCounts.values()].reduce((sum, count) => sum + count, 0),
+    [stageCounts],
+  )
+
+  const pageCount = Math.max(1, Math.ceil(total / pageSize))
+
+  // 헤더 정렬을 끄므로 누를 일이 없습니다. 고객 목록과 같은 처리입니다.
+  const ignoreSort = useCallback(() => undefined, [])
 
   const clearFilters = useCallback(() => {
     setParams(new URLSearchParams(), { replace: true })
@@ -196,7 +176,7 @@ export default function Contracts() {
       outcome: contract.status,
       phase: contract.stagePhase,
     }
-  const selectedContract = detail ?? contracts.find((contract) => contract.id === openId) ?? null
+  const selectedContract = detail ?? pageRows.find((contract) => contract.id === openId) ?? null
   const selectedStage = selectedContract ? stageOf(selectedContract) : undefined
   const isFiltered =
     query.trim() !== '' ||
@@ -207,7 +187,7 @@ export default function Contracts() {
 
   // 첫 진입입니다. 툴바·탭·표가 차례로 나타나면 화면이 두세 번 들썩이므로
   // 화면 한 장을 통째로 자리표시자로 두고 다 받은 뒤 한 번에 바꿉니다.
-  if (loading && contracts.length === 0 && !error) {
+  if (loading && pageRows.length === 0 && !error) {
     return (
       <section className={styles.page} aria-busy={loading}>
         <h1 className="sr-only">계약 현황</h1>
@@ -265,12 +245,12 @@ export default function Contracts() {
           label="계약 단계"
           value={stage}
           countOf={(id) => stageCounts.get(id) ?? 0}
-          total={beforeStage.length}
+          total={stageTotal}
           onChange={(next) => setParam('stage', next)}
         />
       )}
 
-      {!error && loading && contracts.length > 0 && (
+      {!error && loading && pageRows.length > 0 && (
         <InlineLoader label="목록을 새로고침하는 중입니다." />
       )}
 
@@ -281,8 +261,8 @@ export default function Contracts() {
         columns={columns}
         rowKey={(contract) => contract.id}
         handleColumn="org"
-        sort={sort}
-        onSort={onSort}
+        sort={null}
+        onSort={ignoreSort}
         onOpen={(contract) => setOpenId(contract.id)}
         caption="계약 목록. 헤더를 눌러 정렬할 수 있습니다."
         renderCell={(id, contract) => {
@@ -327,12 +307,12 @@ export default function Contracts() {
         }
       />
 
-      {!error && !loading && matched.length > 0 && (
+      {!error && !loading && pageRows.length > 0 && (
         <Pagination
-          page={safePage}
+          page={page}
           pageCount={pageCount}
           pageSize={pageSize}
-          total={matched.length}
+          total={total}
           unit="건"
           onPage={setPage}
           onPageSize={(size) => {

--- a/frontend/src/pages/Customers/Customers.tsx
+++ b/frontend/src/pages/Customers/Customers.tsx
@@ -44,7 +44,7 @@ export default function Customers() {
   const [query, setQuery] = useState('')
   const [selected, setSelected] = useState<ReadonlySet<string>>(new Set())
   const [page, setPage] = useState(1)
-  const [pageSize, setPageSize] = useState(25)
+  const [pageSize, setPageSize] = useState(30)
   const [dialog, setDialog] = useState<OpenDialog>(null)
   const [cardDraft, setCardDraft] = useState<BusinessCardDraft | null>(null)
   const [openId, setOpenId] = useState<string | null>(null)

--- a/frontend/src/pages/Daily/MeetingPick.tsx
+++ b/frontend/src/pages/Daily/MeetingPick.tsx
@@ -37,7 +37,7 @@ export default function MeetingPick() {
     loading: agendaLoading,
     error: agendaError,
     reload: reloadAgenda,
-  } = useAgendaState(undefined, undefined, true)
+  } = useAgendaState(dateISO, dateISO, true)
   const agenda = items.filter((item) => item.date === dateISO)
   const {
     findByAgenda,

--- a/frontend/src/pages/Daily/useDailyReports.ts
+++ b/frontend/src/pages/Daily/useDailyReports.ts
@@ -128,6 +128,20 @@ export interface DraftPayload {
   attachments: DailyReport['attachments']
 }
 
+/**
+ * 이 기간에 이미 쓴 보고서의 번호. 저장할 때 새로 만들지 고칠지를 이걸로 가릅니다.
+ *
+ * 목록에서 찾으면 그 보고서가 현재 페이지 밖일 때 못 찾고 같은 기간에 보고서를 하나 더
+ * 만듭니다. 기간 전체를 서버에 물어야 합니다. 기간 안 어느 날짜든 같은 기간으로 접힙니다.
+ */
+async function savedIdForPeriod(kind: ReportKind, dateISO: string): Promise<string | undefined> {
+  const [from, to] = periodRange(kind, dateISO)
+  const { data } = await client.get<PageResponse<ReportResponse>>('/reports', {
+    params: { report_kind: API_KIND[kind], start_date: from, end_date: to, limit: 1 },
+  })
+  return data.items[0]?.id
+}
+
 function requestOf(draft: DraftPayload): ReportWriteRequest {
   const [from, to] = periodRange(draft.kind, draft.date)
   const included = draft.activities.filter((activity) => activity.included)
@@ -214,39 +228,36 @@ export default function useDailyReports() {
     [reports],
   )
 
-  const save = useCallback(
-    async (draft: DraftPayload, submit: boolean) => {
-      setPending(true)
-      setError(null)
-      try {
-        const existing = findByPeriod(draft.kind, draft.date)
-        const request = requestOf(draft)
-        const { report_kind: _kind, source_activity_id: _source, ...patch } = request
-        const saved = existing
-          ? await client.patch<ReportResponse>(`/reports/${existing.id}`, patch)
-          : await client.post<ReportResponse>('/reports', request)
-        const response = submit
-          ? await client.post<ReportResponse>(`/reports/${saved.data.id}/submit`, {
-              expected_status_code: 'draft',
-            })
-          : saved
-        const report = toReport(response.data)
-        setReports((current) => [report, ...current.filter((item) => item.id !== report.id)])
-        return report
-      } catch (reason: unknown) {
-        setError(
-          errorMessage(
-            reason,
-            submit ? '업무보고를 제출하지 못했습니다.' : '임시저장하지 못했습니다.',
-          ),
-        )
-        throw reason
-      } finally {
-        setPending(false)
-      }
-    },
-    [findByPeriod],
-  )
+  const save = useCallback(async (draft: DraftPayload, submit: boolean) => {
+    setPending(true)
+    setError(null)
+    try {
+      const existingId = await savedIdForPeriod(draft.kind, draft.date)
+      const request = requestOf(draft)
+      const { report_kind: _kind, source_activity_id: _source, ...patch } = request
+      const saved = existingId
+        ? await client.patch<ReportResponse>(`/reports/${existingId}`, patch)
+        : await client.post<ReportResponse>('/reports', request)
+      const response = submit
+        ? await client.post<ReportResponse>(`/reports/${saved.data.id}/submit`, {
+            expected_status_code: 'draft',
+          })
+        : saved
+      const report = toReport(response.data)
+      setReports((current) => [report, ...current.filter((item) => item.id !== report.id)])
+      return report
+    } catch (reason: unknown) {
+      setError(
+        errorMessage(
+          reason,
+          submit ? '업무보고를 제출하지 못했습니다.' : '임시저장하지 못했습니다.',
+        ),
+      )
+      throw reason
+    } finally {
+      setPending(false)
+    }
+  }, [])
 
   return {
     reports,

--- a/frontend/src/pages/Deals/Deals.tsx
+++ b/frontend/src/pages/Deals/Deals.tsx
@@ -73,7 +73,7 @@ export default function Deals() {
 
   const [sort, setSort] = useState<SortState>(null)
   const [page, setPage] = useState(1)
-  const [pageSize, setPageSize] = useState(25)
+  const [pageSize, setPageSize] = useState(30)
   const [openFilter, setOpenFilter] = useState<'pipeline' | 'range' | null>(null)
   const [addingTo, setAddingTo] = useState<string | null>(null)
   const [editingId, setEditingId] = useState<string | null>(null)

--- a/frontend/src/pages/Deals/Deals.tsx
+++ b/frontend/src/pages/Deals/Deals.tsx
@@ -4,7 +4,7 @@ import { useSearchParams } from 'react-router'
 
 import { useCurrentUser } from '@/auth/sessionContext'
 import Button from '@/components/Button'
-import DataTable, { compareBy, type SortState } from '@/components/DataTable'
+import DataTable from '@/components/DataTable'
 import ErrorToast from '@/components/ErrorToast'
 import FilterSelect from '@/components/FilterSelect'
 import { VisitIcon, PlusIcon, SearchIcon } from '@/components/icons'
@@ -38,30 +38,6 @@ export default function Deals() {
   const [openId, setOpenId] = useState<string | null>(null)
   const [params, setParams] = useSearchParams()
   const requestedPipelineId = params.get('pipeline') ?? ''
-  const {
-    pipelines,
-    dealPipelineId,
-    columns,
-    cards,
-    companies,
-    products,
-    dealTypes,
-    loading,
-    error,
-    reload,
-    detail,
-    detailLoading,
-    detailError,
-    reloadDetail,
-    mutationError,
-    clearMutationError,
-    canCreate,
-    isCreating,
-    isPending,
-    createSalesDeal,
-    updateSalesDeal,
-    deleteSalesDeal,
-  } = useSalesDeals(openId, requestedPipelineId || null, 'list')
   const { isManager } = useCurrentUser()
   // 팀원은 서버가 본인 데이터로 제한하므로 담당자 스코프를 요청에 싣지 않습니다.
   const showOwner = isManager
@@ -71,29 +47,12 @@ export default function Deals() {
   const stage = params.get('stage') ?? ''
   const deferredQuery = useDeferredValue(query)
 
-  const [sort, setSort] = useState<SortState>(null)
   const [page, setPage] = useState(1)
   const [pageSize, setPageSize] = useState(30)
   const [openFilter, setOpenFilter] = useState<'pipeline' | 'range' | null>(null)
   const [addingTo, setAddingTo] = useState<string | null>(null)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [deletingId, setDeletingId] = useState<string | null>(null)
-
-  const tableColumns = useMemo(
-    () => dealColumns(columns).filter((column) => column.id !== 'owner' || showOwner),
-    [columns, showOwner],
-  )
-
-  const pipelineOptions = useMemo(
-    () => [
-      { value: '', label: '파이프라인 전체' },
-      ...pipelines.map((pipeline) => ({
-        value: pipeline.id,
-        label: pipeline.name + (pipeline.status_code === 'archived' ? ' (보관)' : ''),
-      })),
-    ],
-    [pipelines],
-  )
 
   const setParam = useCallback(
     (key: string, value: string, fallback = '') => {
@@ -124,48 +83,73 @@ export default function Deals() {
     return iso(addDays(TODAY, -Math.round(months * 30.4)))
   }, [range])
 
-  const beforeStage = useMemo(() => {
-    const needle = deferredQuery.trim().toLowerCase()
-    return cards.filter((card) => {
-      if (fromISO !== null && card.date < fromISO) return false
-      if (needle === '') return true
-      return [card.no, card.org, card.product, card.owner, card.memo ?? '']
-        .join(' ')
-        .toLowerCase()
-        .includes(needle)
-    })
-  }, [cards, deferredQuery, fromISO])
-
-  const stageCounts = useMemo(() => {
-    const counts = new Map<string, number>()
-    for (const card of beforeStage) counts.set(card.stageId, (counts.get(card.stageId) ?? 0) + 1)
-    return counts
-  }, [beforeStage])
-
-  const matched = useMemo(() => {
-    const activeStage = dealPipelineId ? stage : ''
-    const rows =
-      activeStage === '' ? beforeStage : beforeStage.filter((card) => card.stageId === activeStage)
-    if (!sort) return rows
-    const sign = sort.dir === 'asc' ? 1 : -1
-    const compare = compareBy(tableColumns, sort.id)
-    return [...rows].sort((a, b) => sign * compare(a, b))
-  }, [beforeStage, dealPipelineId, sort, stage, tableColumns])
-
-  const pageCount = Math.max(1, Math.ceil(matched.length / pageSize))
-  const safePage = Math.min(page, pageCount)
-  const pageRows = useMemo(
-    () => matched.slice((safePage - 1) * pageSize, safePage * pageSize),
-    [matched, pageSize, safePage],
+  const dealQuery = useMemo(
+    () => ({
+      q: deferredQuery,
+      stageId: stage,
+      // 이 화면에는 담당자 칸이 없습니다. 서버가 보기 범위로 좁힙니다.
+      ownerMemberId: '',
+      fromISO,
+      skip: (page - 1) * pageSize,
+      limit: pageSize,
+    }),
+    [deferredQuery, stage, fromISO, page, pageSize],
   )
 
-  const onSort = useCallback((id: string) => {
-    setSort((previous) => {
-      if (previous?.id !== id) return { id, dir: 'asc' }
-      if (previous.dir === 'asc') return { id, dir: 'desc' }
-      return null
-    })
-  }, [])
+  const {
+    pipelines,
+    dealPipelineId,
+    columns,
+    cards: pageRows,
+    total,
+    counts,
+    companies,
+    products,
+    dealTypes,
+    loading,
+    error,
+    reload,
+    detail,
+    detailLoading,
+    detailError,
+    reloadDetail,
+    mutationError,
+    clearMutationError,
+    canCreate,
+    isCreating,
+    isPending,
+    createSalesDeal,
+    updateSalesDeal,
+    deleteSalesDeal,
+  } = useSalesDeals(openId, requestedPipelineId || null, 'list', undefined, dealQuery)
+
+  const pipelineOptions = useMemo(
+    () => [
+      { value: '', label: '파이프라인 전체' },
+      ...pipelines.map((pipeline) => ({
+        value: pipeline.id,
+        label: pipeline.name + (pipeline.status_code === 'archived' ? ' (보관)' : ''),
+      })),
+    ],
+    [pipelines],
+  )
+
+  const tableColumns = useMemo(
+    () => dealColumns(columns).filter((column) => column.id !== 'owner' || showOwner),
+    [columns, showOwner],
+  )
+
+  // 단계 탭 옆 건수는 서버가 셉니다. 고른 단계는 빼고 센 값입니다.
+  const stageCounts = useMemo(() => new Map(Object.entries(counts)), [counts])
+  const stageTotal = useMemo(
+    () => [...stageCounts.values()].reduce((sum, count) => sum + count, 0),
+    [stageCounts],
+  )
+
+  const pageCount = Math.max(1, Math.ceil(total / pageSize))
+
+  // 헤더 정렬을 끄므로 누를 일이 없습니다. 고객 목록과 같은 처리입니다.
+  const ignoreSort = useCallback(() => undefined, [])
 
   const clearFilters = useCallback(() => {
     setParams(new URLSearchParams(), { replace: true })
@@ -179,10 +163,10 @@ export default function Deals() {
       tone: card.stageTone,
       outcome: card.status,
     }
-  const selectedDeal = detail ?? cards.find((card) => card.id === openId) ?? null
+  const selectedDeal = detail ?? pageRows.find((card) => card.id === openId) ?? null
   const selectedStage = selectedDeal ? stageOf(selectedDeal) : undefined
-  const editingDeal = cards.find((card) => card.id === editingId)
-  const deletingDeal = cards.find((card) => card.id === deletingId)
+  const editingDeal = pageRows.find((card) => card.id === editingId)
+  const deletingDeal = pageRows.find((card) => card.id === deletingId)
   const addingColumn = columns.find((column) => column.id === addingTo)
   const defaultColumn = columns.find((column) => column.id === stage) ?? columns[0]
   const isDeleting = deletingDeal ? isPending(deletingDeal.id) : false
@@ -191,7 +175,7 @@ export default function Deals() {
 
   // 첫 진입입니다. 툴바·탭·표가 차례로 나타나면 화면이 두세 번 들썩이므로
   // 화면 한 장을 통째로 자리표시자로 두고 다 받은 뒤 한 번에 바꿉니다.
-  if (loading && cards.length === 0 && !error) {
+  if (loading && pageRows.length === 0 && !error) {
     return (
       <section className={styles.page} aria-busy={loading}>
         <h1 className="sr-only">영업 현황</h1>
@@ -253,7 +237,7 @@ export default function Deals() {
           label="영업 단계"
           value={stage}
           countOf={(id) => stageCounts.get(id) ?? 0}
-          total={beforeStage.length}
+          total={stageTotal}
           onChange={(next) => setParam('stage', next)}
         />
       )}
@@ -273,7 +257,7 @@ export default function Deals() {
         </div>
       )}
 
-      {!error && loading && cards.length > 0 && (
+      {!error && loading && pageRows.length > 0 && (
         <InlineLoader label="목록을 새로고침하는 중입니다." />
       )}
 
@@ -284,8 +268,8 @@ export default function Deals() {
         columns={tableColumns}
         rowKey={(card) => card.id}
         handleColumn="org"
-        sort={sort}
-        onSort={onSort}
+        sort={null}
+        onSort={ignoreSort}
         onOpen={(card) => setOpenId(card.id)}
         caption="영업 현황 목록. 헤더를 눌러 정렬할 수 있습니다."
         renderCell={(id, card) => {
@@ -328,12 +312,12 @@ export default function Deals() {
         }
       />
 
-      {!error && !loading && matched.length > 0 && (
+      {!error && !loading && pageRows.length > 0 && (
         <Pagination
-          page={safePage}
+          page={page}
           pageCount={pageCount}
           pageSize={pageSize}
-          total={matched.length}
+          total={total}
           unit="건"
           onPage={setPage}
           onPageSize={(size) => {

--- a/frontend/src/pages/Deals/useSalesDeals.ts
+++ b/frontend/src/pages/Deals/useSalesDeals.ts
@@ -12,6 +12,7 @@ import type {
   SalesDealMoveRequest,
   SalesDealPatchRequest,
   SalesDealResponse,
+  TabbedPageResponse,
   SalesDealStatus,
   SalesDealTypeResponse,
   SalesPipelineOutcomeCode,
@@ -208,6 +209,50 @@ async function fetchAllSalesDeals(
   return (await fetchAllPage<SalesDealResponse>('/sales-deals', signal, params)).map(toSalesDeal)
 }
 
+export interface SalesDealQuery {
+  q: string
+  /** 고른 단계 탭. 빈 문자열이면 전체입니다. */
+  stageId: string
+  /** 담당자. 빈 문자열이면 전체입니다. */
+  ownerMemberId: string
+  /** 시작일 하한. null 이면 제한 없음입니다. */
+  fromISO: string | null
+  skip: number
+  limit: number
+}
+
+interface SalesDealPageResult {
+  cards: SalesDeal[]
+  total: number
+  counts: Record<string, number>
+}
+
+async function fetchSalesDealPage(
+  signal: AbortSignal,
+  pipelineId: string | null | undefined,
+  phaseCode: SalesPipelinePhaseCode | undefined,
+  ownerIds: readonly string[] | undefined,
+  query: SalesDealQuery,
+): Promise<SalesDealPageResult> {
+  const needle = query.q.trim()
+  const { data } = await client.get<TabbedPageResponse<SalesDealResponse>>('/sales-deals', {
+    params: {
+      ...(pipelineId ? { sales_pipeline_id: pipelineId } : {}),
+      ...(phaseCode ? { phase_code: phaseCode } : {}),
+      // 담당자를 고르면 그 사람만, 아니면 보기 범위를 따릅니다.
+      owner_member_id: query.ownerMemberId === '' ? ownerIds : [query.ownerMemberId],
+      q: needle === '' ? undefined : needle.slice(0, 100),
+      // 파이프라인을 고르지 않으면 단계 탭이 뜨지 않으므로 단계도 걸지 않습니다.
+      sales_pipeline_stage_id: pipelineId && query.stageId !== '' ? query.stageId : undefined,
+      start_date: query.fromISO ?? undefined,
+      skip: query.skip,
+      limit: query.limit,
+    },
+    signal,
+  })
+  return { cards: data.items.map(toSalesDeal), total: data.total, counts: data.counts }
+}
+
 function toCreateRequest(
   input: SalesDealSaveInput,
   pipelineId: string,
@@ -244,17 +289,26 @@ function toPatchRequest(
   }
 }
 
+/**
+ * `query` 를 주면 목록을 한 쪽씩 받습니다. 주지 않으면 전건을 받습니다.
+ *
+ * 칸반과 매출 요약은 열 머리의 합계·기간별 집계를 전건 위에서 계산하므로 아직 전건이
+ * 필요합니다. 목록 화면만 쪽으로 끊습니다.
+ */
 export default function useSalesDeals(
   openId: string | null,
   requestedPipelineId: string | null,
   mode: 'list' | 'board',
   phaseCode?: SalesPipelinePhaseCode,
+  query?: SalesDealQuery,
 ) {
   const [pipelines, setPipelines] = useState<SalesPipelineResponse[]>([])
   const [dealPipelineId, setDealPipelineId] = useState<string | null>(null)
   const [stagePipelineId, setStagePipelineId] = useState<string | null>(null)
   const [columns, setColumns] = useState<SalesDealColumn[]>([])
   const [cards, setCards] = useState<SalesDeal[]>([])
+  const [total, setTotal] = useState(0)
+  const [counts, setCounts] = useState<Record<string, number>>({})
   const [companies, setCompanies] = useState<SalesDealOption[]>([])
   const [products, setProducts] = useState<SalesDealOption[]>([])
   const [dealTypes, setDealTypes] = useState<SalesDealTypeResponse[]>([])
@@ -271,6 +325,19 @@ export default function useSalesDeals(
   const [pendingKeys, setPendingKeys] = useState<ReadonlySet<string>>(() => new Set())
   const [mutationError, setMutationError] = useState<string | null>(null)
   const ownerIds = useScopeOwnerIds()
+  const [optionsReady, setOptionsReady] = useState(false)
+
+  // 조회 조건을 낱개로 펼쳐 둡니다. 아래 효과가 객체가 아니라 값 하나하나를 보게 해야,
+  // 화면이 조건 객체를 새로 만들 때마다 다시 받지 않습니다.
+  const paging = query !== undefined
+  const {
+    q: queryText = '',
+    stageId: queryStageId = '',
+    ownerMemberId: queryOwnerId = '',
+    fromISO: queryFrom = null,
+    skip: querySkip = 0,
+    limit: queryLimit = 30,
+  } = query ?? {}
 
   useEffect(() => {
     const controller = new AbortController()
@@ -300,7 +367,11 @@ export default function useSalesDeals(
                   )
                   .then((response) => response.data)
               : Promise.resolve([]),
-            fetchAllSalesDeals(controller.signal, filteredPipelineId, phaseCode, ownerIds),
+            // 조회 조건을 받은 목록 화면은 아래 효과가 한 쪽만 받습니다. 여기서 전건을
+            // 받는 것은 칸반과 매출 요약처럼 전건 집계가 필요한 쪽뿐입니다.
+            paging
+              ? Promise.resolve([])
+              : fetchAllSalesDeals(controller.signal, filteredPipelineId, phaseCode, ownerIds),
             // 고객사와 제품은 딜을 등록할 때 고르는 참조 목록이라 범위로 좁히지 않습니다.
             fetchAllPage<CustomerCompanyResponse>('/customer-companies', controller.signal),
             fetchAllPage<ProductResponse>('/products', controller.signal),
@@ -314,10 +385,11 @@ export default function useSalesDeals(
         setDealPipelineId(filteredPipelineId ?? null)
         setStagePipelineId(stagePipeline?.id ?? null)
         setColumns(stageItems.map(toColumn))
-        setCards(dealItems)
+        if (!paging) setCards(dealItems)
         setCompanies(companyItems.map(({ id, name }) => ({ id, name })))
         setProducts(productItems.map(({ id, name }) => ({ id, name })))
         setDealTypes(dealTypeItems)
+        setOptionsReady(true)
       })
       .catch((caught: unknown) => {
         if (!controller.signal.aborted) setError(requestErrorMessage(caught, '목록'))
@@ -327,7 +399,52 @@ export default function useSalesDeals(
       })
 
     return () => controller.abort()
-  }, [mode, phaseCode, reloadKey, requestedPipelineId, ownerIds])
+  }, [mode, phaseCode, reloadKey, requestedPipelineId, ownerIds, paging])
+
+  // 목록 한 쪽. 파이프라인을 정한 뒤에 부릅니다. 정하기 전에 부르면 전체 파이프라인의
+  // 딜이 잠깐 보였다가 바뀝니다.
+  useEffect(() => {
+    if (!paging || !optionsReady) return
+    const controller = new AbortController()
+    setLoading(true)
+    setError(null)
+
+    void fetchSalesDealPage(controller.signal, dealPipelineId, phaseCode, ownerIds, {
+      q: queryText,
+      stageId: queryStageId,
+      ownerMemberId: queryOwnerId,
+      fromISO: queryFrom,
+      skip: querySkip,
+      limit: queryLimit,
+    })
+      .then(({ cards: pageCards, total: pageTotal, counts: pageCounts }) => {
+        if (controller.signal.aborted) return
+        setCards(pageCards)
+        setTotal(pageTotal)
+        setCounts(pageCounts)
+      })
+      .catch((caught: unknown) => {
+        if (!controller.signal.aborted) setError(requestErrorMessage(caught, '목록'))
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false)
+      })
+
+    return () => controller.abort()
+  }, [
+    paging,
+    optionsReady,
+    dealPipelineId,
+    phaseCode,
+    ownerIds,
+    reloadKey,
+    queryText,
+    queryStageId,
+    queryOwnerId,
+    queryFrom,
+    querySkip,
+    queryLimit,
+  ])
 
   useEffect(() => {
     if (openId === null) {
@@ -471,6 +588,8 @@ export default function useSalesDeals(
     activePipeline,
     columns,
     cards,
+    total,
+    counts,
     companies,
     products,
     dealTypes,

--- a/frontend/src/pages/Documents/Documents.tsx
+++ b/frontend/src/pages/Documents/Documents.tsx
@@ -64,7 +64,7 @@ export default function Documents() {
 
   const [sort, setSort] = useState<SortState>(null)
   const [page, setPage] = useState(1)
-  const [pageSize, setPageSize] = useState(25)
+  const [pageSize, setPageSize] = useState(30)
   const [openId, setOpenId] = useState<string | null>(null)
   const [openFilter, setOpenFilter] = useState<'owner' | 'range' | null>(null)
   /** 업로드 모달. 'new' 는 새 문서, 문서 id 면 그 문서의 새 버전입니다. */

--- a/frontend/src/pages/Documents/Documents.tsx
+++ b/frontend/src/pages/Documents/Documents.tsx
@@ -17,8 +17,6 @@ import { InlineLoader, ListPageSkeleton } from '@/components/Skeleton'
 import type { DocumentCategory } from '@/types'
 import { addDays, iso, TODAY } from '@/utils/date'
 
-import { latestOf } from './catalog'
-import { compareBy, linkLabel, type SortState } from './columns'
 import CategoryTabs from './components/CategoryTabs'
 import DocumentDrawer from './components/DocumentDrawer'
 import DocumentTable from './components/DocumentTable'
@@ -39,8 +37,6 @@ const RANGES = [
 const DEFAULT_RANGE = '12'
 
 export default function Documents() {
-  const { documents, findDocument, loading, error, pending, reload, addDocument, addVersion } =
-    useDocuments()
   // 자료를 올리는 것은 팀장 몫입니다. 팀원은 받아 보기만 합니다.
   const { profile, isManager } = useCurrentUser()
   const showOwner = isManager
@@ -50,19 +46,11 @@ export default function Documents() {
   const owner = showOwner ? (params.get('owner') ?? '') : ''
   const range = params.get('range') ?? DEFAULT_RANGE
 
-  const ownerOptions = useMemo(() => {
-    const names = [...new Set(documents.map((doc) => latestOf(doc).owner))].sort()
-    return [
-      { value: '', label: '등록자 전체' },
-      ...names.map((name) => ({ value: name, label: name })),
-    ]
-  }, [documents])
   const category = params.get('category') ?? ''
 
   // 타이핑 중에도 입력이 밀리지 않도록 목록 계산만 한 박자 늦춥니다.
   const deferredQuery = useDeferredValue(query)
 
-  const [sort, setSort] = useState<SortState>(null)
   const [page, setPage] = useState(1)
   const [pageSize, setPageSize] = useState(30)
   const [openId, setOpenId] = useState<string | null>(null)
@@ -89,54 +77,51 @@ export default function Documents() {
     return iso(addDays(TODAY, -Math.round(months * 30.4)))
   }, [range])
 
-  // 분류를 뺀 나머지 조건까지만 거른 목록입니다. 탭의 건수를 여기서 셉니다.
-  const beforeCategory = useMemo(() => {
-    const needle = deferredQuery.trim().toLowerCase()
-    return documents.filter((doc) => {
-      const latest = latestOf(doc)
-      if (owner !== '' && latest.owner !== owner) return false
-      if (fromISO !== null && latest.uploaded < fromISO) return false
-      if (needle === '') return true
-      // 숨은 값(설명·태그·파일명)까지 봅니다. 표에 안 보여도 사람은 그 낱말로 찾습니다.
-      return [doc.title, doc.description, latest.fileName, latest.owner, linkLabel(doc)]
-        .concat(doc.tags)
-        .join(' ')
-        .toLowerCase()
-        .includes(needle)
-    })
-  }, [documents, owner, fromISO, deferredQuery])
-
-  const categoryCounts = useMemo(() => {
-    const map = new Map<DocumentCategory, number>()
-    for (const doc of beforeCategory) map.set(doc.category, (map.get(doc.category) ?? 0) + 1)
-    return map
-  }, [beforeCategory])
-
-  const matched = useMemo(() => {
-    const rows =
-      category === '' ? beforeCategory : beforeCategory.filter((doc) => doc.category === category)
-    if (!sort) return rows
-    const sign = sort.dir === 'asc' ? 1 : -1
-    const compare = compareBy(sort.id)
-    return [...rows].sort((a, b) => sign * compare(a, b))
-  }, [beforeCategory, category, sort])
-
-  // 결과가 줄어들어 현재 페이지가 사라졌으면 마지막 페이지로 당겨 옵니다.
-  const pageCount = Math.max(1, Math.ceil(matched.length / pageSize))
-  const safePage = Math.min(page, pageCount)
-  const pageRows = useMemo(
-    () => matched.slice((safePage - 1) * pageSize, safePage * pageSize),
-    [matched, safePage, pageSize],
+  const documentQuery = useMemo(
+    () => ({
+      q: deferredQuery,
+      category: category as DocumentCategory | '',
+      uploaderMemberId: owner,
+      fromISO,
+      skip: (page - 1) * pageSize,
+      limit: pageSize,
+    }),
+    [deferredQuery, category, owner, fromISO, page, pageSize],
   )
 
-  const onSort = useCallback((id: string) => {
-    // 오름 → 내림 → 해제. 원래 순서로 되돌릴 방법이 있어야 합니다.
-    setSort((prev) => {
-      if (prev?.id !== id) return { id, dir: 'asc' }
-      if (prev.dir === 'asc') return { id, dir: 'desc' }
-      return null
-    })
-  }, [])
+  const {
+    documents: pageRows,
+    total,
+    counts,
+    uploaders,
+    findDocument,
+    loading,
+    error,
+    pending,
+    reload,
+    addDocument,
+    addVersion,
+  } = useDocuments(documentQuery)
+
+  // 분류 탭 옆 건수는 서버가 셉니다. 고른 분류는 빼고 센 값입니다.
+  const categoryCounts = useMemo(() => new Map(Object.entries(counts)), [counts])
+  const categoryTotal = useMemo(
+    () => [...categoryCounts.values()].reduce((sum, count) => sum + count, 0),
+    [categoryCounts],
+  )
+  const pageCount = Math.max(1, Math.ceil(total / pageSize))
+
+  // 등록자 선택지. 받아 둔 목록에서 뽑으면 지금 쪽에 있는 사람만 나옵니다.
+  const ownerOptions = useMemo(
+    () => [
+      { value: '', label: '등록자 전체' },
+      ...uploaders.map((item) => ({ value: item.id, label: item.name })),
+    ],
+    [uploaders],
+  )
+
+  // 헤더 정렬을 끄므로 누를 일이 없습니다. 고객 목록과 같은 처리입니다.
+  const ignoreSort = useCallback(() => undefined, [])
 
   const clearFilters = useCallback(() => {
     setParams(new URLSearchParams(), { replace: true })
@@ -176,7 +161,7 @@ export default function Documents() {
 
   // 첫 진입입니다. 툴바·탭·표가 차례로 나타나면 화면이 두세 번 들썩이므로
   // 화면 한 장을 통째로 자리표시자로 두고 다 받은 뒤 한 번에 바꿉니다.
-  if (loading && documents.length === 0 && !error) {
+  if (loading && pageRows.length === 0 && !error) {
     return (
       <section className={styles.page} aria-busy={loading || pending}>
         {/* Topbar 빵부스러기가 이미 화면 이름을 말하므로 제목은 읽어 주기만 합니다. */}
@@ -235,18 +220,18 @@ export default function Documents() {
       <CategoryTabs
         value={category}
         countOf={(id) => categoryCounts.get(id) ?? 0}
-        total={beforeCategory.length}
+        total={categoryTotal}
         onChange={(next) => setParam('category', next)}
       />
 
-      {!error && loading && documents.length > 0 && (
+      {!error && loading && pageRows.length > 0 && (
         <InlineLoader label="자료 목록을 새로고침하는 중입니다." />
       )}
 
       <DocumentTable
         rows={pageRows}
-        sort={sort}
-        onSort={onSort}
+        sort={null}
+        onSort={ignoreSort}
         onOpen={setOpenId}
         isFiltered={isFiltered}
         onClearFilters={clearFilters}
@@ -255,12 +240,12 @@ export default function Documents() {
         onUpload={() => setUploading('new')}
       />
 
-      {matched.length > 0 && (
+      {pageRows.length > 0 && (
         <Pagination
-          page={safePage}
+          page={page}
           pageCount={pageCount}
           pageSize={pageSize}
-          total={matched.length}
+          total={total}
           unit="건"
           onPage={setPage}
           onPageSize={(size) => {

--- a/frontend/src/pages/Documents/useDocuments.ts
+++ b/frontend/src/pages/Documents/useDocuments.ts
@@ -9,13 +9,31 @@ import type {
   DocumentVersion,
   OrderResponse,
   PageResponse,
+  TabbedPageResponse,
   SalesDealResponse,
   SalesDocument,
 } from '@/types'
 
 import { kindOfFile } from './catalog'
 
+/**
+ * 저장할 때 연결 대상(고객사·계약·발주)을 이름으로 찾는 조회에만 씁니다. 자료 목록
+ * 자체는 서버가 쪽으로 끊어 줍니다.
+ *
+ * ponytail: 같은 이름 후보가 100건을 넘으면 정확히 맞는 것을 놓칩니다. 원래 있던 한계라
+ * 이번에 건드리지 않았습니다. 정확일치 조회 파라미터가 생기면 그때 바꿉니다.
+ */
 const PAGE_LIMIT = 100
+
+/** 등록자 고르는 칸에 세울 사람. 최신 버전을 올린 사람 기준입니다. */
+export interface DocumentUploader {
+  id: string
+  name: string
+}
+
+interface DocumentPageResponse extends TabbedPageResponse<DocumentResponse> {
+  uploaders: { member_id: string; display_name: string }[]
+}
 const CATEGORY_CODE: Record<DocumentCategory, string> = {
   계약서: 'contract',
   발주서: 'purchase_order',
@@ -88,22 +106,6 @@ function toDocument(item: DocumentResponse): SalesDocument {
   }
 }
 
-async function fetchAll<T>(path: string, signal?: AbortSignal): Promise<T[]> {
-  const result: T[] = []
-  let skip = 0
-  while (!signal?.aborted) {
-    const { data } = await client.get<PageResponse<T>>(path, {
-      params: { skip, limit: PAGE_LIMIT },
-      signal,
-    })
-    result.push(...data.items)
-    if (!data.has_more || data.next_skip === null) return result
-    if (data.next_skip <= skip) throw new Error('invalid_pagination')
-    skip = data.next_skip
-  }
-  return result
-}
-
 async function resolveLink(link: SalesDocument['link']) {
   const empty = {
     customer_company_id: null,
@@ -153,20 +155,67 @@ function mutationMessage(reason: unknown, fallback: string): string {
   return errorMessage(reason, fallback)
 }
 
-export default function useDocuments() {
+export interface DocumentQuery {
+  q: string
+  /** 고른 분류 탭. 빈 문자열이면 전체입니다. */
+  category: DocumentCategory | ''
+  /** 최신 버전을 올린 사람. 빈 문자열이면 전체입니다. */
+  uploaderMemberId: string
+  /** 최신 버전을 올린 날짜의 하한. null 이면 제한 없음입니다. */
+  fromISO: string | null
+  skip: number
+  limit: number
+}
+
+export default function useDocuments(query?: DocumentQuery) {
   const [documents, setDocuments] = useState<SalesDocument[]>([])
+  const [total, setTotal] = useState(0)
+  const [counts, setCounts] = useState<Record<string, number>>({})
+  const [uploaders, setUploaders] = useState<DocumentUploader[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [pending, setPending] = useState(false)
   const [reloadKey, setReloadKey] = useState(0)
 
+  // 조회 조건을 낱개로 펼쳐 둡니다. 효과가 객체가 아니라 값 하나하나를 보게 해야, 화면이
+  // 조건 객체를 새로 만들 때마다 다시 받지 않습니다.
+  const {
+    q: queryText = '',
+    category: queryCategory = '',
+    uploaderMemberId: queryUploader = '',
+    fromISO: queryFrom = null,
+    skip: querySkip = 0,
+    limit: queryLimit = 30,
+  } = query ?? {}
+
   useEffect(() => {
     const controller = new AbortController()
     setLoading(true)
     setError(null)
-    void fetchAll<DocumentResponse>('/documents', controller.signal)
-      .then((items) => {
-        if (!controller.signal.aborted) setDocuments(items.map(toDocument))
+    const needle = queryText.trim()
+    void client
+      .get<DocumentPageResponse>('/documents', {
+        params: {
+          q: needle === '' ? undefined : needle.slice(0, 100),
+          category_code: queryCategory === '' ? undefined : CATEGORY_CODE[queryCategory],
+          latest_uploader_member_id: queryUploader === '' ? undefined : queryUploader,
+          latest_uploaded_from: queryFrom === null ? undefined : `${queryFrom}T00:00:00+09:00`,
+          skip: querySkip,
+          limit: queryLimit,
+        },
+        signal: controller.signal,
+      })
+      .then(({ data }) => {
+        if (controller.signal.aborted) return
+        setDocuments(data.items.map(toDocument))
+        setTotal(data.total)
+        setCounts(data.counts)
+        setUploaders(
+          data.uploaders.map(({ member_id, display_name }) => ({
+            id: member_id,
+            name: display_name,
+          })),
+        )
       })
       .catch((reason: unknown) => {
         if (!controller.signal.aborted) {
@@ -178,7 +227,7 @@ export default function useDocuments() {
         if (!controller.signal.aborted) setLoading(false)
       })
     return () => controller.abort()
-  }, [reloadKey])
+  }, [reloadKey, queryText, queryCategory, queryUploader, queryFrom, querySkip, queryLimit])
 
   const findDocument = useCallback(
     (id: string) => documents.find((document) => document.id === id),
@@ -257,6 +306,9 @@ export default function useDocuments() {
 
   return {
     documents,
+    total,
+    counts,
+    uploaders,
     findDocument,
     loading,
     error,

--- a/frontend/src/pages/Meetings/Compose.tsx
+++ b/frontend/src/pages/Meetings/Compose.tsx
@@ -13,7 +13,7 @@ import Modal from '@/components/Modal'
 import { SkeletonDetail } from '@/components/Skeleton'
 import Tabs from '@/components/Tabs'
 import { meetingReportPath, ROUTES } from '@/constants/routes'
-import { useAgendaState } from '@/shared/agenda'
+import { useAgendaItem } from '@/shared/agenda'
 import { showToast } from '@/shared/toast'
 import { fmtDot, parseISO } from '@/utils/date'
 
@@ -37,12 +37,11 @@ export default function Compose() {
 
   const agendaId = params.get('agenda') ?? ''
   const {
-    items: agenda,
+    item,
     loading: agendaLoading,
     error: agendaError,
     reload: reloadAgenda,
-  } = useAgendaState(undefined, undefined, true)
-  const item = agendaId ? agenda.find((entry) => entry.id === agendaId) : undefined
+  } = useAgendaItem(agendaId)
 
   const { findByAgenda, saveReport, saveDraft, loading, error, pending, reload } =
     useMeetingReports()

--- a/frontend/src/pages/Meetings/useMeetingReports.ts
+++ b/frontend/src/pages/Meetings/useMeetingReports.ts
@@ -108,6 +108,19 @@ export interface MeetingDraftPayload {
   aiGeneratedAt?: string
 }
 
+/**
+ * 이 일정으로 이미 쓴 보고서의 번호. 저장할 때 새로 만들지 고칠지를 이걸로 가릅니다.
+ *
+ * 목록에서 찾으면 그 보고서가 현재 페이지 밖일 때 못 찾고 같은 일정에 보고서를 하나 더
+ * 만듭니다. 서버에 직접 물어야 합니다.
+ */
+async function savedIdForAgenda(agendaId: string): Promise<string | undefined> {
+  const { data } = await client.get<PageResponse<ReportResponse>>('/reports', {
+    params: { report_kind: 'meeting', source_activity_id: agendaId, limit: 1 },
+  })
+  return data.items[0]?.id
+}
+
 function requestOf(draft: MeetingDraftPayload): ReportWriteRequest {
   return {
     report_kind: 'meeting',
@@ -183,39 +196,36 @@ export default function useMeetingReports() {
     [reports],
   )
 
-  const save = useCallback(
-    async (draft: MeetingDraftPayload, submit: boolean) => {
-      setPending(true)
-      setError(null)
-      try {
-        const existing = findByAgenda(draft.agendaId)
-        const request = requestOf(draft)
-        const { report_kind: _kind, source_activity_id: _source, ...patch } = request
-        const saved = existing
-          ? await client.patch<ReportResponse>(`/reports/${existing.id}`, patch)
-          : await client.post<ReportResponse>('/reports', request)
-        const response = submit
-          ? await client.post<ReportResponse>(`/reports/${saved.data.id}/submit`, {
-              expected_status_code: 'draft',
-            })
-          : saved
-        const report = toReport(response.data)
-        setReports((current) => [report, ...current.filter((item) => item.id !== report.id)])
-        return report
-      } catch (reason: unknown) {
-        setError(
-          errorMessage(
-            reason,
-            submit ? '미팅 기록을 확정하지 못했습니다.' : '임시저장하지 못했습니다.',
-          ),
-        )
-        throw reason
-      } finally {
-        setPending(false)
-      }
-    },
-    [findByAgenda],
-  )
+  const save = useCallback(async (draft: MeetingDraftPayload, submit: boolean) => {
+    setPending(true)
+    setError(null)
+    try {
+      const existingId = await savedIdForAgenda(draft.agendaId)
+      const request = requestOf(draft)
+      const { report_kind: _kind, source_activity_id: _source, ...patch } = request
+      const saved = existingId
+        ? await client.patch<ReportResponse>(`/reports/${existingId}`, patch)
+        : await client.post<ReportResponse>('/reports', request)
+      const response = submit
+        ? await client.post<ReportResponse>(`/reports/${saved.data.id}/submit`, {
+            expected_status_code: 'draft',
+          })
+        : saved
+      const report = toReport(response.data)
+      setReports((current) => [report, ...current.filter((item) => item.id !== report.id)])
+      return report
+    } catch (reason: unknown) {
+      setError(
+        errorMessage(
+          reason,
+          submit ? '미팅 기록을 확정하지 못했습니다.' : '임시저장하지 못했습니다.',
+        ),
+      )
+      throw reason
+    } finally {
+      setPending(false)
+    }
+  }, [])
 
   return {
     reports,

--- a/frontend/src/pages/Orders/Orders.tsx
+++ b/frontend/src/pages/Orders/Orders.tsx
@@ -8,7 +8,7 @@ import { useNavigate, useSearchParams } from 'react-router'
 
 import { useCurrentUser } from '@/auth/sessionContext'
 import Button from '@/components/Button'
-import DataTable, { compareBy, type SortState } from '@/components/DataTable'
+import DataTable from '@/components/DataTable'
 import ErrorToast from '@/components/ErrorToast'
 import FilterSelect from '@/components/FilterSelect'
 import { OrdersIcon, PlusIcon, SearchIcon } from '@/components/icons'
@@ -43,22 +43,6 @@ const RANGES = [
 const DEFAULT_RANGE = '6'
 
 export default function Orders() {
-  const {
-    orders,
-    salesDeals,
-    statuses,
-    products,
-    suppliers,
-    loading,
-    error,
-    reload,
-    mutationError,
-    clearMutationError,
-    isPending,
-    findOrderById,
-    updateOrder,
-    removeOrder,
-  } = useOrderList()
   const navigate = useNavigate()
   const { isManager } = useCurrentUser()
 
@@ -71,7 +55,6 @@ export default function Orders() {
   // 타이핑 중에도 입력이 밀리지 않도록 목록 계산만 한 박자 늦춥니다.
   const deferredQuery = useDeferredValue(query)
 
-  const [sort, setSort] = useState<SortState>(null)
   const [page, setPage] = useState(1)
   const [pageSize, setPageSize] = useState(30)
   const [openId, setOpenId] = useState<string | null>(null)
@@ -80,22 +63,16 @@ export default function Orders() {
   const [openFilter, setOpenFilter] = useState<'supplier' | 'range' | null>(null)
 
   // 한 사람만 보고 있으면 담당 영업 열은 모든 줄이 같은 값이라 자리만 차지합니다.
+  //
+  // 정렬 API가 붙기 전에 현재 쪽만 정렬하면 전체 순서를 오해하게 됩니다. 고객 목록과
+  // 같은 처리로 헤더 정렬을 끕니다.
   const columns = useMemo(
-    () => ORDER_COLUMNS.filter((col) => col.id !== 'owner' || isManager),
+    () =>
+      ORDER_COLUMNS.filter((col) => col.id !== 'owner' || isManager).map((col) => ({
+        ...col,
+        sortable: false,
+      })),
     [isManager],
-  )
-
-  const supplierOptions = useMemo(
-    () => [
-      { value: '', label: '공급처 전체' },
-      ...suppliers.map((name) => ({ value: name, label: name })),
-    ],
-    [suppliers],
-  )
-
-  const orderStages = useMemo(
-    () => statuses.map(({ code, name, tone }) => ({ id: code, name, tone })),
-    [statuses],
   )
 
   // 기본값은 쿼리에서 지웁니다. 주소를 복사했을 때 조건이 그대로 살아나되 짧게 남습니다.
@@ -117,51 +94,58 @@ export default function Orders() {
     return iso(addDays(TODAY, -Math.round(months * 30.4)))
   }, [range])
 
-  // 상태를 뺀 나머지 조건까지만 거른 목록입니다. 탭의 건수를 여기서 셉니다.
-  const beforeStatus = useMemo(() => {
-    const needle = deferredQuery.trim().toLowerCase()
-    return orders.filter((order) => {
-      if (supplier !== '' && order.supplier !== supplier) return false
-      if (fromISO !== null && order.ordered < fromISO) return false
-      if (needle === '') return true
-      return [order.no, order.hospital, order.supplier, order.salesDeal, order.memo]
-        .concat(orderItemLabel(order))
-        .join(' ')
-        .toLowerCase()
-        .includes(needle)
-    })
-  }, [orders, supplier, fromISO, deferredQuery])
-
-  const statusCounts = useMemo(() => {
-    const map = new Map<string, number>()
-    for (const order of beforeStatus) map.set(order.stageCode, (map.get(order.stageCode) ?? 0) + 1)
-    return map
-  }, [beforeStatus])
-
-  const matched = useMemo(() => {
-    const rows = status === '' ? beforeStatus : beforeStatus.filter((o) => o.stageCode === status)
-    if (!sort) return rows
-    const sign = sort.dir === 'asc' ? 1 : -1
-    const compare = compareBy(columns, sort.id)
-    return [...rows].sort((a, b) => sign * compare(a, b))
-  }, [beforeStatus, status, sort, columns])
-
-  // 결과가 줄어들어 현재 페이지가 사라졌으면 마지막 페이지로 당겨 옵니다.
-  const pageCount = Math.max(1, Math.ceil(matched.length / pageSize))
-  const safePage = Math.min(page, pageCount)
-  const pageRows = useMemo(
-    () => matched.slice((safePage - 1) * pageSize, safePage * pageSize),
-    [matched, safePage, pageSize],
+  const orderQuery = useMemo(
+    () => ({
+      q: deferredQuery,
+      supplier,
+      fromISO,
+      status,
+      skip: (page - 1) * pageSize,
+      limit: pageSize,
+    }),
+    [deferredQuery, supplier, fromISO, status, page, pageSize],
   )
 
-  const onSort = useCallback((id: string) => {
-    // 오름 → 내림 → 해제. 원래 순서로 되돌릴 방법이 있어야 합니다.
-    setSort((prev) => {
-      if (prev?.id !== id) return { id, dir: 'asc' }
-      if (prev.dir === 'asc') return { id, dir: 'desc' }
-      return null
-    })
-  }, [])
+  const {
+    orders: pageRows,
+    total,
+    counts,
+    salesDeals,
+    statuses,
+    products,
+    suppliers,
+    loading,
+    error,
+    reload,
+    mutationError,
+    clearMutationError,
+    isPending,
+    findOrderById,
+    updateOrder,
+    removeOrder,
+  } = useOrderList(undefined, orderQuery)
+
+  const supplierOptions = useMemo(
+    () => [
+      { value: '', label: '공급처 전체' },
+      ...suppliers.map((name) => ({ value: name, label: name })),
+    ],
+    [suppliers],
+  )
+
+  const orderStages = useMemo(
+    () => statuses.map(({ code, name, tone }) => ({ id: code, name, tone })),
+    [statuses],
+  )
+
+  // 탭 옆 건수는 서버가 셉니다. 고른 상태는 빼고 센 값이라 탭을 바꿔도 다른 탭 숫자가
+  // 0 으로 죽지 않습니다.
+  const statusCounts = useMemo(() => new Map(Object.entries(counts)), [counts])
+
+  const pageCount = Math.max(1, Math.ceil(total / pageSize))
+
+  // 헤더 정렬을 끄므로 누를 일이 없습니다. 고객 목록과 같은 처리입니다.
+  const ignoreSort = useCallback(() => undefined, [])
 
   const clearFilters = useCallback(() => {
     setParams(new URLSearchParams(), { replace: true })
@@ -180,7 +164,7 @@ export default function Orders() {
 
   // 첫 진입입니다. 툴바·탭·표가 차례로 나타나면 화면이 두세 번 들썩이므로
   // 화면 한 장을 통째로 자리표시자로 두고 다 받은 뒤 한 번에 바꿉니다.
-  if (loading && orders.length === 0 && !error) {
+  if (loading && pageRows.length === 0 && !error) {
     return (
       <section className={styles.page} aria-busy={loading}>
         {/* Topbar 빵부스러기가 이미 화면 이름을 말하므로 제목은 읽어 주기만 합니다. */}
@@ -235,7 +219,7 @@ export default function Orders() {
         label="발주 상태"
         value={status}
         countOf={(id) => statusCounts.get(id) ?? 0}
-        total={beforeStatus.length}
+        total={[...statusCounts.values()].reduce((sum, count) => sum + count, 0)}
         onChange={(next) => setParam('status', next)}
       />
 
@@ -254,7 +238,7 @@ export default function Orders() {
         </div>
       )}
 
-      {!error && loading && orders.length > 0 && (
+      {!error && loading && pageRows.length > 0 && (
         <InlineLoader label="목록을 새로고침하는 중입니다." />
       )}
 
@@ -265,10 +249,10 @@ export default function Orders() {
         columns={columns}
         rowKey={(order) => order.id}
         handleColumn="hospital"
-        sort={sort}
-        onSort={onSort}
+        sort={null}
+        onSort={ignoreSort}
         onOpen={(order) => setOpenId(order.id)}
-        caption="발주 목록. 헤더를 눌러 정렬할 수 있습니다."
+        caption="발주 목록."
         renderCell={(id, order) => {
           if (id === 'status') return statusChip(order)
           if (id !== 'due' || !isLate(order)) return undefined
@@ -318,12 +302,12 @@ export default function Orders() {
         }
       />
 
-      {matched.length > 0 && (
+      {pageRows.length > 0 && (
         <Pagination
-          page={safePage}
+          page={page}
           pageCount={pageCount}
           pageSize={pageSize}
-          total={matched.length}
+          total={total}
           unit="건"
           onPage={setPage}
           onPageSize={(size) => {

--- a/frontend/src/pages/Orders/Orders.tsx
+++ b/frontend/src/pages/Orders/Orders.tsx
@@ -73,7 +73,7 @@ export default function Orders() {
 
   const [sort, setSort] = useState<SortState>(null)
   const [page, setPage] = useState(1)
-  const [pageSize, setPageSize] = useState(25)
+  const [pageSize, setPageSize] = useState(30)
   const [openId, setOpenId] = useState<string | null>(null)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [deletingId, setDeletingId] = useState<string | null>(null)

--- a/frontend/src/pages/Orders/useOrderList.ts
+++ b/frontend/src/pages/Orders/useOrderList.ts
@@ -222,16 +222,12 @@ export default function useOrderList(detailNo?: string) {
     return () => controller.abort()
   }, [reloadKey, ownerIds])
 
+  // 번호로 서버에 직접 묻습니다. 목록에서 찾으면 그 발주가 현재 페이지 밖일 때 상세가
+  // 열리지 않습니다. 목록과 상세가 같은 모델이라 이 한 번으로 상세까지 받습니다.
   useEffect(() => {
     setDetail(null)
     setDetailError(null)
-    if (detailNo === undefined || loading) {
-      setDetailLoading(detailNo !== undefined && loading)
-      return
-    }
-
-    const summary = orders.find((order) => order.no === detailNo)
-    if (!summary) {
+    if (detailNo === undefined) {
       setDetailLoading(false)
       return
     }
@@ -239,9 +235,12 @@ export default function useOrderList(detailNo?: string) {
     const controller = new AbortController()
     setDetailLoading(true)
     void client
-      .get<OrderResponse>(`/orders/${summary.id}`, { signal: controller.signal })
+      .get<PageResponse<OrderResponse>>('/orders', {
+        params: { order_no: detailNo, limit: 1 },
+        signal: controller.signal,
+      })
       .then(({ data }) => {
-        if (!controller.signal.aborted) setDetail(toOrder(data))
+        if (!controller.signal.aborted) setDetail(data.items[0] ? toOrder(data.items[0]) : null)
       })
       .catch((caught: unknown) => {
         if (!controller.signal.aborted) setDetailError(requestErrorMessage(caught, '상세'))
@@ -251,7 +250,7 @@ export default function useOrderList(detailNo?: string) {
       })
 
     return () => controller.abort()
-  }, [detailNo, detailReloadKey, loading, orders])
+  }, [detailNo, detailReloadKey])
 
   const reload = useCallback(() => setReloadKey((value) => value + 1), [])
   const reloadDetail = useCallback(() => setDetailReloadKey((value) => value + 1), [])

--- a/frontend/src/pages/Orders/useOrderList.ts
+++ b/frontend/src/pages/Orders/useOrderList.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { isAxiosError } from 'axios'
 
 import { client } from '@/api/client'
@@ -9,6 +9,7 @@ import type {
   OrderCreateRequest,
   OrderMoveRequest,
   OrderPatchRequest,
+  OrderPageResponse,
   OrderResponse,
   PageResponse,
   ProductResponse,
@@ -90,12 +91,12 @@ export function toOrder(order: OrderResponse): ApiPurchaseOrder {
   }
 }
 
+/** 등록 폼의 선택지 목록에만 씁니다. 발주 목록 자체는 서버가 쪽으로 끊어 줍니다. */
 async function fetchAllPage<T>(
   path: string,
   signal?: AbortSignal,
   extraParams?: Record<string, unknown>,
 ): Promise<T[]> {
-  // ponytail: 현재 화면의 필터·탭 건수는 전건 기준입니다. 데이터가 커지면 서버 집계로 바꿉니다.
   const items: T[] = []
   let skip = 0
 
@@ -111,16 +112,6 @@ async function fetchAllPage<T>(
   }
 
   return items
-}
-
-async function fetchAllOrders(
-  signal?: AbortSignal,
-  ownerIds?: readonly string[],
-): Promise<ApiPurchaseOrder[]> {
-  // 발주에는 담당자 칸이 따로 없어 서버가 딜의 담당자로 거릅니다.
-  return (await fetchAllPage<OrderResponse>('/orders', signal, { owner_member_id: ownerIds })).map(
-    toOrder,
-  )
 }
 
 function toWriteRequest(draft: OrderDraft): OrderPatchRequest {
@@ -161,8 +152,23 @@ function mutationErrorMessage(error: unknown, action: string): string {
   return transportMessage(error) ?? fallback
 }
 
-export default function useOrderList(detailNo?: string) {
+export interface OrderQuery {
+  q: string
+  /** 고른 공급처. 빈 문자열이면 전체입니다. */
+  supplier: string
+  /** 발주일 하한. null 이면 제한 없음입니다. */
+  fromISO: string | null
+  /** 고른 상태 탭. 빈 문자열이면 전체입니다. */
+  status: string
+  skip: number
+  limit: number
+}
+
+export default function useOrderList(detailNo?: string, query?: OrderQuery) {
   const [orders, setOrders] = useState<ApiPurchaseOrder[]>([])
+  const [total, setTotal] = useState(0)
+  const [counts, setCounts] = useState<Record<string, number>>({})
+  const [suppliers, setSuppliers] = useState<string[]>([])
   const [products, setProducts] = useState<OrderOption[]>([])
   const [salesDeals, setSalesDeals] = useState<OrderSalesDealOption[]>([])
   const [statuses, setStatuses] = useState<PurchaseOrderStatusResponse[]>([])
@@ -180,15 +186,29 @@ export default function useOrderList(detailNo?: string) {
   const [mutationError, setMutationError] = useState<string | null>(null)
   const ownerIds = useScopeOwnerIds()
 
+  // 조회 조건을 낱개로 펼쳐 둡니다. 아래 목록 효과가 객체가 아니라 값 하나하나를 보게
+  // 해야, 화면이 조건 객체를 새로 만들 때마다 다시 받지 않습니다.
+  const listing = query !== undefined
+  const {
+    q: queryText = '',
+    supplier: querySupplier = '',
+    status: queryStatus = '',
+    fromISO: queryFrom = null,
+    skip: querySkip = 0,
+    limit: queryLimit = 30,
+  } = query ?? {}
+
   useEffect(() => {
     const controller = new AbortController()
     setLoading(true)
     setError(null)
 
     void Promise.all([
-      fetchAllOrders(controller.signal, ownerIds),
       // 제품과 딜은 발주를 등록할 때 고르는 목록입니다. 보기 범위로 좁히면 팀원이 맡은
       // 딜의 발주를 넣을 수 없게 됩니다.
+      //
+      // ponytail: 등록 폼의 선택지라 아직 전건을 받습니다. 목록과 달리 쪽으로 끊을 수
+      // 없는 자리이므로, 늘어나면 검색으로 고르는 입력으로 바꿉니다.
       fetchAllPage<ProductResponse>('/products', controller.signal),
       fetchAllPage<SalesDealResponse>('/sales-deals', controller.signal),
       client
@@ -197,9 +217,8 @@ export default function useOrderList(detailNo?: string) {
         })
         .then((response) => response.data),
     ])
-      .then(([orderItems, productItems, dealItems, statusItems]) => {
+      .then(([productItems, dealItems, statusItems]) => {
         if (controller.signal.aborted) return
-        setOrders(orderItems)
         setProducts(productItems.map(({ id, name }) => ({ id, name })))
         setSalesDeals(
           dealItems
@@ -220,7 +239,57 @@ export default function useOrderList(detailNo?: string) {
       })
 
     return () => controller.abort()
-  }, [reloadKey, ownerIds])
+  }, [reloadKey])
+
+  // 목록은 조건이 바뀔 때마다 한 쪽씩 받습니다. 위의 선택지 목록과 나눠 두어야 검색어를
+  // 한 글자 칠 때마다 제품·딜을 다시 받지 않습니다.
+  useEffect(() => {
+    if (!listing) return
+    const controller = new AbortController()
+    setLoading(true)
+    setError(null)
+
+    const needle = queryText.trim()
+    void client
+      .get<OrderPageResponse>('/orders', {
+        params: {
+          q: needle === '' ? undefined : needle.slice(0, 100),
+          supplier_name: querySupplier === '' ? undefined : querySupplier,
+          stage_code: queryStatus === '' ? undefined : queryStatus,
+          start_date: queryFrom ?? undefined,
+          // 발주에는 담당자 칸이 따로 없어 서버가 딜의 담당자로 거릅니다.
+          owner_member_id: ownerIds,
+          skip: querySkip,
+          limit: queryLimit,
+        },
+        signal: controller.signal,
+      })
+      .then(({ data }) => {
+        if (controller.signal.aborted) return
+        setOrders(data.items.map(toOrder))
+        setTotal(data.total)
+        setCounts(data.counts)
+        setSuppliers(data.suppliers)
+      })
+      .catch((caught: unknown) => {
+        if (!controller.signal.aborted) setError(requestErrorMessage(caught, '목록'))
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false)
+      })
+
+    return () => controller.abort()
+  }, [
+    reloadKey,
+    ownerIds,
+    listing,
+    queryText,
+    querySupplier,
+    queryStatus,
+    queryFrom,
+    querySkip,
+    queryLimit,
+  ])
 
   // 번호로 서버에 직접 묻습니다. 목록에서 찾으면 그 발주가 현재 페이지 밖일 때 상세가
   // 열리지 않습니다. 목록과 상세가 같은 모델이라 이 한 번으로 상세까지 받습니다.
@@ -329,10 +398,6 @@ export default function useOrderList(detailNo?: string) {
     [runMutation],
   )
 
-  const suppliers = useMemo(
-    () => [...new Set(orders.map((order) => order.supplier))].sort(),
-    [orders],
-  )
   const findOrderById = useCallback(
     (id: string) => orders.find((order) => order.id === id),
     [orders],
@@ -345,6 +410,8 @@ export default function useOrderList(detailNo?: string) {
 
   return {
     orders,
+    total,
+    counts,
     products,
     salesDeals,
     statuses,

--- a/frontend/src/pages/Products/Products.tsx
+++ b/frontend/src/pages/Products/Products.tsx
@@ -1,9 +1,10 @@
-import { useDeferredValue, useMemo, useState } from 'react'
+import { useDeferredValue, useState } from 'react'
 import { useSearchParams } from 'react-router'
 
 import Button from '@/components/Button'
 import ErrorToast from '@/components/ErrorToast'
 import { PlusIcon, ProductIcon, SearchIcon } from '@/components/icons'
+import Pagination from '@/components/Pagination'
 import SearchInput from '@/components/SearchInput'
 import { InlineLoader, ListPageSkeleton } from '@/components/Skeleton'
 import { wonFull } from '@/utils/format'
@@ -31,30 +32,32 @@ export default function Products() {
   const query = params.get('q') ?? ''
   const deferredQuery = useDeferredValue(query)
   const [adding, setAdding] = useState(false)
+  const [page, setPage] = useState(1)
+  const [pageSize, setPageSize] = useState(30)
 
-  const { products, loading, error, reload, addProduct } = useProducts()
+  const {
+    products: rows,
+    total,
+    loading,
+    error,
+    reload,
+    addProduct,
+  } = useProducts({ q: deferredQuery, skip: (page - 1) * pageSize, limit: pageSize })
 
-  const rows = useMemo(() => {
-    const needle = deferredQuery.trim().toLowerCase()
-    if (needle === '') return products
-    return products.filter((product) =>
-      [product.name, categoryLabel(product.category_code), product.memo ?? '']
-        .join(' ')
-        .toLowerCase()
-        .includes(needle),
-    )
-  }, [products, deferredQuery])
+  const pageCount = Math.max(1, Math.ceil(total / pageSize))
 
+  // 검색어가 바뀌면 결과가 줄어 지금 쪽수가 범위를 넘을 수 있습니다. 첫 쪽으로 돌립니다.
   const setQuery = (value: string) => {
     const next = new URLSearchParams(params)
     if (value === '') next.delete('q')
     else next.set('q', value)
     setParams(next, { replace: true })
+    setPage(1)
   }
 
   // 고객불만 목록과 같은 처리입니다. 첫 진입에서 툴바·표가 따로 들어오면
   // 화면이 두 번 들썩이므로 한 장을 통째로 자리표시자로 둡니다.
-  if (loading && products.length === 0 && !error) {
+  if (loading && rows.length === 0 && !error) {
     return (
       <section className={styles.page} aria-busy={loading}>
         <h1 className="sr-only">상품관리</h1>
@@ -83,7 +86,7 @@ export default function Products() {
         </div>
       </div>
 
-      {!error && loading && products.length > 0 && (
+      {!error && loading && rows.length > 0 && (
         <InlineLoader label="상품 목록을 새로고침하는 중입니다." />
       )}
 
@@ -151,6 +154,19 @@ export default function Products() {
               </tbody>
             </table>
           </div>
+
+          <Pagination
+            page={page}
+            pageCount={pageCount}
+            pageSize={pageSize}
+            total={total}
+            unit="개"
+            onPage={setPage}
+            onPageSize={(size) => {
+              setPageSize(size)
+              setPage(1)
+            }}
+          />
         </div>
       )}
 

--- a/frontend/src/pages/Products/catalog.ts
+++ b/frontend/src/pages/Products/catalog.ts
@@ -13,6 +13,18 @@ export function categoryLabel(code: string): string {
   return LABEL_BY_CODE.get(code as ProductCategoryCode) ?? code
 }
 
+/**
+ * 검색어가 가리키는 분류 코드. 분류 이름은 화면만 알고 DB 에는 코드만 있어서, 이름으로
+ * 찾으려면 화면이 코드로 풀어 보내야 합니다.
+ */
+export function categoryCodesMatching(needle: string): ProductCategoryCode[] {
+  const lowered = needle.trim().toLowerCase()
+  if (lowered === '') return []
+  return CATEGORIES.filter(({ label }) => label.toLowerCase().includes(lowered)).map(
+    ({ code }) => code,
+  )
+}
+
 export function shelfLifeLabel(months: number | null): string {
   return months === null ? '-' : `${months}개월`
 }

--- a/frontend/src/pages/Products/useProducts.ts
+++ b/frontend/src/pages/Products/useProducts.ts
@@ -4,43 +4,44 @@ import { client } from '@/api/client'
 import { errorMessage } from '@/api/errorMessage'
 import type { PageResponse, ProductCreateRequest, ProductResponse } from '@/types'
 
-const PAGE_LIMIT = 100
+import { categoryCodesMatching } from './catalog'
 
-const byName = (a: ProductResponse, b: ProductResponse) => a.name.localeCompare(b.name, 'ko')
-
-async function fetchAll(signal: AbortSignal): Promise<ProductResponse[]> {
-  // ponytail: 상품 마스터는 팀당 수십 건이라 전건을 받습니다. 늘어나면 서버 페이지로 바꿉니다.
-  const items: ProductResponse[] = []
-  let skip = 0
-
-  while (!signal.aborted) {
-    const { data } = await client.get<PageResponse<ProductResponse>>('/products', {
-      params: { skip, limit: PAGE_LIMIT },
-      signal,
-    })
-    items.push(...data.items)
-    if (!data.has_more || data.next_skip === null) break
-    if (data.next_skip <= skip) throw new Error('invalid_pagination')
-    skip = data.next_skip
-  }
-
-  return items
+export interface ProductQuery {
+  q: string
+  skip: number
+  limit: number
 }
 
-export default function useProducts() {
+export default function useProducts({ q, skip, limit }: ProductQuery) {
   const [products, setProducts] = useState<ProductResponse[]>([])
+  const [total, setTotal] = useState(0)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [reloadKey, setReloadKey] = useState(0)
+
+  const needle = q.trim()
 
   useEffect(() => {
     const controller = new AbortController()
     setLoading(true)
     setError(null)
 
-    void fetchAll(controller.signal)
-      .then((items) => {
-        if (!controller.signal.aborted) setProducts(items)
+    void client
+      .get<PageResponse<ProductResponse>>('/products', {
+        params: {
+          q: needle === '' ? undefined : needle.slice(0, 100),
+          // 분류 이름("소모품")으로도 찾습니다. 그 이름은 화면만 알고 있으므로 풀어서
+          // 보내고 서버가 q 와 OR 로 묶습니다.
+          q_category_code: needle === '' ? undefined : categoryCodesMatching(needle),
+          skip,
+          limit,
+        },
+        signal: controller.signal,
+      })
+      .then(({ data }) => {
+        if (controller.signal.aborted) return
+        setProducts(data.items)
+        setTotal(data.total)
       })
       .catch((caught: unknown) => {
         if (!controller.signal.aborted) {
@@ -52,7 +53,7 @@ export default function useProducts() {
       })
 
     return () => controller.abort()
-  }, [reloadKey])
+  }, [needle, skip, limit, reloadKey])
 
   const reload = useCallback(() => setReloadKey((previous) => previous + 1), [])
 
@@ -60,18 +61,23 @@ export default function useProducts() {
    * 자료실(useDocuments.addDocument)과 같은 2단계입니다. 상품을 먼저 만들고
    * 사진이 있으면 그 뒤에 붙입니다. 사진 업로드가 실패해도 상품은 남습니다.
    */
-  const addProduct = useCallback(async (payload: ProductCreateRequest, image: File | null) => {
-    const { data: created } = await client.post<ProductResponse>('/products', payload)
-    let product = created
-    if (image !== null) {
-      const form = new FormData()
-      form.append('upload', image)
-      const { data } = await client.put<ProductResponse>(`/products/${created.id}/image`, form)
-      product = data
-    }
-    setProducts((previous) => [...previous, product].sort(byName))
-    return product
-  }, [])
+  const addProduct = useCallback(
+    async (payload: ProductCreateRequest, image: File | null) => {
+      const { data: created } = await client.post<ProductResponse>('/products', payload)
+      let product = created
+      if (image !== null) {
+        const form = new FormData()
+        form.append('upload', image)
+        const { data } = await client.put<ProductResponse>(`/products/${created.id}/image`, form)
+        product = data
+      }
+      // 새 상품이 이 페이지에 속하는지는 이름 순서가 정합니다. 목록에 끼워 넣지 않고
+      // 다시 받아 서버가 정한 자리에 놓습니다.
+      reload()
+      return product
+    },
+    [reload],
+  )
 
-  return { products, loading, error, reload, addProduct }
+  return { products, total, loading, error, reload, addProduct }
 }

--- a/frontend/src/pages/Quotes/Quotes.tsx
+++ b/frontend/src/pages/Quotes/Quotes.tsx
@@ -69,7 +69,7 @@ export default function Quotes() {
 
   const [sort, setSort] = useState<SortState>(null)
   const [page, setPage] = useState(1)
-  const [pageSize, setPageSize] = useState(25)
+  const [pageSize, setPageSize] = useState(30)
   const [openFilter, setOpenFilter] = useState<'pipeline' | 'owner' | 'range' | null>(null)
 
   const pipelineOptions = useMemo(

--- a/frontend/src/pages/Quotes/Quotes.tsx
+++ b/frontend/src/pages/Quotes/Quotes.tsx
@@ -2,8 +2,9 @@ import { useCallback, useDeferredValue, useMemo, useState } from 'react'
 import { useSearchParams } from 'react-router'
 
 import { useCurrentUser } from '@/auth/sessionContext'
+import useTeamMembers from '@/hooks/useTeamMembers'
 import Button from '@/components/Button'
-import DataTable, { compareBy, type SortState } from '@/components/DataTable'
+import DataTable from '@/components/DataTable'
 import ErrorToast from '@/components/ErrorToast'
 import FilterSelect from '@/components/FilterSelect'
 import { QuoteIcon, SearchIcon } from '@/components/icons'
@@ -46,20 +47,9 @@ export default function Quotes() {
   }
 
   const requestedPipelineId = params.get('pipeline') ?? ''
-  const {
-    pipelines,
-    dealPipelineId,
-    columns: pipelineStages,
-    cards: quotes,
-    loading,
-    error,
-    reload,
-    detail,
-    detailLoading,
-    detailError,
-    reloadDetail,
-  } = useSalesDeals(openId, requestedPipelineId || null, 'list', 'quote')
   const { isManager } = useCurrentUser()
+  // 담당자 선택지. 받아 둔 목록에서 뽑으면 지금 쪽에 있는 사람만 나옵니다.
+  const { members: teamMembers } = useTeamMembers(isManager)
 
   const query = params.get('q') ?? ''
   const owner = isManager ? (params.get('owner') ?? '') : ''
@@ -67,39 +57,9 @@ export default function Quotes() {
   const stage = params.get('stage') ?? ''
   const deferredQuery = useDeferredValue(query)
 
-  const [sort, setSort] = useState<SortState>(null)
   const [page, setPage] = useState(1)
   const [pageSize, setPageSize] = useState(30)
   const [openFilter, setOpenFilter] = useState<'pipeline' | 'owner' | 'range' | null>(null)
-
-  const pipelineOptions = useMemo(
-    () => [
-      { value: '', label: '파이프라인 전체' },
-      ...pipelines.map((pipeline) => ({
-        value: pipeline.id,
-        label: pipeline.name + (pipeline.status_code === 'archived' ? ' (보관)' : ''),
-      })),
-    ],
-    [pipelines],
-  )
-
-  const quoteStages = useMemo(
-    () => pipelineStages.filter((item) => item.phase === 'quote'),
-    [pipelineStages],
-  )
-  const columns = useMemo(
-    () => QUOTE_COLUMNS.filter((column) => column.id !== 'owner' || isManager),
-    [isManager],
-  )
-  const ownerOptions = useMemo(
-    () => [
-      { value: '', label: '담당 전체' },
-      ...[...new Set(quotes.map((item) => item.owner))]
-        .sort()
-        .map((name) => ({ value: name, label: name })),
-    ],
-    [quotes],
-  )
 
   const setParam = useCallback(
     (key: string, value: string, fallback = '') => {
@@ -130,51 +90,78 @@ export default function Quotes() {
     [params, setParams],
   )
 
-  const beforeStage = useMemo(() => {
-    const needle = deferredQuery.trim().toLowerCase()
-    return quotes.filter((quote) => {
-      if (owner !== '' && quote.owner !== owner) return false
-      if (fromISO !== null && (quote.quoteIssuedOn ?? quote.date) < fromISO) return false
-      if (needle === '') return true
-      return [quote.quoteNo ?? quote.no, quote.org, quote.product, quote.owner, quote.memo ?? '']
-        .join(' ')
-        .toLowerCase()
-        .includes(needle)
-    })
-  }, [deferredQuery, fromISO, owner, quotes])
-
-  const stageCounts = useMemo(() => {
-    const counts = new Map<string, number>()
-    for (const quote of beforeStage) counts.set(quote.stageId, (counts.get(quote.stageId) ?? 0) + 1)
-    return counts
-  }, [beforeStage])
-
-  const matched = useMemo(() => {
-    const activeStage = dealPipelineId ? stage : ''
-    const rows =
-      activeStage === ''
-        ? beforeStage
-        : beforeStage.filter((quote) => quote.stageId === activeStage)
-    if (!sort) return rows
-    const sign = sort.dir === 'asc' ? 1 : -1
-    const compare = compareBy(columns, sort.id)
-    return [...rows].sort((a, b) => sign * compare(a, b))
-  }, [beforeStage, columns, dealPipelineId, sort, stage])
-
-  const pageCount = Math.max(1, Math.ceil(matched.length / pageSize))
-  const safePage = Math.min(page, pageCount)
-  const pageRows = useMemo(
-    () => matched.slice((safePage - 1) * pageSize, safePage * pageSize),
-    [matched, pageSize, safePage],
+  const dealQuery = useMemo(
+    () => ({
+      q: deferredQuery,
+      stageId: stage,
+      ownerMemberId: owner,
+      fromISO,
+      skip: (page - 1) * pageSize,
+      limit: pageSize,
+    }),
+    [deferredQuery, stage, owner, fromISO, page, pageSize],
   )
 
-  const onSort = useCallback((id: string) => {
-    setSort((previous) => {
-      if (previous?.id !== id) return { id, dir: 'asc' }
-      if (previous.dir === 'asc') return { id, dir: 'desc' }
-      return null
-    })
-  }, [])
+  const {
+    pipelines,
+    dealPipelineId,
+    columns: pipelineStages,
+    cards: pageRows,
+    total,
+    counts,
+    loading,
+    error,
+    reload,
+    detail,
+    detailLoading,
+    detailError,
+    reloadDetail,
+  } = useSalesDeals(openId, requestedPipelineId || null, 'list', 'quote', dealQuery)
+
+  const quoteStages = useMemo(
+    () => pipelineStages.filter((item) => item.phase === 'quote'),
+    [pipelineStages],
+  )
+  // 정렬 API가 붙기 전에 현재 쪽만 정렬하면 전체 순서를 오해하게 됩니다.
+  const columns = useMemo(
+    () =>
+      QUOTE_COLUMNS.filter((column) => column.id !== 'owner' || isManager).map((column) => ({
+        ...column,
+        sortable: false,
+      })),
+    [isManager],
+  )
+  const ownerOptions = useMemo(
+    () => [
+      { value: '', label: '담당 전체' },
+      ...teamMembers.map((item) => ({ value: item.id, label: item.display_name })),
+    ],
+    [teamMembers],
+  )
+
+  const pipelineOptions = useMemo(
+    () => [
+      { value: '', label: '파이프라인 전체' },
+      ...pipelines.map((pipeline) => ({
+        value: pipeline.id,
+        label: pipeline.name + (pipeline.status_code === 'archived' ? ' (보관)' : ''),
+      })),
+    ],
+    [pipelines],
+  )
+
+  // 단계 탭 옆 건수는 서버가 셉니다. 고른 단계는 빼고 센 값이라 탭을 바꿔도 다른 단계
+  // 숫자가 0 으로 죽지 않습니다.
+  const stageCounts = useMemo(() => new Map(Object.entries(counts)), [counts])
+  const stageTotal = useMemo(
+    () => [...stageCounts.values()].reduce((sum, count) => sum + count, 0),
+    [stageCounts],
+  )
+
+  const pageCount = Math.max(1, Math.ceil(total / pageSize))
+
+  // 헤더 정렬을 끄므로 누를 일이 없습니다. 고객 목록과 같은 처리입니다.
+  const ignoreSort = useCallback(() => undefined, [])
 
   const clearFilters = useCallback(() => {
     setParams(new URLSearchParams(), { replace: true })
@@ -189,7 +176,7 @@ export default function Quotes() {
       outcome: quote.status,
       phase: quote.stagePhase,
     }
-  const selectedQuote = detail ?? quotes.find((quote) => quote.id === openId) ?? null
+  const selectedQuote = detail ?? pageRows.find((quote) => quote.id === openId) ?? null
   const selectedStage = selectedQuote ? stageOf(selectedQuote) : undefined
   const isFiltered =
     query.trim() !== '' ||
@@ -200,7 +187,7 @@ export default function Quotes() {
 
   // 첫 진입입니다. 툴바·탭·표가 차례로 나타나면 화면이 두세 번 들썩이므로
   // 화면 한 장을 통째로 자리표시자로 두고 다 받은 뒤 한 번에 바꿉니다.
-  if (loading && quotes.length === 0 && !error) {
+  if (loading && pageRows.length === 0 && !error) {
     return (
       <section className={styles.page} aria-busy={loading}>
         <h1 className="sr-only">견적 현황</h1>
@@ -258,12 +245,12 @@ export default function Quotes() {
           label="견적 단계"
           value={stage}
           countOf={(id) => stageCounts.get(id) ?? 0}
-          total={beforeStage.length}
+          total={stageTotal}
           onChange={(next) => setParam('stage', next)}
         />
       )}
 
-      {!error && loading && quotes.length > 0 && (
+      {!error && loading && pageRows.length > 0 && (
         <InlineLoader label="목록을 새로고침하는 중입니다." />
       )}
 
@@ -274,8 +261,8 @@ export default function Quotes() {
         columns={columns}
         rowKey={(quote) => quote.id}
         handleColumn="org"
-        sort={sort}
-        onSort={onSort}
+        sort={null}
+        onSort={ignoreSort}
         onOpen={(quote) => setOpenId(quote.id)}
         caption="견적 목록. 헤더를 눌러 정렬할 수 있습니다."
         renderCell={(id, quote) => {
@@ -338,12 +325,12 @@ export default function Quotes() {
         }
       />
 
-      {!error && !loading && matched.length > 0 && (
+      {!error && !loading && pageRows.length > 0 && (
         <Pagination
-          page={safePage}
+          page={page}
           pageCount={pageCount}
           pageSize={pageSize}
-          total={matched.length}
+          total={total}
           unit="건"
           onPage={setPage}
           onPageSize={(size) => {

--- a/frontend/src/shared/agenda.ts
+++ b/frontend/src/shared/agenda.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useSyncExternalStore } from 'react'
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react'
 
 import { client } from '@/api/client'
 import { errorMessage } from '@/api/errorMessage'
@@ -377,6 +377,53 @@ export function useAgendaState(
     error: loadError,
     reload: () => loadAgenda(startDate, endDate, true, ownScopeOnly),
   }
+}
+
+/**
+ * 활동 하나만 받아 옵니다. 보고서 작성 화면이 주소의 활동 번호로 바로 들어올 때 씁니다.
+ *
+ * 목록에서 찾으면 그 활동이 언제 것인지 모르는 채로 전 기간을 받아야 합니다. 번호를 아는
+ * 조회이므로 단건으로 받습니다.
+ */
+export function useAgendaItem(id: string) {
+  const [item, setItem] = useState<AgendaItem | undefined>(undefined)
+  const [loading, setLoading] = useState(id !== '')
+  const [error, setError] = useState<string | null>(null)
+  const [reloadKey, setReloadKey] = useState(0)
+  const scopeKey = useScopeKey()
+
+  useEffect(() => {
+    if (id === '') {
+      setItem(undefined)
+      setLoading(false)
+      setError(null)
+      return
+    }
+    const controller = new AbortController()
+    setLoading(true)
+    setError(null)
+    client
+      .get<ActivityRead>(`/activities/${id}`, { signal: controller.signal })
+      .then(({ data }) => {
+        const next = activityToAgenda(data)
+        // 보고는 본인이 한 일을 적습니다. 주소를 직접 고쳐 남의 일정으로 들어오면 비웁니다.
+        // 팀장이 아니면 서버가 이미 본인 것만 주므로 그대로 받습니다.
+        const own = getOwnMemberIds()
+        const mine =
+          own === undefined ||
+          (next.ownerMemberId !== undefined && own.includes(next.ownerMemberId))
+        setItem(mine ? next : undefined)
+        setLoading(false)
+      })
+      .catch((cause: unknown) => {
+        if (controller.signal.aborted) return
+        setError(errorMessage(cause, '일정을 불러오지 못했습니다.'))
+        setLoading(false)
+      })
+    return () => controller.abort()
+  }, [id, reloadKey, scopeKey])
+
+  return { item, loading, error, reload: () => setReloadKey((key) => key + 1) }
 }
 
 /**

--- a/frontend/src/types/customers.ts
+++ b/frontend/src/types/customers.ts
@@ -114,3 +114,11 @@ export interface PageResponse<T> {
   has_more: boolean
   next_skip: number | null
 }
+
+/**
+ * 탭이 있는 목록의 한 쪽. `counts` 는 {탭 코드: 건수}이고, 고른 탭은 빼고 센 값이라
+ * `total` 과 다릅니다. 탭까지 적용해 세면 고른 탭만 숫자가 남고 나머지가 0 이 됩니다.
+ */
+export interface TabbedPageResponse<T> extends PageResponse<T> {
+  counts: Record<string, number>
+}

--- a/frontend/src/types/orders.ts
+++ b/frontend/src/types/orders.ts
@@ -1,3 +1,4 @@
+import type { TabbedPageResponse } from './customers'
 import type { ColumnTone } from './stage'
 
 export interface OrderLine {
@@ -117,4 +118,12 @@ export type OrderPatchRequest = Omit<OrderCreateRequest, 'stage_code'>
 export interface OrderMoveRequest {
   expected_stage_code: string
   stage_code: string
+}
+
+/**
+ * 발주 목록 한 쪽. `counts` 는 상태 탭 옆 건수, `suppliers` 는 공급처 고르는 칸에 세울
+ * 이름입니다. 둘 다 자기 조건만 빼고 집계한 값이라 쪽이 바뀌어도 그대로입니다.
+ */
+export interface OrderPageResponse extends TabbedPageResponse<OrderResponse> {
+  suppliers: string[]
 }


### PR DESCRIPTION
## 변경 요약

전건을 받아 브라우저에서 거르고 세던 목록 화면들을 한 쪽씩 받도록 바꾼다. 목록이 늘어도 첫 화면이 받는 양이 늘지 않는다.

**서버 페이지네이션 전환** — 상품 / 고객불만 / 발주 / 견적·계약·영업기회 / 자료실

- 검색·탭·기간·담당자 등 화면 필터를 서버로 넘긴다
- 탭 옆 건수(`counts`)를 서버가 센다. 고른 조건만 빼고 집계해 탭을 바꿔도 다른 탭 숫자가 0으로 죽지 않는다
- 선택지(공급처·등록자·담당자)를 서버가 준다. 받아 둔 목록에서 뽑으면 지금 쪽에 있는 값만 고를 수 있다
- 서버 정렬이 없는 화면의 헤더 정렬을 끈다. 현재 쪽만 정렬하면 전체 순서를 오해하게 된다
- 상품·고객불만 목록에 없던 Pagination 을 붙인다
- 선택지·폼 조회를 목록 조회와 분리한다. 한 효과에 묶여 있으면 검색어 한 글자마다 다시 받는다

**페이지네이션 때문에 드러난 버그 수정**

- 현재 페이지 밖의 발주는 상세가 열리지 않던 문제 — `/api/orders` 에 정확일치 `order_no` 필터 추가, 상세 조회까지 이 요청 하나로 합침(2회→1회)
- 같은 일정·기간에 업무보고가 중복 생성되던 문제 — 받아 둔 배열 탐색 대신 `source_activity_id`·기간 조회로 서버에 묻는다
- 보고서 작성 화면이 2000~2099년 일정을 계속 받던 문제 — 실제로 쓰는 하루 또는 단건만 요청한다

**기준 정리**

- 쪽당 개수 선택지를 25/50/100 → 30/50/100, 6개 목록 기본값을 30으로 맞춤(백엔드 `limit` 기본값·`api-conventions.md` 와 동일)

## 검증

- `uv run pytest` (backend): 207 passed
- `npm run typecheck` (frontend): 통과
- `npx oxlint` (frontend): 통과
- 브라우저 수동 확인은 미실행. 로컬에서 실행하지 않았다

## 영향 및 주의 사항

- 검색 동작 차이(발주): 품목 검색이 제품명으로 걸린다. 예전에는 "제품명 3개" 로 이어 붙인 문자열을 훑어 수량까지 맞았으나 이제 수량은 걸리지 않는다
- `/api/sales-deals` 에 `date_basis` 추가. 기본값이 시작일이라 대시보드 등 기존 조회는 그대로다
- `/api/products`·`/api/sales-deals`·`/api/orders`·`/api/support-requests`·`/api/documents` 응답에 `counts` 등 필드가 추가됐다(기존 필드 제거 없음)
- 딜 칸반·매출 요약은 전건 집계가 필요해 조건 없이 조회하던 기존 동작을 유지한다
- 남은 한계: 자료실 저장 시 연결 대상을 이름으로 찾는 조회가 첫 100건 안에서만 맞춘다. 원래 있던 동작이라 이번에 손대지 않고 `ponytail:` 주석으로 표시했다