### PR TITLE
feat: 팀장이 공지·지시사항을 직접 관리하는 화면과 API 를 더한다

### DIFF
--- a/backend/app/api/dashboard.py
+++ b/backend/app/api/dashboard.py
@@ -72,7 +72,8 @@ async def _notice_summary(
         await db.execute(
             notices_api._joined_select(Notice, notices_api._author.display_name)
             .where(*conditions)
-            .order_by(Notice.published_at.desc(), Notice.id)
+            # 팀장이 정한 순서가 티커에도 그대로 반영되어야 한다.
+            .order_by(Notice.sort_order, Notice.published_at.desc(), Notice.id)
             .limit(limit)
         )
     ).all()
@@ -82,6 +83,7 @@ async def _notice_summary(
         items=[
             NoticeBrief(
                 id=notice.id,
+                type=notice.type,
                 tag=notice.tag,
                 author_display_name=author_display_name,
                 title=notice.title,
@@ -360,8 +362,8 @@ async def read_dashboard(
     return DashboardRead(
         as_of=as_of,
         date=day,
-        notices=await _notice_summary(db, member, "team", params.notice_limit),
-        directives=await _notice_summary(db, member, "personal", params.notice_limit),
+        notices=await _notice_summary(db, member, "NOTICE", params.notice_limit),
+        directives=await _notice_summary(db, member, "DIRECTIVE", params.notice_limit),
         visited_companies=visited,
         activities=activity_total,
         today_activities=await _today_activities(db, member, owner_ids, day),

--- a/backend/app/api/notices.py
+++ b/backend/app/api/notices.py
@@ -1,21 +1,68 @@
-from datetime import datetime
+"""공지와 팀장 지시사항.
+
+읽기는 팀원 모두가 하고 쓰기는 팀장만 한다. 팀원이 보는 목록은 지운 것·숨긴 것·노출 기간
+밖을 모두 걷어내지만, 팀장 관리 목록은 기간을 보지 않는다. 아직 시작하지 않은 글과 이미 끝난
+글을 봐야 고칠 수 있기 때문이다.
+
+본문은 편집기가 만든 HTML 이다. 저장 직전에 services.html_sanitize 가 허용한 태그만 남기고,
+본문 안의 사진은 `/notice-images/{id}` 라는 내부 참조로만 남는다. 실제로 볼 수 있는 주소는
+응답을 만들 때마다 서명 URL 로 새로 발급한다. 저장소 주소는 응답에 나가지 않는다.
+"""
+
+from datetime import UTC, date, datetime
 from typing import Annotated
-from uuid import UUID
+from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
-from fastapi import APIRouter, HTTPException, Query, status
-from sqlalchemy import func, or_, select
+from fastapi import APIRouter, File, HTTPException, Query, Response, UploadFile, status
+from sqlalchemy import and_, delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
 from app.api.deps import CurrentMember, DbSession
-from app.models.workspace import Member, Notice
-from app.schemas.notices import NoticePage, NoticePageParams, NoticeRead
+from app.core.config import settings
+from app.models.workspace import Member, Notice, NoticeImage, NoticeTarget
+from app.schemas.notices import (
+    NoticeCreate,
+    NoticeImageRead,
+    NoticeManageListItem,
+    NoticeManagePage,
+    NoticeManagePageParams,
+    NoticeManageRead,
+    NoticePage,
+    NoticePageParams,
+    NoticePatch,
+    NoticeRead,
+    NoticeTargetRead,
+)
+from app.services import storage
+from app.services.html_sanitize import (
+    NOTICE_IMAGE_PREFIX,
+    BodyEmpty,
+    image_ids,
+    sanitize_body,
+)
+from app.services.storage import StorageError
+from app.services.upload_guard import UploadRejected, check_image_upload, check_size
 
 router = APIRouter(tags=["notices"])
 
 _SEOUL = ZoneInfo("Asia/Seoul")
 _author = aliased(Member)
+
+# 본문 사진은 상품 사진과 같은 규칙으로 받는다.
+NOTICE_IMAGE_MAX_BYTES = 5 * 1024 * 1024
+# 본문을 한 번 그리는 동안 살아 있으면 된다.
+NOTICE_IMAGE_EXPIRES_IN = 300
+
+# 옛 어휘(team/personal)와 새 어휘(NOTICE/DIRECTIVE)를 함께 받는다. 대시보드가 옛 어휘로
+# _scope 를 부르고 있어 둘 다 통해야 한다.
+_SCOPE_TO_TYPE = {
+    "team": "NOTICE",
+    "personal": "DIRECTIVE",
+    "NOTICE": "NOTICE",
+    "DIRECTIVE": "DIRECTIVE",
+}
 
 
 def _contains(value: str) -> str:
@@ -27,48 +74,256 @@ def _seoul(value: datetime | None) -> datetime | None:
     return None if value is None else value.astimezone(_SEOUL)
 
 
+def _today() -> date:
+    """업무상 오늘은 Asia/Seoul 기준이다. dashboard._day_bounds 와 같은 규약이다."""
+    return datetime.now(_SEOUL).date()
+
+
 def _joined_select(*entities):
     return (
         select(*entities).select_from(Notice).join(_author, Notice.author_member_id == _author.id)
     )
 
 
-def _scope(member: Member, requested: str | None):
-    """공지는 팀 전체가 보고 지시는 수신자 본인만 본다. 담당자 범위와 무관하다."""
+def _targeted_to(member_id: UUID):
+    """이 지시가 그 사람에게 왔는지 묻는다.
+
+    조인하지 않고 EXISTS 로 묻는다. 조인하면 지시 한 건이 수신자 수만큼 늘어나 목록의 total 이
+    부풀고 같은 글이 여러 줄로 보인다.
+    """
+    return (
+        select(NoticeTarget.member_id)
+        .where(NoticeTarget.notice_id == Notice.id, NoticeTarget.member_id == member_id)
+        .exists()
+    )
+
+
+def _visible(member: Member, requested_type: str | None):
+    """팀원이 볼 수 있는 것. 지운 것, 숨긴 것, 노출 기간 밖은 여기서 모두 빠진다."""
+    today = _today()
     conditions = [
         Notice.team_id == member.team_id,
         _author.team_id == member.team_id,
         _author.role_code.in_(("member", "manager")),
+        Notice.deleted_at.is_(None),
+        Notice.is_hidden.is_(False),
+        Notice.display_start_date <= today,
+        or_(Notice.display_end_date.is_(None), Notice.display_end_date >= today),
     ]
-    if requested == "team":
-        conditions.append(Notice.recipient_member_id.is_(None))
-    elif requested == "personal":
-        conditions.append(Notice.recipient_member_id == member.id)
+    if requested_type == "NOTICE":
+        conditions.append(Notice.type == "NOTICE")
+    elif requested_type == "DIRECTIVE":
+        conditions.append(Notice.type == "DIRECTIVE")
+        conditions.append(_targeted_to(member.id))
     else:
         conditions.append(
             or_(
-                Notice.recipient_member_id.is_(None),
-                Notice.recipient_member_id == member.id,
+                Notice.type == "NOTICE",
+                and_(Notice.type == "DIRECTIVE", _targeted_to(member.id)),
             )
         )
     return conditions
 
 
-def _notice_read(notice: Notice, author_display_name: str) -> NoticeRead:
+def _scope(member: Member, requested: str | None):
+    """공지는 팀 전체가 보고 지시는 수신자 본인만 본다. 담당자 범위와 무관하다.
+
+    이름과 인자 모양을 그대로 둔다. dashboard 가 이 함수를 직접 가져다 쓰므로, 여기 조건이
+    곧 대시보드 카드의 조건이다.
+    """
+    return _visible(member, _SCOPE_TO_TYPE.get(requested or ""))
+
+
+def _require_manager(member: Member) -> None:
+    """공지와 지시는 팀장이 관리한다. 읽기는 팀원 그대로다."""
+    if member.role_code != "manager":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="manager_required")
+
+
+def _require_storage() -> None:
+    if not settings.storage_configured:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="storage_not_configured",
+        )
+
+
+async def _flush_and_commit(db: AsyncSession) -> None:
+    try:
+        await db.flush()
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+
+
+async def _render_body(db: AsyncSession, member: Member, body: str) -> str:
+    """본문의 사진 참조를 그 자리에서 발급한 서명 URL 로 바꾼다.
+
+    본문에는 저장소 주소가 없고 우리 id 만 있다. 서명 URL 은 짧게 살기 때문에 본문에 박아
+    둘 수 없고, 읽을 때마다 새로 만든다. 발급에 실패한 사진은 참조를 그대로 두어 본문의
+    나머지가 함께 무너지지 않게 한다.
+    """
+    wanted = image_ids(body)
+    if not wanted:
+        return body
+
+    rows = (
+        await db.execute(
+            select(NoticeImage.id, NoticeImage.storage_key).where(
+                NoticeImage.id.in_([UUID(value) for value in wanted]),
+                NoticeImage.team_id == member.team_id,
+            )
+        )
+    ).all()
+
+    rendered = body
+    for image_id, storage_key in rows:
+        try:
+            url = await storage.signed_url(
+                storage_key=storage_key,
+                expires_in=NOTICE_IMAGE_EXPIRES_IN,
+            )
+        except StorageError:
+            continue
+        rendered = rendered.replace(f"{NOTICE_IMAGE_PREFIX}{image_id}", url)
+    return rendered
+
+
+async def _load_targets(
+    db: AsyncSession,
+    notices: list[Notice],
+) -> dict[UUID, list[NoticeTargetRead]]:
+    """지시들의 수신자를 한 번에 읽는다. 행마다 따로 묻지 않는다."""
+    grouped: dict[UUID, list[NoticeTargetRead]] = {notice.id: [] for notice in notices}
+    directive_ids = [notice.id for notice in notices if notice.type == "DIRECTIVE"]
+    if not directive_ids:
+        return grouped
+
+    result = await db.execute(
+        select(NoticeTarget.notice_id, Member.id, Member.display_name)
+        .join(Member, NoticeTarget.member_id == Member.id)
+        .where(NoticeTarget.notice_id.in_(directive_ids))
+        .order_by(NoticeTarget.created_at, Member.display_name, Member.id)
+    )
+    for notice_id, member_id, display_name in result.all():
+        grouped[notice_id].append(NoticeTargetRead(id=member_id, display_name=display_name))
+    return grouped
+
+
+async def _resolve_targets(
+    db: AsyncSession,
+    member: Member,
+    target_member_ids: list[UUID],
+) -> list[Member]:
+    """수신자를 정한다. 고른 순서가 곧 표시 순서다."""
+    ordered = list(dict.fromkeys(target_member_ids))
+    if not ordered:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="directive_target_required",
+        )
+
+    result = await db.execute(
+        select(Member).where(
+            Member.id.in_(ordered),
+            Member.team_id == member.team_id,
+            Member.active.is_(True),
+            Member.role_code.in_(("member", "manager")),
+        )
+    )
+    found = {row.id: row for row in result.scalars().all()}
+    if len(found) != len(ordered):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="notice_target_member_not_found",
+        )
+    return [found[target_id] for target_id in ordered]
+
+
+def _sanitize(body: str) -> str:
+    try:
+        return sanitize_body(body)
+    except BodyEmpty as error:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="notice_body_empty",
+        ) from error
+
+
+def _check_display_range(start: date, end: date | None) -> None:
+    """스키마는 시작일을 생략한 요청의 범위를 보지 못한다. 값이 정해진 뒤 다시 본다."""
+    if end is not None and end < start:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="invalid_notice_display_range",
+        )
+
+
+def _notice_read(
+    notice: Notice,
+    author_display_name: str,
+    targets: list[NoticeTargetRead],
+    body: str,
+) -> NoticeRead:
     return NoticeRead(
         id=notice.id,
-        scope="team" if notice.recipient_member_id is None else "personal",
+        scope="team" if notice.type == "NOTICE" else "personal",
+        type=notice.type,
         author_member_id=notice.author_member_id,
         author_display_name=author_display_name,
-        recipient_member_id=notice.recipient_member_id,
+        recipient_member_id=targets[0].id if len(targets) == 1 else None,
         tag=notice.tag,
         title=notice.title,
-        body=notice.body,
+        body=body,
         image_alt=notice.image_alt,
         published_at=_seoul(notice.published_at),
         due_at=_seoul(notice.due_at),
         due_text=notice.due_text,
     )
+
+
+def _manage_fields(
+    notice: Notice,
+    author_display_name: str,
+    targets: list[NoticeTargetRead],
+) -> dict:
+    return {
+        "id": notice.id,
+        "type": notice.type,
+        "author_member_id": notice.author_member_id,
+        "author_display_name": author_display_name,
+        "tag": notice.tag,
+        "title": notice.title,
+        "image_alt": notice.image_alt,
+        "published_at": _seoul(notice.published_at),
+        "due_at": _seoul(notice.due_at),
+        "due_text": notice.due_text,
+        "display_start_date": notice.display_start_date,
+        "display_end_date": notice.display_end_date,
+        "is_hidden": notice.is_hidden,
+        "sort_order": notice.sort_order,
+        "targets": targets,
+        "target_member_ids": [target.id for target in targets],
+        "updated_at": _seoul(notice.updated_at),
+    }
+
+
+def _manage_list_item(
+    notice: Notice,
+    author_display_name: str,
+    targets: list[NoticeTargetRead],
+) -> NoticeManageListItem:
+    return NoticeManageListItem(**_manage_fields(notice, author_display_name, targets))
+
+
+def _manage_read(
+    notice: Notice,
+    author_display_name: str,
+    targets: list[NoticeTargetRead],
+    body: str,
+) -> NoticeManageRead:
+    return NoticeManageRead(**_manage_fields(notice, author_display_name, targets), body=body)
 
 
 async def _notice_row(db: AsyncSession, member: Member, notice_id: UUID):
@@ -86,13 +341,48 @@ async def _notice_row(db: AsyncSession, member: Member, notice_id: UUID):
     return row
 
 
+async def _manage_row(db: AsyncSession, member: Member, notice_id: UUID):
+    """팀장이 관리하는 한 건. 숨겼거나 기간이 지난 것도 잡힌다."""
+    result = await db.execute(
+        _joined_select(Notice, _author.display_name).where(
+            Notice.id == notice_id,
+            Notice.team_id == member.team_id,
+            Notice.deleted_at.is_(None),
+        )
+    )
+    row = result.one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="notice_not_found",
+        )
+    return row
+
+
+async def _notice_for_update(db: AsyncSession, member: Member, notice_id: UUID) -> Notice:
+    notice = (
+        await db.execute(
+            select(Notice)
+            .where(
+                Notice.id == notice_id,
+                Notice.team_id == member.team_id,
+                Notice.deleted_at.is_(None),
+            )
+            .with_for_update(of=Notice)
+        )
+    ).scalar_one_or_none()
+    if notice is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="notice_not_found")
+    return notice
+
+
 @router.get("/notices", response_model=NoticePage)
 async def list_notices(
     page: Annotated[NoticePageParams, Query()],
     member: CurrentMember,
     db: DbSession,
 ) -> NoticePage:
-    scope = _scope(member, page.scope)
+    scope = _visible(member, page.type or _SCOPE_TO_TYPE.get(page.scope or ""))
     if page.published_from is not None:
         scope.append(Notice.published_at >= page.published_from)
     if page.published_to is not None:
@@ -113,11 +403,21 @@ async def list_notices(
     rows_result = await db.execute(
         _joined_select(Notice, _author.display_name)
         .where(*scope)
-        .order_by(Notice.published_at.desc(), Notice.id)
+        .order_by(Notice.sort_order, Notice.published_at.desc(), Notice.id)
         .offset(page.skip)
         .limit(page.limit)
     )
-    items = [_notice_read(*row) for row in rows_result.all()]
+    rows = rows_result.all()
+    targets = await _load_targets(db, [notice for notice, _ in rows])
+    items = [
+        _notice_read(
+            notice,
+            author_display_name,
+            targets[notice.id],
+            await _render_body(db, member, notice.body),
+        )
+        for notice, author_display_name in rows
+    ]
     has_more = page.skip + len(items) < total
     return NoticePage(
         items=items,
@@ -129,10 +429,288 @@ async def list_notices(
     )
 
 
+# 아래 /notices/{notice_id} 보다 먼저 선언한다. 순서가 바뀌면 "manage" 와 "images" 가
+# UUID 로 읽혀 422 가 난다.
+@router.get("/notices/manage", response_model=NoticeManagePage)
+async def list_notices_for_manage(
+    page: Annotated[NoticeManagePageParams, Query()],
+    member: CurrentMember,
+    db: DbSession,
+) -> NoticeManagePage:
+    _require_manager(member)
+    # 노출 기간은 보지 않는다. 아직 시작하지 않은 글과 끝난 글도 팀장은 봐야 고칠 수 있다.
+    conditions = [
+        Notice.team_id == member.team_id,
+        _author.team_id == member.team_id,
+        Notice.deleted_at.is_(None),
+    ]
+    if not page.include_hidden:
+        conditions.append(Notice.is_hidden.is_(False))
+    if page.type is not None:
+        conditions.append(Notice.type == page.type)
+    if page.q is not None:
+        pattern = _contains(page.q)
+        conditions.append(
+            or_(
+                Notice.title.ilike(pattern, escape="\\"),
+                Notice.body.ilike(pattern, escape="\\"),
+                Notice.tag.ilike(pattern, escape="\\"),
+                _author.display_name.ilike(pattern, escape="\\"),
+            )
+        )
+
+    total_result = await db.execute(_joined_select(func.count(Notice.id)).where(*conditions))
+    total = total_result.scalar_one()
+    rows_result = await db.execute(
+        _joined_select(Notice, _author.display_name)
+        .where(*conditions)
+        .order_by(Notice.sort_order, Notice.published_at.desc(), Notice.id)
+        .offset(page.skip)
+        .limit(page.limit)
+    )
+    rows = rows_result.all()
+    targets = await _load_targets(db, [notice for notice, _ in rows])
+    items = [
+        _manage_list_item(notice, author_display_name, targets[notice.id])
+        for notice, author_display_name in rows
+    ]
+    has_more = page.skip + len(items) < total
+    return NoticeManagePage(
+        items=items,
+        skip=page.skip,
+        limit=page.limit,
+        total=total,
+        has_more=has_more,
+        next_skip=page.skip + len(items) if has_more else None,
+    )
+
+
+@router.get("/notices/manage/{notice_id}", response_model=NoticeManageRead)
+async def get_notice_for_manage(
+    notice_id: UUID,
+    member: CurrentMember,
+    db: DbSession,
+) -> NoticeManageRead:
+    _require_manager(member)
+    notice, author_display_name = await _manage_row(db, member, notice_id)
+    targets = (await _load_targets(db, [notice]))[notice.id]
+    body = await _render_body(db, member, notice.body)
+    return _manage_read(notice, author_display_name, targets, body)
+
+
+@router.post(
+    "/notices/images",
+    response_model=NoticeImageRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def upload_notice_image(
+    member: CurrentMember,
+    db: DbSession,
+    upload: Annotated[UploadFile, File()],
+) -> NoticeImageRead:
+    """본문에 넣을 사진을 받는다.
+
+    돌려주는 url 은 저장소 주소가 아니라 우리 내부 참조다. 본문에는 이것만 박히고, 볼 수 있는
+    주소는 읽을 때마다 새로 발급한다.
+
+    ponytail: 본문에서 빠진 사진의 저장소 객체는 아직 회수하지 않는다. notice_image 에
+    team_id 를 두었으므로 나중에 팀 단위로 훑어 정리할 수 있다.
+    """
+    _require_manager(member)
+    _require_storage()
+    content = await upload.read()
+
+    try:
+        check_size(len(content), NOTICE_IMAGE_MAX_BYTES)
+        allowed = check_image_upload(
+            file_name=upload.filename or "",
+            declared_media_type=upload.content_type,
+            content=content,
+        )
+    except UploadRejected as rejected:
+        raise HTTPException(status_code=rejected.status_code, detail=rejected.detail) from rejected
+
+    storage_key = storage.build_storage_key(member.team_id, allowed.extension)
+    try:
+        await storage.upload(
+            storage_key=storage_key,
+            content=content,
+            media_type=allowed.media_type,
+        )
+    except StorageError as error:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(error),
+        ) from error
+
+    image = NoticeImage(
+        id=uuid4(),
+        team_id=member.team_id,
+        uploaded_by_member_id=member.id,
+        storage_key=storage_key,
+        media_type=allowed.media_type,
+    )
+    try:
+        db.add(image)
+        await db.flush()
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        # DB 기록이 실패하면 올린 객체를 지워 고아를 남기지 않는다.
+        await storage.remove(storage_key=storage_key)
+        raise
+    return NoticeImageRead(id=image.id, url=f"{NOTICE_IMAGE_PREFIX}{image.id}")
+
+
 @router.get("/notices/{notice_id}", response_model=NoticeRead)
 async def get_notice(
     notice_id: UUID,
     member: CurrentMember,
     db: DbSession,
 ) -> NoticeRead:
-    return _notice_read(*await _notice_row(db, member, notice_id))
+    notice, author_display_name = await _notice_row(db, member, notice_id)
+    targets = (await _load_targets(db, [notice]))[notice.id]
+    body = await _render_body(db, member, notice.body)
+    return _notice_read(notice, author_display_name, targets, body)
+
+
+@router.post("/notices", response_model=NoticeManageRead, status_code=status.HTTP_201_CREATED)
+async def create_notice(
+    payload: NoticeCreate,
+    response: Response,
+    member: CurrentMember,
+    db: DbSession,
+) -> NoticeManageRead:
+    _require_manager(member)
+    body = _sanitize(payload.body)
+
+    targets: list[Member] = []
+    if payload.type == "DIRECTIVE":
+        targets = await _resolve_targets(db, member, payload.target_member_ids or [])
+
+    display_start_date = payload.display_start_date or _today()
+    _check_display_range(display_start_date, payload.display_end_date)
+
+    now = datetime.now(UTC)
+    notice = Notice(
+        id=uuid4(),
+        team_id=member.team_id,
+        author_member_id=member.id,
+        type=payload.type,
+        tag=payload.tag,
+        title=payload.title,
+        body=body,
+        # DB 기본값에 기대지 않고 넣는다. 넣은 객체를 그대로 응답으로 쓰기 때문이다.
+        image_storage_key=None,
+        image_alt=payload.image_alt,
+        published_at=now,
+        due_at=payload.due_at,
+        due_text=payload.due_text,
+        display_start_date=display_start_date,
+        display_end_date=payload.display_end_date,
+        is_hidden=payload.is_hidden,
+        sort_order=payload.sort_order,
+        updated_at=now,
+        deleted_at=None,
+    )
+    db.add(notice)
+    for target in targets:
+        db.add(NoticeTarget(notice_id=notice.id, member_id=target.id))
+    await _flush_and_commit(db)
+
+    response.headers["Location"] = f"/api/notices/{notice.id}"
+    return _manage_read(
+        notice,
+        member.display_name,
+        [NoticeTargetRead(id=target.id, display_name=target.display_name) for target in targets],
+        await _render_body(db, member, notice.body),
+    )
+
+
+@router.patch("/notices/{notice_id}", response_model=NoticeManageRead)
+async def update_notice(
+    notice_id: UUID,
+    payload: NoticePatch,
+    member: CurrentMember,
+    db: DbSession,
+) -> NoticeManageRead:
+    _require_manager(member)
+    values = payload.model_dump(exclude_unset=True)
+
+    try:
+        notice = await _notice_for_update(db, member, notice_id)
+
+        final_type = values.get("type", notice.type)
+        # 수신자를 어떻게 할지 먼저 정한다. None 은 "그대로 둔다" 는 뜻이다.
+        if "target_member_ids" in values:
+            requested_targets = values.pop("target_member_ids")
+        elif final_type != notice.type:
+            # 종류가 바뀌는데 수신자를 주지 않았다. 공지로 가면 비우고, 지시로 가면 받아야 한다.
+            if final_type == "DIRECTIVE":
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                    detail="directive_target_required",
+                )
+            requested_targets = []
+        else:
+            requested_targets = None
+
+        if final_type == "NOTICE" and requested_targets:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail="notice_cannot_have_targets",
+            )
+        if final_type == "DIRECTIVE" and requested_targets is not None and not requested_targets:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail="directive_target_required",
+            )
+
+        resolved: list[Member] = []
+        if requested_targets and final_type == "DIRECTIVE":
+            resolved = await _resolve_targets(db, member, requested_targets)
+
+        if "body" in values:
+            values["body"] = _sanitize(values["body"])
+
+        for field_name, value in values.items():
+            setattr(notice, field_name, value)
+        _check_display_range(notice.display_start_date, notice.display_end_date)
+        notice.updated_at = datetime.now(UTC)
+
+        if requested_targets is not None:
+            # 수신자는 통째로 갈아 끼운다. 지운 뒤 고른 순서대로 다시 넣는다.
+            await db.execute(delete(NoticeTarget).where(NoticeTarget.notice_id == notice.id))
+            for target in resolved:
+                db.add(NoticeTarget(notice_id=notice.id, member_id=target.id))
+
+        await db.flush()
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+
+    notice, author_display_name = await _manage_row(db, member, notice_id)
+    targets = (await _load_targets(db, [notice]))[notice.id]
+    body = await _render_body(db, member, notice.body)
+    return _manage_read(notice, author_display_name, targets, body)
+
+
+@router.delete("/notices/{notice_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_notice(
+    notice_id: UUID,
+    member: CurrentMember,
+    db: DbSession,
+) -> None:
+    """지우지 않고 가린다. 수신자 행은 남겨 되살릴 여지를 없애지 않는다."""
+    _require_manager(member)
+    try:
+        notice = await _notice_for_update(db, member, notice_id)
+        now = datetime.now(UTC)
+        notice.deleted_at = now
+        notice.updated_at = now
+        await db.flush()
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise

--- a/backend/app/models/workspace.py
+++ b/backend/app/models/workspace.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 from uuid import UUID
 
 from sqlalchemy import ForeignKey, text
@@ -41,12 +41,51 @@ class Notice(Base):
     id: Mapped[UUID] = mapped_column(primary_key=True)
     team_id: Mapped[UUID] = mapped_column(ForeignKey("public.team.id"))
     author_member_id: Mapped[UUID] = mapped_column(ForeignKey("public.member.id"))
-    recipient_member_id: Mapped[UUID | None] = mapped_column(ForeignKey("public.member.id"))
+    # NOTICE 는 팀 전체가 보고, DIRECTIVE 는 NoticeTarget 이 가리키는 사람만 본다.
+    type: Mapped[str]
     tag: Mapped[str | None]
     title: Mapped[str]
+    # 허용 태그만 남긴 HTML. services.html_sanitize 를 지나야 여기에 들어온다.
     body: Mapped[str]
     image_storage_key: Mapped[str | None]
     image_alt: Mapped[str | None]
     published_at: Mapped[datetime] = mapped_column(server_default=text("now()"))
     due_at: Mapped[datetime | None]
     due_text: Mapped[str | None]
+    # 노출 기간은 날짜다. 기준 시간대는 Asia/Seoul 이고 시작일과 종료일 모두 그 날을 포함한다.
+    # DB 기본값을 두지 않았으므로 앱이 항상 값을 넣는다.
+    display_start_date: Mapped[date]
+    display_end_date: Mapped[date | None]
+    is_hidden: Mapped[bool] = mapped_column(server_default=text("false"))
+    sort_order: Mapped[int] = mapped_column(server_default=text("0"))
+    updated_at: Mapped[datetime] = mapped_column(server_default=text("now()"))
+    deleted_at: Mapped[datetime | None]
+
+
+class NoticeTarget(Base):
+    """지시 한 건의 수신자. 공지에는 행이 없다. created_at 순서가 곧 표시 순서다."""
+
+    __tablename__ = "notice_target"
+
+    notice_id: Mapped[UUID] = mapped_column(
+        ForeignKey("public.notice.id", ondelete="CASCADE"), primary_key=True
+    )
+    member_id: Mapped[UUID] = mapped_column(ForeignKey("public.member.id"), primary_key=True)
+    created_at: Mapped[datetime] = mapped_column(server_default=text("now()"))
+
+
+class NoticeImage(Base):
+    """공지 본문에 넣은 사진.
+
+    본문 HTML 은 `/notice-images/{id}` 로만 가리킨다. 저장소 주소(storage_key)는 응답에
+    나가지 않고, 실제로 볼 수 있는 주소는 읽을 때마다 서명 URL 로 새로 발급한다.
+    """
+
+    __tablename__ = "notice_image"
+
+    id: Mapped[UUID] = mapped_column(primary_key=True)
+    team_id: Mapped[UUID] = mapped_column(ForeignKey("public.team.id"))
+    uploaded_by_member_id: Mapped[UUID] = mapped_column(ForeignKey("public.member.id"))
+    storage_key: Mapped[str]
+    media_type: Mapped[str]
+    created_at: Mapped[datetime] = mapped_column(server_default=text("now()"))

--- a/backend/app/schemas/dashboard.py
+++ b/backend/app/schemas/dashboard.py
@@ -5,12 +5,14 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field
 
 from app.schemas.activities import ActivityRead
+from app.schemas.notices import NoticeType
 
 
 class NoticeBrief(BaseModel):
     """티커에 세우는 한 줄. 본문과 이미지는 눌렀을 때 /api/notices/{id} 가 준다."""
 
     id: UUID
+    type: NoticeType
     tag: str | None
     author_display_name: str
     title: str

--- a/backend/app/schemas/notices.py
+++ b/backend/app/schemas/notices.py
@@ -1,3 +1,4 @@
+from datetime import date as Date
 from datetime import datetime
 from typing import Annotated, Literal, Self
 from uuid import UUID
@@ -8,19 +9,48 @@ SearchQuery = Annotated[
     str,
     StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=100),
 ]
+Title = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=254),
+]
+Tag = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=64),
+]
+ShortText = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=254),
+]
+# 편집기가 만든 HTML. 여기서는 길이만 본다. 허용 태그는 services.html_sanitize 가 정한다.
+BodyHtml = Annotated[
+    str,
+    StringConstraints(strict=True, min_length=1, max_length=200_000),
+]
 
 # team 은 수신자가 없는 팀 공지, personal 은 로그인한 사람에게 온 지시다.
+# 종류 컬럼(type)이 생긴 뒤로는 NOTICE/DIRECTIVE 와 1:1 이며, 기존 호출자를 위해 남겨 둔다.
 NoticeScope = Literal["team", "personal"]
+NoticeType = Literal["NOTICE", "DIRECTIVE"]
+
+# 노출 순서는 팀장이 손으로 넣는다. 화면이 다루기 어려운 값이 들어오지 않게 폭을 좁힌다.
+_SORT_ORDER = Field(ge=-9_999, le=9_999)
 
 
 class NoticeRead(BaseModel):
+    """팀원이 보는 공지 한 건."""
+
     id: UUID
     scope: NoticeScope
+    type: NoticeType
     author_member_id: UUID
     author_display_name: str
+    # 수신자가 정확히 한 명일 때만 그 사람이다. 여러 명이거나 공지면 None 이다.
+    # ponytail: 수신자가 여러 명이 될 수 있게 되면서 뜻이 좁아졌다. 화면이 targets 로
+    # 옮겨 간 뒤 뗀다.
     recipient_member_id: UUID | None
     tag: str | None
     title: str
+    # 허용 태그만 남은 HTML. 사진 주소는 이 응답을 만들 때 서명 URL 로 바꿔 넣는다.
     body: str
     # image_storage_key 는 내부 저장소 주소라 응답하지 않는다. 대체 텍스트만 내보낸다.
     image_alt: str | None
@@ -38,10 +68,137 @@ class NoticePage(BaseModel):
     next_skip: int | None
 
 
+class NoticeTargetRead(BaseModel):
+    id: UUID
+    display_name: str
+
+
+class NoticeManageListItem(BaseModel):
+    """팀장 관리 목록의 한 줄.
+
+    본문(body)을 싣지 않는다. 본문 안의 사진마다 서명 URL 을 발급해야 하는데, 목록은 한 번에
+    30건이라 발급 호출이 곱절로 늘어난다. 폼을 열 때 단건 조회가 본문을 준다.
+    """
+
+    id: UUID
+    type: NoticeType
+    author_member_id: UUID
+    author_display_name: str
+    tag: str | None
+    title: str
+    image_alt: str | None
+    published_at: datetime
+    due_at: datetime | None
+    due_text: str | None
+    display_start_date: Date
+    display_end_date: Date | None
+    is_hidden: bool
+    sort_order: int
+    targets: list[NoticeTargetRead]
+    target_member_ids: list[UUID]
+    updated_at: datetime
+
+
+class NoticeManageRead(NoticeManageListItem):
+    """수정 폼이 채워 넣을 한 건. 목록 항목에 본문을 더한 것이다."""
+
+    body: str
+
+
+class NoticeManagePage(BaseModel):
+    items: list[NoticeManageListItem]
+    skip: int
+    limit: int
+    total: int
+    has_more: bool
+    next_skip: int | None
+
+
+class NoticeImageRead(BaseModel):
+    """올린 사진. url 은 본문에 그대로 박는 내부 참조다."""
+
+    id: UUID
+    url: str
+
+
+class _WriteModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class NoticeCreate(_WriteModel):
+    type: NoticeType
+    title: Title
+    body: BodyHtml
+    tag: Tag | None = None
+    image_alt: ShortText | None = None
+    due_at: datetime | None = None
+    due_text: ShortText | None = None
+    # 주지 않으면 라우터가 오늘(Asia/Seoul)로 채운다.
+    display_start_date: Date | None = None
+    display_end_date: Date | None = None
+    is_hidden: bool = False
+    sort_order: Annotated[int, _SORT_ORDER] = 0
+    # DIRECTIVE 에만 쓴다. NOTICE 에 주면 거절한다.
+    target_member_ids: list[UUID] | None = None
+
+    @model_validator(mode="after")
+    def _validate(self) -> Self:
+        if self.display_start_date is not None and self.display_end_date is not None:
+            if self.display_end_date < self.display_start_date:
+                raise ValueError("invalid_notice_display_range")
+        if self.type == "NOTICE" and self.target_member_ids:
+            raise ValueError("notice_cannot_have_targets")
+        if self.type == "DIRECTIVE" and not self.target_member_ids:
+            raise ValueError("directive_target_required")
+        return self
+
+
+class NoticePatch(_WriteModel):
+    """보낸 항목만 바꾼다.
+
+    종류와 수신자의 정합성은 여기서 보지 않는다. 부분 값만 오므로 바뀐 뒤의 모습을 알 수 없고,
+    라우터가 기존 행과 합친 뒤에 판단한다.
+    """
+
+    type: NoticeType | None = None
+    title: Title | None = None
+    body: BodyHtml | None = None
+    tag: Tag | None = None
+    image_alt: ShortText | None = None
+    due_at: datetime | None = None
+    due_text: ShortText | None = None
+    display_start_date: Date | None = None
+    # None 을 명시하면 무기한으로 되돌린다.
+    display_end_date: Date | None = None
+    is_hidden: bool | None = None
+    sort_order: Annotated[int, _SORT_ORDER] | None = None
+    # 보내면 수신자 전체를 이 목록으로 바꾼다.
+    target_member_ids: list[UUID] | None = None
+
+    @model_validator(mode="after")
+    def required_fields_cannot_be_null(self) -> Self:
+        for field_name in (
+            "type",
+            "title",
+            "body",
+            "display_start_date",
+            "is_hidden",
+            "sort_order",
+            "target_member_ids",
+        ):
+            if field_name in self.model_fields_set and getattr(self, field_name) is None:
+                raise ValueError(f"{field_name} cannot be null")
+        if self.display_start_date is not None and self.display_end_date is not None:
+            if self.display_end_date < self.display_start_date:
+                raise ValueError("invalid_notice_display_range")
+        return self
+
+
 class NoticePageParams(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     scope: NoticeScope | None = None
+    type: NoticeType | None = None
     q: SearchQuery | None = None
     published_from: datetime | None = None
     published_to: datetime | None = None
@@ -53,4 +210,19 @@ class NoticePageParams(BaseModel):
         if self.published_from is not None and self.published_to is not None:
             if self.published_to < self.published_from:
                 raise ValueError("invalid_notice_range")
+        if self.scope is not None and self.type is not None:
+            wanted = "NOTICE" if self.scope == "team" else "DIRECTIVE"
+            if self.type != wanted:
+                raise ValueError("conflicting_notice_filter")
         return self
+
+
+class NoticeManagePageParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: NoticeType | None = None
+    q: SearchQuery | None = None
+    # 팀장 화면이라 숨긴 것도 기본으로 함께 본다. 숨겨야 고칠 수 있다.
+    include_hidden: bool = True
+    skip: int = Field(default=0, ge=0, le=9_223_372_036_854_775_807)
+    limit: int = Field(default=30, ge=1, le=30)

--- a/backend/app/services/html_sanitize.py
+++ b/backend/app/services/html_sanitize.py
@@ -1,0 +1,103 @@
+"""공지 본문 HTML 에서 허용한 것만 남긴다.
+
+이 결과는 브라우저에서 그대로 innerHTML 이 된다(프론트 NoticeDrawer). 저장형 XSS 를 막는
+방어선이 여기 하나뿐이므로 단순화를 이유로 느슨하게 두지 않는다.
+
+편집기(프론트 components/RichTextEditor)도 valid_elements 로 태그를 좁히지만 그건 화면의
+편의다. API 는 편집기를 거치지 않은 요청도 받으므로 저장 직전에 서버가 다시 자른다.
+두 허용목록은 한 쌍이다. 한쪽만 넓히면 화면에서 넣은 것이 저장할 때 조용히 사라진다.
+"""
+
+import re
+
+import nh3
+
+_TAGS: set[str] = {
+    "p",
+    "br",
+    "strong",
+    "b",
+    "em",
+    "i",
+    "u",
+    "s",
+    "ul",
+    "ol",
+    "li",
+    "blockquote",
+    "h2",
+    "h3",
+    "h4",
+    "a",
+    "img",
+}
+_ATTRIBUTES: dict[str, set[str]] = {
+    # rel 은 두지 않는다. link_rel 이 noopener 를 직접 붙이므로 nh3 가 허용을 거부한다.
+    "a": {"href", "title", "target"},
+    "img": {"src", "alt", "title", "width", "height"},
+}
+# 사진은 저장소에 올리고 본문에는 내부 참조만 둔다. data: 를 열면 본문이 통째로 커지고
+# 사진마다 다른 검사 경로가 생기므로 받지 않는다.
+_URL_SCHEMES: set[str] = {"http", "https", "mailto"}
+
+# 본문이 가리킬 수 있는 사진 주소. POST /api/notices/images 가 돌려주는 모양 그대로다.
+NOTICE_IMAGE_PREFIX = "/notice-images/"
+_IMAGE_SRC = re.compile(
+    r"^/notice-images/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+_IMG_TAG = re.compile(r"<img\b[^>]*>", re.IGNORECASE)
+_SRC_ATTR = re.compile(r"""\bsrc\s*=\s*["']([^"']*)["']""", re.IGNORECASE)
+
+
+class BodyEmpty(ValueError):
+    """태그를 다 벗기고 나니 글자가 하나도 남지 않았다."""
+
+
+def _drop_foreign_images(html: str) -> str:
+    """우리 저장소가 아닌 사진을 버린다.
+
+    nh3 는 스킴만 보고 경로 모양은 보지 못한다. 상대 경로는 스킴이 없어 그대로 통과하므로
+    `/notice-images/{uuid}` 가 아닌 src 는 여기서 걷어낸다. 외부 주소를 그리면 열람자
+    아이피가 그쪽으로 새고, 사진이 언제든 다른 것으로 바뀔 수 있다.
+    """
+
+    def keep(match: re.Match[str]) -> str:
+        src = _SRC_ATTR.search(match.group(0))
+        if src is not None and _IMAGE_SRC.match(src.group(1)):
+            return match.group(0)
+        return ""
+
+    return _IMG_TAG.sub(keep, html)
+
+
+def strip_tags(html: str) -> str:
+    """태그를 모두 벗긴 글자만 남긴다. 본문이 비었는지 볼 때 쓴다."""
+    return nh3.clean(html, tags=set())
+
+
+def sanitize_body(html: str) -> str:
+    """허용목록 밖을 전부 잘라낸 HTML 을 돌려준다. 남는 글자가 없으면 BodyEmpty 다."""
+    cleaned = _drop_foreign_images(
+        nh3.clean(
+            html,
+            tags=_TAGS,
+            attributes=_ATTRIBUTES,
+            url_schemes=_URL_SCHEMES,
+            link_rel="noopener noreferrer",
+            strip_comments=True,
+        )
+    )
+    # notice.body 에 btrim(body) <> '' CHECK 가 걸려 있다. 사진만 있는 본문은 허용한다.
+    if strip_tags(cleaned).strip() == "" and NOTICE_IMAGE_PREFIX not in cleaned:
+        raise BodyEmpty
+    return cleaned
+
+
+def image_ids(html: str) -> list[str]:
+    """본문이 가리키는 사진 id 를 처음 나온 순서대로 돌려준다. 중복은 한 번만 센다."""
+    found: dict[str, None] = {}
+    for tag in _IMG_TAG.findall(html):
+        src = _SRC_ATTR.search(tag)
+        if src is not None and _IMAGE_SRC.match(src.group(1)):
+            found[src.group(1).removeprefix(NOTICE_IMAGE_PREFIX)] = None
+    return list(found)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
     "asyncpg>=0.31.0",
     "fastapi>=0.141.1",
     "httpx>=0.28.1",
+    "nh3>=0.3.1",
     "pydantic-settings>=2.14.2",
     "pyjwt[crypto]>=2.10.1",
     "python-multipart>=0.0.32",

--- a/backend/sql/20260825_0005_notice_management.sql
+++ b/backend/sql/20260825_0005_notice_management.sql
@@ -1,0 +1,129 @@
+-- 공지와 팀장 지시사항을 팀장이 직접 관리하게 한다.
+--
+-- 지금까지 notice 는 recipient_member_id 하나로 "없으면 팀 공지, 있으면 개인 지시" 를 겸했다.
+-- 지시 한 건을 여러 명에게 보내야 하므로 종류(type)를 컬럼으로 세우고 수신자는 notice_target
+-- 으로 옮긴다. 옮긴 뒤 recipient_member_id 는 뗀다.
+--
+-- 노출 기간은 date 다. 업무상 의미가 "게시 기간" 이지 "게시 시각" 이 아니고, 기준 시간대가
+-- Asia/Seoul 이라 timestamptz 로 두면 UTC 로 비교되는 하루가 화면이 말하는 하루와 어긋난다.
+-- 시작일과 종료일 모두 그 날을 포함한다. 종료일이 없으면 무기한이다.
+--
+-- 본문(body)은 이제 편집기가 만든 HTML 이다. 저장 직전에 서버(app/services/html_sanitize.py)가
+-- 허용한 태그만 남긴다. 본문 안의 사진은 notice_image 가 가리키는 저장소 객체다.
+
+BEGIN;
+
+-- 1) 종류. 기존 행은 수신자 유무로 가른다.
+ALTER TABLE public.notice
+    ADD COLUMN type text CHECK (type IN ('NOTICE', 'DIRECTIVE'));
+
+UPDATE public.notice
+   SET type = CASE WHEN recipient_member_id IS NULL THEN 'NOTICE' ELSE 'DIRECTIVE' END;
+
+ALTER TABLE public.notice
+    ALTER COLUMN type SET NOT NULL;
+
+COMMENT ON COLUMN public.notice.type IS
+    'NOTICE 는 팀 전체 공지, DIRECTIVE 는 notice_target 이 가리키는 사람에게 가는 지시다.';
+
+-- 2) 노출 기간. 시작일은 기존 게시 시각의 서울 날짜로 백필하고 종료일은 비운다(무기한).
+--    DEFAULT 는 두지 않는다. 앱이 항상 값을 넣고, tests/test_models.py 가 대조하는
+--    server_default 문자열을 Postgres 가 정규화해 되돌려 주면서 어긋날 여지를 남기지 않는다.
+ALTER TABLE public.notice
+    ADD COLUMN display_start_date date,
+    ADD COLUMN display_end_date date;
+
+UPDATE public.notice
+   SET display_start_date = (published_at AT TIME ZONE 'Asia/Seoul')::date;
+
+ALTER TABLE public.notice
+    ALTER COLUMN display_start_date SET NOT NULL;
+
+ALTER TABLE public.notice
+    ADD CONSTRAINT notice_display_range_check
+        CHECK (display_end_date IS NULL OR display_end_date >= display_start_date);
+
+COMMENT ON COLUMN public.notice.display_start_date IS
+    '노출 시작일(Asia/Seoul, 그 날 포함). 이 날부터 화면에 선다.';
+COMMENT ON COLUMN public.notice.display_end_date IS
+    '노출 종료일(Asia/Seoul, 그 날 포함). NULL 이면 무기한이다.';
+
+-- 3) 숨김과 정렬. 숨김은 지우는 것이 아니라 잠깐 내리는 것이다.
+ALTER TABLE public.notice
+    ADD COLUMN is_hidden boolean NOT NULL DEFAULT false,
+    ADD COLUMN sort_order integer NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN public.notice.is_hidden IS
+    '켜면 팀장 관리 화면에만 남고 대시보드와 목록에서 빠진다.';
+COMMENT ON COLUMN public.notice.sort_order IS
+    '작을수록 위에 선다. 같으면 published_at 최신순이다.';
+
+-- 4) 수정과 삭제 흔적. activity, sales_deal 의 deleted_at 과 같은 뜻이다.
+ALTER TABLE public.notice
+    ADD COLUMN updated_at timestamptz NOT NULL DEFAULT now(),
+    ADD COLUMN deleted_at timestamptz;
+
+COMMENT ON COLUMN public.notice.deleted_at IS
+    '삭제한 시각. 행을 지우지 않고 이 값으로 가린다.';
+COMMENT ON COLUMN public.notice.body IS
+    '허용 태그만 남긴 HTML. app/services/html_sanitize.py 를 지나야 들어온다.';
+
+-- 5) 수신자 매핑. activity_companion 과 같은 모양이다.
+CREATE TABLE public.notice_target (
+    notice_id uuid NOT NULL
+        REFERENCES public.notice (id) ON DELETE CASCADE,
+    member_id uuid NOT NULL REFERENCES public.member (id),
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (notice_id, member_id)
+);
+
+COMMENT ON TABLE public.notice_target IS
+    '지시 한 건의 수신자. 공지(NOTICE)에는 행이 없다. created_at 순서가 표시 순서다.';
+
+-- 자기에게 온 지시를 훑는 조회가 member_id 로 들어온다.
+CREATE INDEX notice_target_member_idx ON public.notice_target (member_id);
+
+-- 기존 수신자 1명을 그대로 옮긴다.
+INSERT INTO public.notice_target (notice_id, member_id)
+SELECT id, recipient_member_id
+  FROM public.notice
+ WHERE recipient_member_id IS NOT NULL;
+
+-- 6) 본문에 넣은 사진. 편집기가 올리면 여기에 한 행이 남고 본문에는 id 만 박힌다.
+--    storage_key 는 product.image_storage_key 와 같은 뜻이며 API 응답에 나가지 않는다.
+CREATE TABLE public.notice_image (
+    id uuid PRIMARY KEY,
+    team_id uuid NOT NULL REFERENCES public.team (id),
+    uploaded_by_member_id uuid NOT NULL REFERENCES public.member (id),
+    storage_key text NOT NULL CHECK (btrim(storage_key) <> ''),
+    media_type text NOT NULL CHECK (btrim(media_type) <> ''),
+    created_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.notice_image IS
+    '공지 본문에 들어간 사진. 본문 HTML 은 /notice-images/{id} 로만 가리키고, 실제 주소는 '
+    '읽을 때마다 서명 URL 로 새로 발급한다.';
+
+CREATE INDEX notice_image_team_idx ON public.notice_image (team_id);
+
+-- 7) 옛 인덱스와 컬럼을 뗀다. 조회 조건이 recipient_member_id 를 더 보지 않는다.
+DROP INDEX IF EXISTS public.notice_team_recipient_published_idx;
+
+ALTER TABLE public.notice
+    DROP COLUMN recipient_member_id;
+
+-- 팀원 목록과 팀장 관리 목록이 모두 (team_id, type) 으로 좁히고 sort_order, published_at 으로
+-- 세운다. 지워진 행은 어느 쪽도 보지 않는다.
+CREATE INDEX notice_team_type_order_idx
+    ON public.notice (team_id, type, sort_order, published_at DESC)
+    WHERE deleted_at IS NULL;
+
+-- 지금 화면에 서는 것만 훑는 대시보드 경로.
+CREATE INDEX notice_visible_idx
+    ON public.notice (team_id, type, display_start_date, display_end_date)
+    WHERE deleted_at IS NULL AND is_hidden = false;
+
+ALTER TABLE public.notice_target ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.notice_image ENABLE ROW LEVEL SECURITY;
+
+COMMIT;

--- a/backend/sql/README.md
+++ b/backend/sql/README.md
@@ -57,6 +57,16 @@
   상품 목록(`GET /api/products`)은 발주·영업 화면이 함께 쓰므로 팀원에게도 그대로 열려 있고,
   쓰기(`POST /api/products`, 사진 업로드)만 팀장으로 제한합니다.
 
+- `20260825_0005_notice_management.sql`: 공지·지시사항을 팀장이 직접 관리하게 합니다.
+  `notice`에 `type`(NOTICE/DIRECTIVE), `display_start_date`·`display_end_date`(date, 양끝 포함),
+  `is_hidden`, `sort_order`, `updated_at`, `deleted_at`을 더하고 **`recipient_member_id`를 뗍니다.**
+  수신자는 지시 하나에 여러 명이 붙을 수 있으므로 `notice_target` 매핑 테이블로 옮깁니다.
+  기존 행은 수신자 유무로 `type`을, 게시 시각의 서울 날짜로 `display_start_date`를 백필하고
+  종료일은 비워 무기한으로 둡니다. 본문(`body`)은 이제 편집기가 만든 HTML이며
+  `app/services/html_sanitize.py`가 허용한 태그만 남깁니다. 본문에 넣은 사진은
+  `notice_image`가 가리키는 저장소 객체이고, 본문에는 `/notice-images/{id}`만 박힙니다.
+  `storage_key`는 `notice.image_storage_key`와 같은 뜻이며 API 응답에 나가지 않습니다.
+
 `20260819_0001`은 빈 `public` 스키마에 처음부터 만드는 것을 전제로 합니다. 되돌리는 마이그레이션이
 아니므로 적용 전에 아래 런북의 1~2단계를 먼저 수행합니다.
 
@@ -70,6 +80,7 @@
 | 2026-08-24 | 개발 | `20260824_0003_customer_contact_assignees.sql` | session pooler | 성공. customer_company +1컬럼 / customer_contact +1컬럼 / customer_contact_assignee 신설(RLS on). 기존 고객 2건의 등록자·담당자를 owner_member_id 로 백필 |
 | 2026-08-24 | 개발 | `20260824_0004_customer_contact_visited.sql` | session pooler | 성공. customer_contact +1컬럼(`visited` boolean NOT NULL DEFAULT false). 기존 고객 2건 모두 기본값대로 미방문 |
 | 2026-08-24 | 개발 | `20260824_0004_product_fields.sql` | session pooler | 성공. product 4→9컬럼(`category_code`, `unit_price`, `shelf_life_months`, `memo`, `image_storage_key`). 기존 product 행이 0건이라 백필 대상 없음. `tests/test_models.py` 통과 |
+| 2026-08-25 | 개발 | `20260825_0005_notice_management.sql` | session pooler | 성공. notice 12→18컬럼(`recipient_member_id` 제거, `type`·`display_start_date`·`display_end_date`·`is_hidden`·`sort_order`·`updated_at`·`deleted_at` 추가) / notice_target·notice_image 신설(RLS on) / `notice_team_recipient_published_idx` 를 `notice_team_type_order_idx`·`notice_visible_idx` 로 교체. 기존 notice 행이 0건이라 백필 대상 없음 |
 
 ## 개발 DB 재구축 런북
 
@@ -103,6 +114,8 @@ DROP TABLE IF EXISTS
     public.sales_target,
     public.support_response,
     public.support_request,
+    public.notice_image,
+    public.notice_target,
     public.notice,
     public.activity_companion,
     public.activity,

--- a/backend/tests/test_dashboard.py
+++ b/backend/tests/test_dashboard.py
@@ -124,15 +124,21 @@ def _notice(author: Member) -> Notice:
         id=uuid4(),
         team_id=author.team_id,
         author_member_id=author.id,
-        recipient_member_id=None,
+        type="NOTICE",
         tag="공지",
         title="합성 공지",
-        body="합성 본문",
+        body="<p>합성 본문</p>",
         image_storage_key="team/secret-object-key.png",
         image_alt=None,
         published_at=NOW,
         due_at=None,
         due_text=None,
+        display_start_date=NOW.date(),
+        display_end_date=None,
+        is_hidden=False,
+        sort_order=0,
+        updated_at=NOW,
+        deleted_at=None,
     )
 
 

--- a/backend/tests/test_html_sanitize.py
+++ b/backend/tests/test_html_sanitize.py
@@ -1,0 +1,83 @@
+"""공지 본문 sanitize.
+
+이 결과가 브라우저에서 그대로 innerHTML 이 되므로, 통과하면 안 되는 것을 하나씩 못박는다.
+"""
+
+import pytest
+
+from app.services.html_sanitize import BodyEmpty, image_ids, sanitize_body
+
+_IMAGE = "/notice-images/11111111-2222-3333-4444-555555555555"
+
+
+def test_allowed_markup_survives():
+    body = sanitize_body("<p><strong>공지</strong>입니다.</p><ul><li>첫째</li></ul>")
+    assert body == "<p><strong>공지</strong>입니다.</p><ul><li>첫째</li></ul>"
+
+
+def test_script_tag_is_removed():
+    body = sanitize_body("<p>안녕</p><script>alert(1)</script>")
+    assert "script" not in body
+    assert "alert" not in body
+
+
+def test_event_handler_attribute_is_removed():
+    body = sanitize_body(f'<img src="{_IMAGE}" onerror="alert(1)">')
+    assert "onerror" not in body
+    assert _IMAGE in body
+
+
+def test_javascript_href_is_removed():
+    body = sanitize_body('<p><a href="javascript:alert(1)">누르기</a></p>')
+    assert "javascript" not in body
+
+
+def test_external_link_gets_noopener():
+    body = sanitize_body('<p><a href="https://example.com">링크</a></p>')
+    assert 'rel="noopener noreferrer"' in body
+
+
+def test_image_outside_our_storage_is_dropped():
+    body = sanitize_body('<p>본문</p><img src="https://evil.example/track.png">')
+    assert "<img" not in body
+    assert "evil.example" not in body
+
+
+def test_relative_path_pretending_to_be_our_image_is_dropped():
+    body = sanitize_body('<p>본문</p><img src="/notice-images/../../etc/passwd">')
+    assert "<img" not in body
+
+
+def test_data_uri_image_is_dropped():
+    body = sanitize_body('<p>본문</p><img src="data:image/png;base64,AAAA">')
+    assert "<img" not in body
+
+
+def test_unknown_tag_is_unwrapped_but_text_stays():
+    body = sanitize_body("<p>앞</p><marquee>가운데</marquee>")
+    assert "marquee" not in body
+    assert "가운데" in body
+
+
+def test_body_that_becomes_empty_is_rejected():
+    with pytest.raises(BodyEmpty):
+        sanitize_body("<script>alert(1)</script>")
+
+
+def test_whitespace_only_body_is_rejected():
+    with pytest.raises(BodyEmpty):
+        sanitize_body("<p>   </p>")
+
+
+def test_image_only_body_is_allowed():
+    """사진 한 장만 올린 공지도 본문으로 인정한다."""
+    assert sanitize_body(f'<img src="{_IMAGE}">').startswith("<img")
+
+
+def test_image_ids_are_collected_in_order_without_duplicates():
+    other = "/notice-images/99999999-8888-7777-6666-555555555555"
+    html = f'<img src="{_IMAGE}"><img src="{other}"><img src="{_IMAGE}">'
+    assert image_ids(html) == [
+        "11111111-2222-3333-4444-555555555555",
+        "99999999-8888-7777-6666-555555555555",
+    ]

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -23,7 +23,12 @@ EXPECTED_COLUMN_COUNTS = {
     # 20260824_0004 로 product 에 category_code/unit_price/shelf_life_months/memo/
     # image_storage_key 가 늘었다.
     "product": 9,
-    "notice": 12,
+    # 20260825_0005 로 notice 에 type/display_start_date/display_end_date/is_hidden/
+    # sort_order/updated_at/deleted_at 이 늘고 recipient_member_id 가 빠졌다.
+    # 수신자는 notice_target 으로 옮겼고, 본문 사진은 notice_image 가 가리킨다.
+    "notice": 18,
+    "notice_target": 3,
+    "notice_image": 6,
     "activity": 22,
     "activity_category": 10,
     "activity_action_tag": 10,
@@ -53,14 +58,14 @@ def test_all_database_tables_are_mapped():
     assert {
         table.name: len(table.columns) for table in Base.metadata.sorted_tables
     } == EXPECTED_COLUMN_COUNTS
-    assert sum(len(table.columns) for table in Base.metadata.tables.values()) == 279
+    assert sum(len(table.columns) for table in Base.metadata.tables.values()) == 294
 
     foreign_key_constraints = [
         foreign_key
         for table in Base.metadata.tables.values()
         for foreign_key in table.foreign_key_constraints
     ]
-    assert len(foreign_key_constraints) == 67
+    assert len(foreign_key_constraints) == 70
     assert all(
         element.column.table.schema == "public"
         for foreign_key in foreign_key_constraints

--- a/backend/tests/test_notices.py
+++ b/backend/tests/test_notices.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from uuid import UUID, uuid4
 
 import pytest
@@ -6,12 +6,15 @@ from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
 from app.api.deps import get_current_member
+from app.core.config import settings
 from app.db.session import get_db
 from app.main import app
 from app.models.workspace import Member, Notice
-from app.schemas.notices import NoticePageParams
+from app.schemas.notices import NoticeManagePageParams, NoticePageParams
 
+ORIGIN = settings.cors_origin_list[0]
 NOW = datetime(2026, 8, 17, 9, tzinfo=UTC)
+TODAY = date(2026, 8, 17)
 _MISSING = object()
 
 
@@ -24,6 +27,10 @@ class _Result:
         assert self.scalar is not _MISSING
         return self.scalar
 
+    def scalar_one_or_none(self):
+        assert len(self.rows) <= 1
+        return self.rows[0] if self.rows else None
+
     def one_or_none(self):
         assert len(self.rows) <= 1
         return self.rows[0] if self.rows else None
@@ -31,16 +38,34 @@ class _Result:
     def all(self):
         return self.rows
 
+    def scalars(self):
+        return self
+
 
 class _Db:
     def __init__(self, *results: _Result):
         self.results = list(results)
         self.statements = []
+        self.added = []
+        self.committed = False
+        self.rolled_back = False
 
     async def execute(self, statement):
         self.statements.append(statement)
         assert self.results, "예상보다 많은 쿼리가 실행되었습니다."
         return self.results.pop(0)
+
+    def add(self, instance):
+        self.added.append(instance)
+
+    async def flush(self):
+        return None
+
+    async def commit(self):
+        self.committed = True
+
+    async def rollback(self):
+        self.rolled_back = True
 
 
 @pytest.fixture(autouse=True)
@@ -61,21 +86,29 @@ def _member(*, role: str = "member", team_id: UUID | None = None) -> Member:
     )
 
 
-def _notice(author: Member, *, recipient_id: UUID | None = None) -> Notice:
-    return Notice(
-        id=uuid4(),
-        team_id=author.team_id,
-        author_member_id=author.id,
-        recipient_member_id=recipient_id,
-        tag="공지",
-        title="합성 공지",
-        body="합성 본문",
-        image_storage_key="team/secret-object-key.png",
-        image_alt="합성 이미지",
-        published_at=NOW,
-        due_at=None,
-        due_text=None,
-    )
+def _notice(author: Member, *, type: str = "NOTICE", **overrides) -> Notice:
+    fields = {
+        "id": uuid4(),
+        "team_id": author.team_id,
+        "author_member_id": author.id,
+        "type": type,
+        "tag": "공지",
+        "title": "합성 공지",
+        "body": "<p>합성 본문</p>",
+        "image_storage_key": "team/secret-object-key.png",
+        "image_alt": "합성 이미지",
+        "published_at": NOW,
+        "due_at": None,
+        "due_text": None,
+        "display_start_date": TODAY,
+        "display_end_date": None,
+        "is_hidden": False,
+        "sort_order": 0,
+        "updated_at": NOW,
+        "deleted_at": None,
+    }
+    fields.update(overrides)
+    return Notice(**fields)
 
 
 def _client(db: _Db, member: Member) -> TestClient:
@@ -94,6 +127,8 @@ def test_notice_page_params_reject_unsafe_values():
     with pytest.raises(ValidationError):
         NoticePageParams(scope="everyone")
     with pytest.raises(ValidationError):
+        NoticePageParams(type="EVERYONE")
+    with pytest.raises(ValidationError):
         NoticePageParams(
             published_from="2026-08-17T00:00:00+09:00",
             published_to="2026-08-10T00:00:00+09:00",
@@ -102,6 +137,22 @@ def test_notice_page_params_reject_unsafe_values():
         NoticePageParams(limit=31)
     with pytest.raises(ValidationError):
         NoticePageParams(recipient_member_id=str(uuid4()))
+
+
+def test_scope_and_type_filters_must_agree():
+    """옛 어휘와 새 어휘를 함께 보내면서 서로 다른 것을 가리키면 거절한다."""
+    with pytest.raises(ValidationError):
+        NoticePageParams(scope="team", type="DIRECTIVE")
+    assert NoticePageParams(scope="team", type="NOTICE").type == "NOTICE"
+
+
+def test_manage_page_params_reject_unsafe_values():
+    with pytest.raises(ValidationError):
+        NoticeManagePageParams(limit=31)
+    with pytest.raises(ValidationError):
+        NoticeManagePageParams(type="EVERYONE")
+    # 팀장 화면은 숨긴 것도 기본으로 함께 본다.
+    assert NoticeManagePageParams().include_hidden is True
 
 
 def test_storage_key_is_never_exposed():
@@ -122,25 +173,33 @@ def test_storage_key_is_never_exposed():
 def test_scope_splits_team_notice_and_personal_directive():
     member = _member()
     team_notice = _notice(member)
-    personal = _notice(member, recipient_id=member.id)
+    personal = _notice(member, type="DIRECTIVE")
 
     team_db = _Db(_Result(scalar=1), _Result(rows=[(team_notice, member.display_name)]))
     with _client(team_db, member) as client:
         team = client.get("/api/notices?scope=team")
     assert team.status_code == 200
     assert team.json()["items"][0]["scope"] == "team"
+    assert team.json()["items"][0]["type"] == "NOTICE"
     assert team.json()["items"][0]["recipient_member_id"] is None
-    assert "public.notice.recipient_member_id IS NULL" in str(team_db.statements[0])
+    assert "public.notice.type = " in str(team_db.statements[0])
 
-    personal_db = _Db(_Result(scalar=1), _Result(rows=[(personal, member.display_name)]))
+    personal_db = _Db(
+        _Result(scalar=1),
+        _Result(rows=[(personal, member.display_name)]),
+        # 지시는 수신자를 한 번 더 읽는다.
+        _Result(rows=[(personal.id, member.id, member.display_name)]),
+    )
     with _client(personal_db, member) as client:
         mine = client.get("/api/notices?scope=personal")
     assert mine.status_code == 200
     assert mine.json()["items"][0]["scope"] == "personal"
+    assert mine.json()["items"][0]["type"] == "DIRECTIVE"
+    # 수신자가 한 명이면 옛 필드도 그 사람을 가리킨다.
     assert mine.json()["items"][0]["recipient_member_id"] == str(member.id)
 
     sql = str(personal_db.statements[0])
-    assert "public.notice.recipient_member_id =" in sql
+    assert "EXISTS (SELECT public.notice_target.member_id" in sql
     assert member.id in personal_db.statements[0].compile().params.values()
 
 
@@ -157,8 +216,24 @@ def test_default_scope_hides_other_members_directive():
 
     sql = str(db.statements[0])
     # 팀 공지이거나 내가 수신자인 지시만 보인다.
-    assert "public.notice.recipient_member_id IS NULL OR public.notice.recipient_member_id =" in sql
+    assert "public.notice.type = " in sql
+    assert "EXISTS (SELECT public.notice_target.member_id" in sql
     assert "public.notice.team_id =" in sql
+
+
+def test_hidden_expired_and_deleted_notices_are_invisible():
+    """팀원 목록은 지운 것, 숨긴 것, 노출 기간 밖을 모두 걷어낸다."""
+    member = _member()
+    db = _Db(_Result(scalar=0), _Result(rows=[]))
+
+    with _client(db, member) as client:
+        assert client.get("/api/notices").status_code == 200
+
+    sql = str(db.statements[0])
+    assert "public.notice.deleted_at IS NULL" in sql
+    assert "public.notice.is_hidden IS false" in sql
+    assert "public.notice.display_start_date <=" in sql
+    assert "public.notice.display_end_date IS NULL OR public.notice.display_end_date >=" in sql
 
 
 def test_other_team_notice_is_hidden():
@@ -171,3 +246,266 @@ def test_other_team_notice_is_hidden():
     assert response.status_code == 404
     assert response.json() == {"detail": "notice_not_found"}
     assert member.team_id in db.statements[0].compile().params.values()
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "payload"),
+    [
+        ("get", "/api/notices/manage", None),
+        ("get", f"/api/notices/manage/{uuid4()}", None),
+        ("post", "/api/notices", {"type": "NOTICE", "title": "제목", "body": "<p>본문</p>"}),
+        ("patch", f"/api/notices/{uuid4()}", {"title": "제목"}),
+        ("delete", f"/api/notices/{uuid4()}", None),
+    ],
+)
+def test_writing_and_managing_requires_manager(method, path, payload):
+    member = _member(role="member")
+    db = _Db()
+
+    with _client(db, member) as client:
+        response = getattr(client, method)(
+            path, headers={"Origin": ORIGIN}, **({"json": payload} if payload else {})
+        )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "manager_required"}
+    assert db.statements == []
+
+
+def test_manage_route_is_not_shadowed_by_the_id_route():
+    """/notices/manage 가 /notices/{notice_id} 아래에 있으면 UUID 로 읽혀 422 가 난다."""
+    member = _member(role="member")
+    db = _Db()
+
+    with _client(db, member) as client:
+        response = client.get("/api/notices/manage")
+
+    assert response.status_code == 403
+
+
+def test_manage_list_keeps_hidden_and_ignores_display_period():
+    manager = _member(role="manager")
+    hidden = _notice(manager, is_hidden=True, display_end_date=date(2026, 1, 1))
+    db = _Db(_Result(scalar=1), _Result(rows=[(hidden, manager.display_name)]))
+
+    with _client(db, manager) as client:
+        response = client.get("/api/notices/manage")
+
+    assert response.status_code == 200
+    item = response.json()["items"][0]
+    assert item["is_hidden"] is True
+    # 목록은 본문을 싣지 않는다. 사진마다 서명 URL 을 발급하게 되기 때문이다.
+    assert "body" not in item
+
+    sql = str(db.statements[0])
+    assert "public.notice.deleted_at IS NULL" in sql
+    assert "is_hidden" not in sql
+    assert "display_start_date" not in sql
+
+
+def test_manage_list_can_hide_hidden_notices():
+    manager = _member(role="manager")
+    db = _Db(_Result(scalar=0), _Result(rows=[]))
+
+    with _client(db, manager) as client:
+        assert client.get("/api/notices/manage?include_hidden=false").status_code == 200
+
+    assert "public.notice.is_hidden IS false" in str(db.statements[0])
+
+
+def test_create_notice_stores_sanitized_body():
+    manager = _member(role="manager")
+    db = _Db()
+
+    with _client(db, manager) as client:
+        response = client.post(
+            "/api/notices",
+            headers={"Origin": ORIGIN},
+            json={
+                "type": "NOTICE",
+                "title": "합성 공지",
+                "body": '<p>안녕</p><script>alert(1)</script><img src="https://evil.example/x.png">',
+                "sort_order": -10,
+            },
+        )
+
+    assert response.status_code == 201
+    assert response.headers["Location"].startswith("/api/notices/")
+    assert db.committed is True
+
+    body = response.json()["body"]
+    assert "script" not in body
+    assert "evil.example" not in body
+    assert "<p>안녕</p>" in body
+    assert response.json()["sort_order"] == -10
+    assert response.json()["targets"] == []
+    # 오늘부터 무기한이 기본이다.
+    assert response.json()["display_end_date"] is None
+
+
+def test_create_notice_rejects_body_that_is_only_markup():
+    manager = _member(role="manager")
+    db = _Db()
+
+    with _client(db, manager) as client:
+        response = client.post(
+            "/api/notices",
+            headers={"Origin": ORIGIN},
+            json={"type": "NOTICE", "title": "합성 공지", "body": "<script>alert(1)</script>"},
+        )
+
+    assert response.status_code == 422
+    assert response.json() == {"detail": "notice_body_empty"}
+    assert db.committed is False
+
+
+def test_create_directive_requires_targets():
+    manager = _member(role="manager")
+    db = _Db()
+
+    with _client(db, manager) as client:
+        response = client.post(
+            "/api/notices",
+            headers={"Origin": ORIGIN},
+            json={
+                "type": "DIRECTIVE",
+                "title": "합성 지시",
+                "body": "<p>본문</p>",
+                "target_member_ids": [],
+            },
+        )
+
+    assert response.status_code == 422
+    assert db.committed is False
+
+
+def test_create_notice_rejects_targets():
+    manager = _member(role="manager")
+    db = _Db()
+
+    with _client(db, manager) as client:
+        response = client.post(
+            "/api/notices",
+            headers={"Origin": ORIGIN},
+            json={
+                "type": "NOTICE",
+                "title": "합성 공지",
+                "body": "<p>본문</p>",
+                "target_member_ids": [str(uuid4())],
+            },
+        )
+
+    assert response.status_code == 422
+    assert db.committed is False
+
+
+def test_create_directive_rejects_member_outside_the_team():
+    manager = _member(role="manager")
+    # 같은 팀에서 찾지 못하면 빈 결과가 돌아온다.
+    db = _Db(_Result(rows=[]))
+
+    with _client(db, manager) as client:
+        response = client.post(
+            "/api/notices",
+            headers={"Origin": ORIGIN},
+            json={
+                "type": "DIRECTIVE",
+                "title": "합성 지시",
+                "body": "<p>본문</p>",
+                "target_member_ids": [str(uuid4())],
+            },
+        )
+
+    assert response.status_code == 422
+    assert response.json() == {"detail": "notice_target_member_not_found"}
+    assert db.committed is False
+
+
+def test_create_notice_rejects_reversed_display_range():
+    manager = _member(role="manager")
+    db = _Db()
+
+    with _client(db, manager) as client:
+        response = client.post(
+            "/api/notices",
+            headers={"Origin": ORIGIN},
+            json={
+                "type": "NOTICE",
+                "title": "합성 공지",
+                "body": "<p>본문</p>",
+                "display_start_date": "2026-08-20",
+                "display_end_date": "2026-08-10",
+            },
+        )
+
+    assert response.status_code == 422
+    assert db.committed is False
+
+
+def test_end_date_before_today_is_rejected_when_start_is_omitted():
+    """시작일을 생략하면 스키마가 범위를 보지 못한다. 라우터가 오늘로 채운 뒤 다시 본다."""
+    manager = _member(role="manager")
+    db = _Db()
+
+    with _client(db, manager) as client:
+        response = client.post(
+            "/api/notices",
+            headers={"Origin": ORIGIN},
+            json={
+                "type": "NOTICE",
+                "title": "합성 공지",
+                "body": "<p>본문</p>",
+                "display_end_date": "2020-01-01",
+            },
+        )
+
+    assert response.status_code == 422
+    assert response.json() == {"detail": "invalid_notice_display_range"}
+
+
+def test_patch_cannot_turn_a_notice_into_a_directive_without_targets():
+    manager = _member(role="manager")
+    notice = _notice(manager)
+    db = _Db(_Result(rows=[notice]))
+
+    with _client(db, manager) as client:
+        response = client.patch(
+            f"/api/notices/{notice.id}",
+            headers={"Origin": ORIGIN},
+            json={"type": "DIRECTIVE"},
+        )
+
+    assert response.status_code == 422
+    assert response.json() == {"detail": "directive_target_required"}
+    assert db.rolled_back is True
+    assert db.committed is False
+
+
+def test_patch_rejects_explicit_nulls_on_required_fields():
+    manager = _member(role="manager")
+    db = _Db()
+
+    with _client(db, manager) as client:
+        response = client.patch(
+            f"/api/notices/{uuid4()}",
+            headers={"Origin": ORIGIN},
+            json={"title": None},
+        )
+
+    assert response.status_code == 422
+
+
+def test_delete_is_soft():
+    manager = _member(role="manager")
+    notice = _notice(manager)
+    db = _Db(_Result(rows=[notice]))
+
+    with _client(db, manager) as client:
+        response = client.delete(f"/api/notices/{notice.id}", headers={"Origin": ORIGIN})
+
+    assert response.status_code == 204
+    assert notice.deleted_at is not None
+    assert notice.updated_at is not None
+    assert db.committed is True
+    # 행을 실제로 지우지 않는다.
+    assert "DELETE FROM" not in " ".join(str(statement) for statement in db.statements)

--- a/backend/tests/test_pagination.py
+++ b/backend/tests/test_pagination.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, ValidationError
 from app.schemas.activities import ActivityPageParams
 from app.schemas.customers import CustomerContactPageParams, CustomerPageParams
 from app.schemas.documents import DocumentPageParams
-from app.schemas.notices import NoticePageParams
+from app.schemas.notices import NoticeManagePageParams, NoticePageParams
 from app.schemas.orders import OrderPageParams
 from app.schemas.reports import ReportPageParams
 from app.schemas.sales_deals import ProductPageParams, SalesDealPageParams
@@ -21,6 +21,7 @@ PAGE_PARAMS: list[type[BaseModel]] = [
     CustomerPageParams,
     CustomerContactPageParams,
     DocumentPageParams,
+    NoticeManagePageParams,
     NoticePageParams,
     OrderPageParams,
     ProductPageParams,

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -72,6 +72,7 @@ dependencies = [
     { name = "asyncpg" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "nh3" },
     { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
@@ -92,6 +93,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "fastapi", specifier = ">=0.141.1" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "nh3", specifier = ">=0.3.1" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10.1" },
     { name = "python-multipart", specifier = ">=0.0.32" },
@@ -433,6 +435,40 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/7b/6248dada39781db1ab3ebf08943080df0796098515a87f6f8696d14ec744/narwhals-2.25.0.tar.gz", hash = "sha256:62c036c810662bf7820b7737077176313bc59350eeeefb808510f388c743e4b2", size = 677076, upload-time = "2026-08-20T18:10:15.454Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/dc/55481808fd70ef1567cf13540ffd4702af3f74b112e35427564b03f79c2d/narwhals-2.25.0-py3-none-any.whl", hash = "sha256:1f0f403e8c7e4463cde9bfe78b12fdd809e3ae3dda6d9b2f802934fb9c7a6a8f", size = 467373, upload-time = "2026-08-20T18:10:13.834Z" },
+]
+
+[[package]]
+name = "nh3"
+version = "0.3.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/2f/022b27146d52d24b1b353b003359134788ecbcd6fcdf6283adbd57c0fbc8/nh3-0.3.7.tar.gz", hash = "sha256:71860d01c16f4d8c72e334e0674beb2b0899dbd0bf760de18932ef4390303848", size = 25662, upload-time = "2026-08-23T14:26:30.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/88/b594f0e86856b37e182fb663283da419eea6424972506e640e890885467f/nh3-0.3.7-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:91a4dab4e94d9fc54b9f67b1adfb23e81fab7ab43f33c3b8c97be9aa38f789ba", size = 1471147, upload-time = "2026-08-23T14:25:55.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/60/847a21339f095c4d4c655af31fa2d18b174585bcc210709facacc7ce205c/nh3-0.3.7-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eae64328e46a25785535afcb6885b6f182ecaf5ee8c88f8c075422db8aacc65b", size = 820463, upload-time = "2026-08-23T14:25:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/7f/1a103e00aaf5e59f2dee4c2709aac609bb2d4bb74fddaf0dcfade11ed87b/nh3-0.3.7-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4968fe8d2db97c6f047659bf46a449fd8ec377f44ebf3e0a1b96c0d3a333ae32", size = 861456, upload-time = "2026-08-23T14:25:58.087Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/4a/e9c436089a0c80b928011ead0efd156aa7639a19b6064ef58dcedcab8369/nh3-0.3.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:be53a4825585f701955cb9baf49f478f56eb81e20294329fe4bc689dd5dd81fa", size = 1023930, upload-time = "2026-08-23T14:25:59.465Z" },
+    { url = "https://files.pythonhosted.org/packages/04/5c/aa1468e3e281e78d2b3b7d762ccba59f681af355e971dbd255d5903f7b86/nh3-0.3.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:94fd6e59553fbb9ffd8ba71bbd5a54e3126ba01799a097ae30d5341d750bc6ac", size = 1102614, upload-time = "2026-08-23T14:26:00.869Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/57d186d9d3dd38905dc12dddb3484406cdf6aa0b1ce33639a2d277d4ee1c/nh3-0.3.7-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:18f4278ecd157d43cb35acd5aae9f35cfa79f546b4922bd86536adc0f6312102", size = 1059915, upload-time = "2026-08-23T14:26:02.388Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/53/097a5ad0b34b15d67a472ef849165a54209fa5fbd3e639801c6fe439ba28/nh3-0.3.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:808def0c8c07843e6e50dc84f532457bfa2cfd17417b219a5d9e7c773709331a", size = 1047402, upload-time = "2026-08-23T14:26:03.897Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/c57a2c70534418310889a65ccfac3525e62f0bc0a8613225903403755ce7/nh3-0.3.7-cp314-cp314t-win32.whl", hash = "sha256:874b7d67a067bd29a59223f6270fc30da4edd8e6d87fd219fc93bcbaa662c946", size = 619895, upload-time = "2026-08-23T14:26:05.105Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b7/efda1d0a611d940bdfde6893bde1ea6b7b7d48c31273aea48e35b822fd58/nh3-0.3.7-cp314-cp314t-win_amd64.whl", hash = "sha256:614dac4a4c36ad084e78447d16fe898dedd762e354a7ab9cda2984e82f67883d", size = 633456, upload-time = "2026-08-23T14:26:06.661Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/18/3ab564595cb88196f50d26e163ed0fd2acc731ab26ac615df91981885887/nh3-0.3.7-cp314-cp314t-win_arm64.whl", hash = "sha256:157ec1eb7a62f3d9a7badb8d82d89aa810e3e24e097eedfa481a25d0c8a99877", size = 611003, upload-time = "2026-08-23T14:26:07.813Z" },
+    { url = "https://files.pythonhosted.org/packages/94/0d/c257754bf57f829f307aa226bbe136d3a1356b5a0d08324c7b6bd2a8aacd/nh3-0.3.7-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:6c3aa50eb26e9228238271db9f983cbc3b006dfbfeca2d4dc34c33ddc6ac5ea5", size = 1493959, upload-time = "2026-08-23T14:26:09.025Z" },
+    { url = "https://files.pythonhosted.org/packages/07/42/a687e7091928806e514f89fa2666f25ec9bfe0a902fc4402b25e51ce408b/nh3-0.3.7-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f266d3f1b3647449923a8e406524632220dd5d8b647078dfe45b885d33d10479", size = 859615, upload-time = "2026-08-23T14:26:10.606Z" },
+    { url = "https://files.pythonhosted.org/packages/85/05/b0e6bef633549a23347d5462aa288fcc42381e7918482062ca3cb456242a/nh3-0.3.7-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e8fd1ab205258b29254f72db377d99e2c96aa7653ef3b015ccab0420b094b506", size = 839872, upload-time = "2026-08-23T14:26:12.037Z" },
+    { url = "https://files.pythonhosted.org/packages/17/40/2a0921d45b20828708bcb56887e47dcf8cae13818de5bf9a01308d348712/nh3-0.3.7-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:19f288c938ec6eef1f5d2c6cab47838e71fef8097e1c1233802be5a6230ba086", size = 1091325, upload-time = "2026-08-23T14:26:13.34Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d1/9d70e0e418a48280ec0ddc6c1b08b4b1136ebcc31a1625e57ff5c665fa51/nh3-0.3.7-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de2b2aab32ea303405debefdcfc58043d3e635fa3f67b9eb140d2b0e0c0d2563", size = 1042482, upload-time = "2026-08-23T14:26:14.667Z" },
+    { url = "https://files.pythonhosted.org/packages/93/a7/02dd159d4e71f98607d8d4249cddb7561e77be1a8e4dec77d76e1b68fc99/nh3-0.3.7-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b7279d43323a25225df23576af6594a16693f61431170848b8b2ac21ad4f174", size = 946868, upload-time = "2026-08-23T14:26:16.094Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/ed/c5510c615dce55b6fcc364aa1838142f938beed64f5e4927490dfcaf4405/nh3-0.3.7-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70f5ac8626e899a4bab0ef74ca2f5bd602f49c7b739e6e5026b4afc6d63dac42", size = 832161, upload-time = "2026-08-23T14:26:17.272Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e3/3212c1a5b5745245d7f18885207bbddb34c56075f34dd682bd539aad55cc/nh3-0.3.7-cp38-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:5ffdfcb9a686ffb12765376bcfb6b5b55728516d3c0ee317d29982381ded3df8", size = 849791, upload-time = "2026-08-23T14:26:18.498Z" },
+    { url = "https://files.pythonhosted.org/packages/20/64/9e36594efad6c290de4240d02cb2bd80c339a4ab1c4de66e599ffa6d9d81/nh3-0.3.7-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bc42bb1193c1e28a1e74c2cabaca178e118a7103e8832699fef8a2b3e2496493", size = 875473, upload-time = "2026-08-23T14:26:19.908Z" },
+    { url = "https://files.pythonhosted.org/packages/00/0c/1a8985fd43fea5530c0ac890b6f0b423770ee72f111b70b7a77f2dec243a/nh3-0.3.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d56e76bd3cadb09b6b0cef364850811663734b348a25f5f587a2819c495367bd", size = 1036463, upload-time = "2026-08-23T14:26:21.536Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/5d/891e533b716cf00df76ad0ba6485dcfd14d59a6430a3cc99057c4c04004e/nh3-0.3.7-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:fd4a70efb45d5372174f718878eb7a35c12677626a63b2f103b23b833457dcac", size = 1116029, upload-time = "2026-08-23T14:26:22.907Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e5/ae8c0782fce74fb6fcf7234bb3d4017f37ce181b4f9d29369eab21c50a04/nh3-0.3.7-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:15f5fbf090f5c88d61c820e1fc1fceecb6520cca9fe85649c06b57ef9dc9ff62", size = 1076589, upload-time = "2026-08-23T14:26:24.302Z" },
+    { url = "https://files.pythonhosted.org/packages/26/a4/c3423351e8d864ad756e85e15f0c01433361f14d34e4ed156482c0518f2a/nh3-0.3.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6698a822132beedab80f131c08d8d0ac5a178ddeb488d02ca4b67716ecfac7af", size = 1058871, upload-time = "2026-08-23T14:26:25.674Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6a/478f153f1d7c0baaa3d1e8bb5fdcee3a6235f90fe44ea969a9d4e2b8c47a/nh3-0.3.7-cp38-abi3-win32.whl", hash = "sha256:6e4280115d44c3b278eef712a86748c1a723105cd79feec46952383117ab4e59", size = 630729, upload-time = "2026-08-23T14:26:26.932Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b9/34433ccb1f0fe6968dabbb7d4bf5721c6221878ef07832748c06655a6a80/nh3-0.3.7-cp38-abi3-win_amd64.whl", hash = "sha256:618e3059caf41ccdf5dcccb3fa9df4cf6e4efe23d1382a8bbfca272a8a4f8bfc", size = 644462, upload-time = "2026-08-23T14:26:28.294Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/70/e140dffff6e808dc6343598df76e7e2407fd0f581de3524c75fba2e0cf24/nh3-0.3.7-cp38-abi3-win_arm64.whl", hash = "sha256:f04b7d333b27f13ca439da3cf1c75c2fba34f104969f6ce4ac8e7079699c2f4a", size = 621867, upload-time = "2026-08-23T14:26:29.547Z" },
 ]
 
 [[package]]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ import MyPage from '@/pages/MyPage'
 import NotFound from '@/pages/NotFound'
 import Notifications from '@/pages/Notifications'
 import Orders, { OrderDetail, OrderNew } from '@/pages/Orders'
+import Notices from '@/pages/Notices'
 import Products from '@/pages/Products'
 import Quotes from '@/pages/Quotes'
 import Sales from '@/pages/Sales'
@@ -53,6 +54,7 @@ export default function App() {
               {/* 팀장만 들어갈 수 있는 화면. 팀원이 주소를 직접 치면 대시보드로 돌아갑니다. */}
               <Route element={<ManagerRoute />}>
                 <Route path={ROUTES.TEAM} element={<Team />} />
+                <Route path={ROUTES.NOTICES} element={<Notices />} />
                 <Route path={ROUTES.PRODUCTS} element={<Products />} />
               </Route>
 

--- a/frontend/src/components/RichTextEditor/RichTextEditor.module.scss
+++ b/frontend/src/components/RichTextEditor/RichTextEditor.module.scss
@@ -1,0 +1,22 @@
+// 편집기는 iframe 안에서 그려집니다. 여기서는 테두리와 툴바 색만 화면에 맞춥니다.
+.root {
+  :global(.tox-tinymce) {
+    border: 1px solid var(--line);
+    border-radius: var(--r-sm);
+  }
+
+  :global(.tox .tox-toolbar__primary) {
+    background: var(--surface-2);
+  }
+
+  :global(.tox .tox-editor-header) {
+    box-shadow: none;
+    border-bottom: 1px solid var(--line);
+  }
+}
+
+.error {
+  margin-top: var(--s1);
+  color: var(--red-ink);
+  font-size: 11px;
+}

--- a/frontend/src/components/RichTextEditor/RichTextEditor.tsx
+++ b/frontend/src/components/RichTextEditor/RichTextEditor.tsx
@@ -1,0 +1,128 @@
+// 본문 한 덩어리를 그대로 쓰는 편집기. TinyMCE 는 자체 호스팅(GPL) 으로 씁니다.
+//
+// 미팅보고서(pages/Meetings/components/ReportDocument)와 같은 라이브러리를 쓰지만 목적이
+// 다릅니다. 저쪽은 항목 제목이 잠긴 문서를 고치고 결과를 항목별 값으로 쪼갭니다. 여기는
+// HTML 한 덩어리를 그대로 주고받습니다. 두 화면을 한 컴포넌트로 묶으면 서로의 회귀 원인이
+// 되므로 나눠 둡니다.
+//
+// 허용 태그(valid_elements)는 서버 app/services/html_sanitize.py 의 허용목록과 한 쌍입니다.
+// 한쪽만 넓히면 화면에서 넣은 것이 저장할 때 조용히 사라집니다.
+import { useRef, useState } from 'react'
+import { Editor } from '@tinymce/tinymce-react'
+
+import 'tinymce/tinymce'
+import 'tinymce/models/dom/model'
+import 'tinymce/themes/silver'
+import 'tinymce/icons/default'
+import 'tinymce/plugins/lists'
+import 'tinymce/plugins/link'
+import 'tinymce/plugins/image'
+import 'tinymce/plugins/autolink'
+// 스킨 CSS 는 번들에 담습니다. 주소로 받아 오게 두면 빌드 결과에서 경로가 어긋납니다.
+import 'tinymce/skins/ui/oxide/skin.min.css'
+
+import { client } from '@/api/client'
+import { errorMessage } from '@/api/errorMessage'
+import type { NoticeImageResponse } from '@/types'
+
+import styles from './RichTextEditor.module.scss'
+
+// 서버(upload_guard._IMAGE_ALLOWED, notices.NOTICE_IMAGE_MAX_BYTES)와 같게 둡니다.
+const IMAGE_MAX_BYTES = 5 * 1024 * 1024
+
+interface Props {
+  value: string
+  onChange: (html: string) => void
+  disabled?: boolean
+  /**
+   * 본문을 통째로 다시 세워야 할 때만 올립니다. 편집 중에는 절대 바뀌면 안 됩니다.
+   * ReportDocument 와 같은 이유입니다. 글자를 칠 때마다 initialValue 를 새로 넘기면
+   * 편집기가 본문을 갈아 끼워 커서가 앞으로 돌아가고 한글 조합이 끊깁니다.
+   */
+  docKey?: number
+  height?: number
+  label?: string
+}
+
+export default function RichTextEditor({
+  value,
+  onChange,
+  disabled = false,
+  docKey = 0,
+  height = 320,
+  label = '본문',
+}: Props) {
+  const [uploadError, setUploadError] = useState<string | null>(null)
+
+  const doc = useRef<{ key: number; html: string } | null>(null)
+  if (doc.current === null || doc.current.key !== docKey) {
+    doc.current = { key: docKey, html: value }
+  }
+
+  return (
+    <div className={styles.root}>
+      <Editor
+        key={docKey}
+        initialValue={doc.current.html}
+        disabled={disabled}
+        // 자체 호스팅 GPL 이용임을 밝힙니다. 없으면 편집기가 경고를 띄웁니다.
+        licenseKey="gpl"
+        onEditorChange={onChange}
+        init={{
+          // 보고서와 달리 iframe 을 씁니다. 인쇄할 일이 없고, 본문 CSS 가 관리 화면
+          // 스타일과 섞이지 않아야 합니다.
+          inline: false,
+          height,
+          skin: false,
+          promotion: false,
+          branding: false,
+          menubar: false,
+          statusbar: false,
+          plugins: 'lists link image autolink',
+          toolbar:
+            'bold italic underline | bullist numlist | blockquote | link image | removeformat',
+          // 서버 html_sanitize._TAGS/_ATTRIBUTES 와 같은 목록입니다.
+          // rel 은 두지 않습니다. 서버가 link_rel 로 noopener 를 직접 붙입니다.
+          valid_elements:
+            'p,br,strong/b,em/i,u,s,ul,ol,li,blockquote,h2,h3,h4,' +
+            'a[href|title|target],img[src|alt|title|width|height]',
+          // 워드·한글에서 붙여 넣는 서식 쓰레기를 걸러 냅니다.
+          paste_data_images: true,
+          // 사진은 고르는 즉시 저장소로 올리고 본문에는 내부 참조만 남깁니다.
+          automatic_uploads: true,
+          images_file_types: 'png,jpg,jpeg,webp',
+          images_upload_handler: async (blobInfo) => {
+            const blob = blobInfo.blob()
+            if (blob.size > IMAGE_MAX_BYTES) {
+              throw new Error('사진은 5MB까지 올릴 수 있습니다.')
+            }
+            const form = new FormData()
+            form.append('upload', blob, blobInfo.filename())
+            try {
+              const { data } = await client.post<NoticeImageResponse>('/notices/images', form)
+              setUploadError(null)
+              // 저장소 주소가 아니라 우리 내부 참조입니다. 볼 수 있는 주소는 서버가
+              // 본문을 내보낼 때마다 새로 발급합니다.
+              return data.url
+            } catch (caught: unknown) {
+              const message = errorMessage(caught, '사진을 올리지 못했습니다.')
+              setUploadError(message)
+              throw new Error(message)
+            }
+          },
+          link_default_target: '_blank',
+          link_default_protocol: 'https',
+          a11y_advanced_options: true,
+          content_style:
+            'body{font-family:inherit;font-size:14px;line-height:1.7}img{max-width:100%;height:auto}',
+        }}
+      />
+      <span className="sr-only">{label}</span>
+      {uploadError !== null && (
+        <p className={styles.error} role="alert">
+          {uploadError}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/RichTextEditor/index.ts
+++ b/frontend/src/components/RichTextEditor/index.ts
@@ -1,0 +1,1 @@
+export { default } from './RichTextEditor'

--- a/frontend/src/constants/navigation.ts
+++ b/frontend/src/constants/navigation.ts
@@ -3,6 +3,7 @@
 import type { FC } from 'react'
 
 import {
+  BellIcon,
   CalendarIcon,
   ComplaintIcon,
   ContractIcon,
@@ -85,6 +86,7 @@ export const NAV_SECTIONS: NavSection[] = [
     title: '관리',
     managerOnly: true,
     items: [
+      { to: ROUTES.NOTICES, label: '공지관리', icon: BellIcon },
       { to: ROUTES.PRODUCTS, label: '상품관리', icon: ProductIcon },
       { to: ROUTES.TEAM, label: '팀 관리', icon: TeamIcon },
     ],

--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -26,6 +26,8 @@ export const ROUTES = {
   ORDERS: '/orders',
   DOCUMENTS: '/documents',
   PRODUCTS: '/products', // 상품관리 (팀장 전용). 상품 목록 조회 자체는 팀원도 씁니다.
+  // 공지·팀장 지시사항 관리 (팀장 전용). 읽기는 대시보드 티커와 알림에서 합니다.
+  NOTICES: '/notices',
   // 마이페이지. 진입은 사이드바 하단 이름과 헤더 아바타에서 합니다.
   // 바꿀 수 있는 설정이 없어 '설정' 대신 내 정보·약관을 보는 화면 하나만 둡니다.
   MYPAGE: '/mypage',

--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -104,12 +104,12 @@ export default function Dashboard() {
         <>
           <div className={styles.notices}>
             <NoticeTicker
-              items={data.notices.items.map((item) => toNotice(item, 'team'))}
+              items={data.notices.items.map((item) => toNotice(item))}
               onOpen={(notice) => setOpen({ type: 'notice', label: '공지', notice })}
             />
             <NoticeTicker
               label="팀장 지시사항"
-              items={data.directives.items.map((item) => toNotice(item, 'personal'))}
+              items={data.directives.items.map((item) => toNotice(item))}
               onOpen={(notice) => setOpen({ type: 'notice', label: '팀장 지시사항', notice })}
             />
           </div>

--- a/frontend/src/pages/Dashboard/components/NoticeDrawer/NoticeDrawer.module.scss
+++ b/frontend/src/pages/Dashboard/components/NoticeDrawer/NoticeDrawer.module.scss
@@ -13,20 +13,55 @@
   letter-spacing: -0.01em;
 }
 
+// 본문은 HTML 한 덩어리입니다. 편집기가 낼 수 있는 태그(RichTextEditor.valid_elements)에
+// 맞춰 자식 요소의 여백과 크기를 여기서 정합니다.
 .detail {
   margin-top: var(--s3);
   color: var(--ink-2);
   font-size: 13px;
   line-height: 1.75;
-  white-space: pre-line;
-}
 
-// 첨부 이미지는 드로어 폭에 맞춰 줄이고 원래 비율을 지킵니다.
-.image {
-  display: block;
-  width: 100%;
-  height: auto;
-  margin-top: var(--s4);
-  border: 1px solid var(--line);
-  border-radius: var(--r-md);
+  :global(p) {
+    margin: 0 0 0.75em;
+  }
+
+  :global(ul),
+  :global(ol) {
+    margin: 0 0 0.75em;
+    padding-left: 1.25em;
+  }
+
+  :global(h2),
+  :global(h3),
+  :global(h4) {
+    margin: 1.25em 0 0.5em;
+    color: var(--ink);
+    font-size: 14px;
+    font-weight: 700;
+  }
+
+  :global(blockquote) {
+    margin: 0 0 0.75em;
+    padding-left: var(--s3);
+    border-left: 3px solid var(--line);
+    color: var(--muted);
+  }
+
+  :global(a) {
+    color: var(--brand-ink);
+    text-decoration: underline;
+  }
+
+  // 첨부 사진은 드로어 폭에 맞춰 줄이고 원래 비율을 지킵니다.
+  :global(img) {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    margin: var(--s3) 0;
+    border-radius: var(--r-sm);
+  }
+
+  > :global(*:last-child) {
+    margin-bottom: 0;
+  }
 }

--- a/frontend/src/pages/Dashboard/components/NoticeDrawer/NoticeDrawer.tsx
+++ b/frontend/src/pages/Dashboard/components/NoticeDrawer/NoticeDrawer.tsx
@@ -45,13 +45,12 @@ export default function NoticeDrawer({ label, notice, onClose }: Props) {
       ) : loading || body === null ? (
         <InlineLoader label="전문을 불러오는 중입니다." />
       ) : (
-        <>
-          <p className={styles.detail}>{body.body}</p>
-          {/* 이미지는 있는 글에만 붙습니다. 본문을 읽고 난 뒤에 옵니다. */}
-          {notice.image && (
-            <img className={styles.image} src={notice.image} alt={body.image_alt ?? ''} />
-          )}
-        </>
+        /* 본문은 팀장이 편집기로 쓴 HTML 입니다. 서버(app/services/html_sanitize.py)가
+           저장할 때 허용 태그만 남기므로 여기서 다시 자르지 않고 그대로 그립니다.
+           허용목록을 넓힐 일이 생기면 반드시 서버 쪽을 먼저 봅니다.
+           사진도 본문 안에 있습니다. 주소는 서버가 응답할 때마다 새로 발급합니다. */
+        // oxlint-disable-next-line react/no-danger
+        <div className={styles.detail} dangerouslySetInnerHTML={{ __html: body.body }} />
       )}
     </Drawer>
   )

--- a/frontend/src/pages/Dashboard/components/NoticeTicker/NoticeTicker.tsx
+++ b/frontend/src/pages/Dashboard/components/NoticeTicker/NoticeTicker.tsx
@@ -67,7 +67,7 @@ export default function NoticeTicker({ label = '공지', items: notices = [], on
 
       <ul className={styles.list} aria-live="polite">
         {current.map((n) => (
-          <li key={n.text}>
+          <li key={n.id ?? n.text}>
             <button type="button" onClick={() => onOpen(n)}>
               <p>{n.text}</p>
               <small>{postedLabel(n)}</small>

--- a/frontend/src/pages/Notices/Notices.module.scss
+++ b/frontend/src/pages/Notices/Notices.module.scss
@@ -1,0 +1,248 @@
+// 상품관리(pages/Products)의 툴바·표·모달을 공지 목록에 맞게 고쳐 씁니다.
+// 폰용 카드 목록은 두지 않습니다. 카드 안 가로 스크롤로 충분합니다.
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s3);
+}
+
+/* ---- 툴바 ---- */
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--s2);
+  flex-wrap: wrap;
+}
+
+.search {
+  flex: 1 1 320px;
+  max-width: 640px;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: var(--s2);
+  margin-left: auto;
+
+  @include sm {
+    margin-left: 0;
+    width: 100%;
+    justify-content: flex-end;
+  }
+}
+
+/* ---- 표 ---- */
+
+.card {
+  @include card;
+  overflow: hidden;
+}
+
+.scroller {
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+}
+
+.table {
+  min-width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  table-layout: fixed;
+
+  th,
+  td {
+    height: 48px;
+    padding: 0 var(--s3);
+    text-align: left;
+    vertical-align: middle;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  thead th {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    height: 40px;
+    background: var(--surface-2);
+    border-bottom: 1px solid var(--line);
+    color: var(--ink-2);
+    font-size: 12px;
+    font-weight: 600;
+  }
+
+  tbody td {
+    border-bottom: 1px solid var(--line);
+    color: var(--ink-2);
+    font-size: 13px;
+  }
+
+  tbody td.title {
+    color: var(--ink);
+    font-weight: 600;
+  }
+
+  tbody td.targets {
+    color: var(--muted);
+  }
+
+  tbody tr:last-child td {
+    border-bottom: 0;
+  }
+
+  tbody tr:hover td {
+    background: var(--fill-2);
+  }
+
+  // 숨긴 글은 목록에 남지만 지금 화면에 서지 않는다는 것이 보여야 합니다.
+  tbody tr.isHidden td.title,
+  tbody tr.isHidden td {
+    color: var(--muted);
+  }
+}
+
+.badge {
+  @include tag-pill;
+  background: var(--fill-2);
+  color: var(--ink-2);
+}
+
+/* ---- 줄 끝 관리 버튼 ---- */
+
+.rowActions {
+  display: flex;
+  align-items: center;
+  gap: var(--s1);
+}
+
+.remove {
+  padding: 0 var(--s2);
+  border: 0;
+  border-radius: var(--r-sm);
+  background: none;
+  color: var(--red-ink);
+  font-size: 12px;
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    background: var(--red-tint);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+}
+
+/* ---- 빈 상태 ---- */
+
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--s3);
+  padding: var(--s8) var(--s5);
+  color: var(--muted);
+  text-align: center;
+
+  p {
+    font-size: 13px;
+  }
+}
+
+/* ---- 등록·수정 모달 (components/NoticeFormModal.tsx) ---- */
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--s3);
+
+  @include sm {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.field {
+  @include form-field;
+}
+
+.isWide {
+  grid-column: 1 / -1;
+}
+
+.label {
+  color: var(--ink-2);
+  font-size: 12px;
+  font-weight: 600;
+
+  b {
+    margin-left: 3px;
+    color: var(--red);
+  }
+}
+
+.error {
+  color: var(--red-ink);
+  font-size: 11px;
+}
+
+.hint {
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.danger {
+  border-color: var(--red-tint);
+  background: var(--red-tint);
+  color: var(--red-ink);
+
+  &:hover {
+    background: var(--red-tint);
+    filter: brightness(0.97);
+  }
+}
+
+/* ---- 게시기간 ---- */
+
+.period {
+  display: flex;
+  align-items: center;
+  gap: var(--s2);
+  flex-wrap: wrap;
+
+  > span {
+    color: var(--muted);
+  }
+}
+
+// 열린 달력은 DatePicker 의 형제로 붙습니다. 이 감싸개가 없으면 그 달력이 기간 칸 하나를
+// 차지해 종료 입력을 다음 줄로 밀어냅니다.
+.pickerCell {
+  position: relative;
+  flex: 0 1 200px;
+}
+
+.picker {
+  width: 100%;
+}
+
+/* ---- 숨기기 스위치 ---- */
+
+.switch {
+  display: flex;
+  align-items: center;
+  gap: var(--s2);
+  color: var(--ink-2);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+
+  input {
+    width: 16px;
+    height: 16px;
+    accent-color: var(--brand);
+  }
+}

--- a/frontend/src/pages/Notices/Notices.tsx
+++ b/frontend/src/pages/Notices/Notices.tsx
@@ -1,0 +1,284 @@
+import { useDeferredValue, useState } from 'react'
+import { useSearchParams } from 'react-router'
+
+import Button from '@/components/Button'
+import ErrorToast from '@/components/ErrorToast'
+import { BellIcon, PlusIcon, SearchIcon } from '@/components/icons'
+import Modal from '@/components/Modal'
+import Pagination, { PAGE_SIZE } from '@/components/Pagination'
+import SearchInput from '@/components/SearchInput'
+import { InlineLoader, ListPageSkeleton } from '@/components/Skeleton'
+import StatusBadge from '@/components/StatusBadge'
+import Tabs from '@/components/Tabs'
+import { showToast } from '@/shared/toast'
+import type { NoticeManageListResponse, NoticeManageResponse, NoticeType } from '@/types'
+
+import NoticeFormModal from './components/NoticeFormModal'
+import NoticeRowActions from './components/NoticeRowActions'
+import {
+  COLUMNS,
+  TABLE_WIDTH,
+  TYPE_TABS,
+  periodLabel,
+  stateOf,
+  targetsLabel,
+} from './noticeCatalog'
+import useNotices from './useNotices'
+
+import styles from './Notices.module.scss'
+
+/** 열려 있는 폼. 등록은 initial 이 없고, 수정은 본문까지 받아 온 한 건을 답니다. */
+type FormState = { mode: 'create' } | { mode: 'edit'; notice: NoticeManageResponse }
+
+export default function Notices() {
+  const [params, setParams] = useSearchParams()
+  const type = (params.get('type') === 'DIRECTIVE' ? 'DIRECTIVE' : 'NOTICE') satisfies NoticeType
+  const query = params.get('q') ?? ''
+  const deferredQuery = useDeferredValue(query)
+  const [page, setPage] = useState(1)
+  const [form, setForm] = useState<FormState | null>(null)
+  const [removing, setRemoving] = useState<NoticeManageListResponse | null>(null)
+  const [busyId, setBusyId] = useState<string | null>(null)
+
+  const {
+    notices: rows,
+    total,
+    loading,
+    error,
+    reload,
+    loadNotice,
+    addNotice,
+    editNotice,
+    removeNotice,
+    toggleHidden,
+  } = useNotices({ type, q: deferredQuery, skip: (page - 1) * PAGE_SIZE, limit: PAGE_SIZE })
+
+  const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE))
+
+  const patchParams = (change: (next: URLSearchParams) => void) => {
+    const next = new URLSearchParams(params)
+    change(next)
+    setParams(next, { replace: true })
+    // 조건이 바뀌면 결과가 줄어 지금 쪽수가 범위를 넘을 수 있습니다. 첫 쪽으로 돌립니다.
+    setPage(1)
+  }
+
+  const setType = (value: NoticeType) =>
+    patchParams((next) => {
+      if (value === 'NOTICE') next.delete('type')
+      else next.set('type', value)
+    })
+
+  const setQuery = (value: string) =>
+    patchParams((next) => {
+      if (value === '') next.delete('q')
+      else next.set('q', value)
+    })
+
+  // 목록에는 본문이 없습니다. 폼을 열 때 단건으로 받아 옵니다.
+  const openEdit = async (row: NoticeManageListResponse) => {
+    setBusyId(row.id)
+    try {
+      setForm({ mode: 'edit', notice: await loadNotice(row.id) })
+    } catch {
+      showToast('공지를 불러오지 못했습니다.')
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  const switchHidden = async (row: NoticeManageListResponse) => {
+    setBusyId(row.id)
+    try {
+      await toggleHidden(row)
+      showToast(row.is_hidden ? '다시 보이게 했습니다.' : '숨겼습니다.')
+    } catch {
+      showToast('상태를 바꾸지 못했습니다.')
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  const confirmRemove = async () => {
+    if (removing === null) return
+    setBusyId(removing.id)
+    try {
+      await removeNotice(removing.id)
+      showToast('삭제했습니다.')
+      setRemoving(null)
+    } catch {
+      showToast('삭제하지 못했습니다.')
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  // 첫 진입에서 툴바·표가 따로 들어오면 화면이 두 번 들썩입니다. 한 장을 통째로 둡니다.
+  if (loading && rows.length === 0 && !error) {
+    return (
+      <section className={styles.page} aria-busy={loading}>
+        <h1 className="sr-only">공지관리</h1>
+        <ListPageSkeleton label="공지 목록을 불러오는 중입니다." />
+      </section>
+    )
+  }
+
+  return (
+    <section className={styles.page} aria-busy={loading}>
+      <h1 className="sr-only">공지관리</h1>
+
+      <Tabs items={TYPE_TABS} value={type} label="공지 종류" onChange={setType} />
+
+      <div className={styles.toolbar}>
+        <SearchInput
+          className={styles.search}
+          value={query}
+          placeholder="제목·본문·태그·작성자 검색"
+          label="공지 검색"
+          onChange={setQuery}
+        />
+        <div className={styles.actions}>
+          <Button disabled={loading} onClick={() => setForm({ mode: 'create' })}>
+            <PlusIcon width={15} height={15} />
+            {type === 'DIRECTIVE' ? '지시 등록' : '공지 등록'}
+          </Button>
+        </div>
+      </div>
+
+      {!error && loading && rows.length > 0 && (
+        <InlineLoader label="공지 목록을 새로고침하는 중입니다." />
+      )}
+
+      <ErrorToast message={error} onRetry={reload} />
+
+      {rows.length === 0 ? (
+        <div className={styles.card}>
+          <div className={styles.empty}>
+            {query.trim() !== '' ? (
+              <>
+                <SearchIcon width={34} height={34} strokeWidth={1.5} />
+                <p>조건에 맞는 글이 없습니다.</p>
+                <Button variant="outline" onClick={() => setQuery('')}>
+                  검색 초기화
+                </Button>
+              </>
+            ) : (
+              <>
+                <BellIcon width={34} height={34} strokeWidth={1.5} />
+                <p>등록된 글이 없습니다.</p>
+                <Button onClick={() => setForm({ mode: 'create' })}>
+                  {type === 'DIRECTIVE' ? '지시 등록' : '공지 등록'}
+                </Button>
+              </>
+            )}
+          </div>
+        </div>
+      ) : (
+        <div className={styles.card}>
+          {/* 좁은 화면에서는 표가 카드 안에서만 옆으로 흐릅니다. */}
+          <div className={styles.scroller}>
+            <table className={styles.table} style={{ width: TABLE_WIDTH }}>
+              <caption className="sr-only">등록된 공지·지시사항 목록</caption>
+              <colgroup>
+                {COLUMNS.map((column) => (
+                  <col key={column.id} style={{ width: column.width }} />
+                ))}
+              </colgroup>
+              <thead>
+                <tr>
+                  {COLUMNS.map((column) => (
+                    <th key={column.id} scope="col">
+                      {column.header}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => {
+                  const state = stateOf(row)
+                  return (
+                    <tr key={row.id} className={row.is_hidden ? styles.isHidden : undefined}>
+                      <td className="tnum">{row.sort_order}</td>
+                      <td className={styles.title} title={row.title}>
+                        {row.title}
+                      </td>
+                      <td>{row.tag === null ? '-' : <i className={styles.badge}>{row.tag}</i>}</td>
+                      <td className={styles.targets} title={targetsLabel(row)}>
+                        {targetsLabel(row)}
+                      </td>
+                      <td className="tnum">{periodLabel(row)}</td>
+                      <td>
+                        <StatusBadge label={state.label} tone={state.tone} />
+                      </td>
+                      <td>{row.author_display_name}</td>
+                      <td>
+                        <NoticeRowActions
+                          row={row}
+                          busy={busyId === row.id}
+                          onEdit={() => void openEdit(row)}
+                          onToggleHidden={() => void switchHidden(row)}
+                          onDelete={() => setRemoving(row)}
+                        />
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          <Pagination page={page} pageCount={pageCount} total={total} unit="건" onPage={setPage} />
+        </div>
+      )}
+
+      {form !== null && (
+        <NoticeFormModal
+          initial={form.mode === 'edit' ? form.notice : undefined}
+          defaultType={type}
+          onClose={() => setForm(null)}
+          onSubmit={async (payload) => {
+            if (form.mode === 'edit') {
+              await editNotice(form.notice.id, payload)
+              showToast('수정했습니다.')
+            } else {
+              await addNotice(payload as Parameters<typeof addNotice>[0])
+              showToast('등록했습니다.')
+            }
+            setForm(null)
+          }}
+        />
+      )}
+
+      {removing !== null && (
+        <Modal
+          title="공지를 삭제할까요?"
+          description={`'${removing.title}' 이(가) 대시보드와 목록에서 사라집니다.`}
+          onClose={() => setRemoving(null)}
+          onSubmit={confirmRemove}
+          footer={
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={busyId !== null}
+                onClick={() => setRemoving(null)}
+              >
+                취소
+              </Button>
+              <Button
+                type="submit"
+                variant="outline"
+                className={styles.danger}
+                disabled={busyId !== null}
+              >
+                삭제
+              </Button>
+            </>
+          }
+        >
+          <p className={styles.hint}>지운 글은 목록에서 되살릴 수 없습니다.</p>
+        </Modal>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/pages/Notices/components/NoticeFormModal.tsx
+++ b/frontend/src/pages/Notices/components/NoticeFormModal.tsx
@@ -1,0 +1,382 @@
+// 공지·지시 등록과 수정을 겸하는 폼. 상품 등록 모달(pages/Products)의 뼈대를 그대로 씁니다.
+//
+// 수정은 바뀐 항목만 보냅니다. 통째로 보내면 그 사이 다른 곳에서 바뀐 값을 되돌려 놓습니다.
+import { useState, type ReactNode } from 'react'
+import DatePicker, { registerLocale } from 'react-datepicker'
+import { ko } from 'date-fns/locale'
+
+import { errorMessage } from '@/api/errorMessage'
+import Button from '@/components/Button'
+import MemberMultiSelect from '@/components/MemberMultiSelect'
+import Modal from '@/components/Modal'
+import RichTextEditor from '@/components/RichTextEditor'
+import type {
+  NoticeCreateRequest,
+  NoticeManageResponse,
+  NoticePatchRequest,
+  NoticeType,
+} from '@/types'
+import { iso, parseISO, TODAY } from '@/utils/date'
+
+import { TYPE_TABS } from '../noticeCatalog'
+
+import 'react-datepicker/dist/react-datepicker.css'
+import styles from '../Notices.module.scss'
+
+registerLocale('ko', ko)
+
+interface Props {
+  /** 수정할 글. 주지 않으면 등록입니다. */
+  initial?: NoticeManageResponse
+  /** 등록할 때 미리 골라 둘 종류. 지금 열려 있는 탭입니다. */
+  defaultType: NoticeType
+  onClose: () => void
+  onSubmit: (payload: NoticeCreateRequest | NoticePatchRequest) => Promise<void>
+}
+
+type Errors = Partial<Record<'title' | 'body' | 'targets' | 'period' | 'sortOrder', string>>
+
+/** 태그를 벗긴 글자. 서버 html_sanitize 가 본문이 비었는지 보는 것과 같은 판단입니다. */
+function textOf(html: string): string {
+  return html
+    .replace(/<[^>]*>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .trim()
+}
+
+export default function NoticeFormModal({ initial, defaultType, onClose, onSubmit }: Props) {
+  const editing = initial !== undefined
+
+  const [type, setType] = useState<NoticeType>(initial?.type ?? defaultType)
+  const [title, setTitle] = useState(initial?.title ?? '')
+  const [tag, setTag] = useState(initial?.tag ?? '')
+  const [body, setBody] = useState(initial?.body ?? '')
+  const [targetIds, setTargetIds] = useState<string[]>(initial?.target_member_ids ?? [])
+  const [start, setStart] = useState<Date>(
+    initial ? parseISO(initial.display_start_date) : new Date(TODAY),
+  )
+  const [end, setEnd] = useState<Date | null>(
+    initial?.display_end_date ? parseISO(initial.display_end_date) : null,
+  )
+  const [hidden, setHidden] = useState(initial?.is_hidden ?? false)
+  const [sortOrder, setSortOrder] = useState(String(initial?.sort_order ?? 0))
+  const [dueText, setDueText] = useState(initial?.due_text ?? '')
+
+  const [errors, setErrors] = useState<Errors>({})
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  const submit = async () => {
+    if (submitting) return
+
+    // 서버가 내는 오류 코드와 1:1 로 맞춥니다.
+    const found: Errors = {}
+    if (title.trim() === '') found.title = '제목을 입력하세요.'
+    if (textOf(body) === '' && !body.includes('<img')) found.body = '본문을 입력하세요.'
+    if (type === 'DIRECTIVE' && targetIds.length === 0) {
+      found.targets = '수신자를 한 명 이상 고르세요.'
+    }
+    if (end !== null && iso(end) < iso(start)) {
+      found.period = '종료일은 시작일 이후여야 합니다.'
+    }
+    const order = Number(sortOrder)
+    if (sortOrder.trim() === '' || !Number.isInteger(order) || order < -9999 || order > 9999) {
+      found.sortOrder = '-9999~9999 사이의 정수로 입력하세요.'
+    }
+    setErrors(found)
+    if (Object.keys(found).length > 0) return
+
+    const next: NoticeCreateRequest = {
+      type,
+      title: title.trim(),
+      body,
+      tag: tag.trim() === '' ? null : tag.trim(),
+      due_text: dueText.trim() === '' ? null : dueText.trim(),
+      display_start_date: iso(start),
+      display_end_date: end === null ? null : iso(end),
+      is_hidden: hidden,
+      sort_order: order,
+      target_member_ids: type === 'DIRECTIVE' ? targetIds : null,
+    }
+
+    setSubmitting(true)
+    setSubmitError(null)
+    try {
+      await onSubmit(editing ? changedFields(initial, next) : next)
+    } catch (caught: unknown) {
+      setSubmitError(
+        errorMessage(caught, editing ? '수정하지 못했습니다.' : '등록하지 못했습니다.'),
+      )
+      setSubmitting(false)
+    }
+  }
+
+  const close = () => {
+    if (!submitting) onClose()
+  }
+
+  return (
+    <Modal
+      title={editing ? '공지 수정' : '공지 등록'}
+      size="lg"
+      onClose={close}
+      onSubmit={submit}
+      footer={
+        <>
+          <Button type="button" variant="outline" disabled={submitting} onClick={close}>
+            취소
+          </Button>
+          <Button type="submit" disabled={submitting}>
+            {submitting ? '저장 중…' : editing ? '수정' : '등록'}
+          </Button>
+        </>
+      }
+    >
+      <div className={styles.grid} aria-busy={submitting}>
+        <Field label="종류" required>
+          <select
+            value={type}
+            disabled={submitting}
+            onChange={(event) => {
+              setType(event.target.value as NoticeType)
+              setErrors((previous) => ({ ...previous, targets: undefined }))
+            }}
+          >
+            {TYPE_TABS.map((tab) => (
+              <option key={tab.value} value={tab.value}>
+                {tab.label}
+              </option>
+            ))}
+          </select>
+        </Field>
+
+        <Field label="태그">
+          <input
+            value={tag}
+            maxLength={64}
+            disabled={submitting}
+            placeholder="예: 필독"
+            onChange={(event) => setTag(event.target.value)}
+          />
+        </Field>
+
+        <Field label="제목" required error={errors.title} wide>
+          <input
+            value={title}
+            maxLength={254}
+            disabled={submitting}
+            placeholder="예: 3분기 영업 목표 안내"
+            onChange={(event) => {
+              setTitle(event.target.value)
+              setErrors((previous) => ({ ...previous, title: undefined }))
+            }}
+          />
+        </Field>
+
+        {type === 'DIRECTIVE' && (
+          <div className={`${styles.field} ${styles.isWide}`}>
+            <span className={styles.label}>
+              수신자<b aria-hidden="true">*</b>
+            </span>
+            <MemberMultiSelect
+              value={targetIds}
+              label="수신자"
+              placeholder="이름으로 검색"
+              disabled={submitting}
+              invalid={errors.targets !== undefined}
+              onChange={(memberIds) => {
+                setTargetIds(memberIds)
+                setErrors((previous) => ({ ...previous, targets: undefined }))
+              }}
+            />
+            <span className={styles.hint}>고른 사람만 대시보드에서 이 지시를 봅니다.</span>
+            {errors.targets && <span className={styles.error}>{errors.targets}</span>}
+          </div>
+        )}
+
+        <div className={`${styles.field} ${styles.isWide}`}>
+          <span className={styles.label}>
+            본문<b aria-hidden="true">*</b>
+          </span>
+          <RichTextEditor
+            value={body}
+            disabled={submitting}
+            // 폼이 서 있는 동안에는 본문을 갈아 끼우지 않습니다. 갈면 커서가 앞으로
+            // 돌아가고 한글 조합이 끊깁니다.
+            docKey={0}
+            onChange={(html) => {
+              setBody(html)
+              setErrors((previous) => ({ ...previous, body: undefined }))
+            }}
+          />
+          {errors.body && <span className={styles.error}>{errors.body}</span>}
+        </div>
+
+        <div className={`${styles.field} ${styles.isWide}`}>
+          <span className={styles.label}>
+            게시기간<b aria-hidden="true">*</b>
+          </span>
+          <div className={styles.period}>
+            <DayPicker
+              selected={start}
+              label="노출 시작일"
+              disabled={submitting}
+              onChange={(date) => {
+                if (date === null) return
+                setStart(date)
+                setErrors((previous) => ({ ...previous, period: undefined }))
+              }}
+            />
+            <span aria-hidden="true">~</span>
+            <DayPicker
+              selected={end}
+              label="노출 종료일"
+              minDate={start}
+              isClearable
+              disabled={submitting}
+              onChange={(date) => {
+                setEnd(date)
+                setErrors((previous) => ({ ...previous, period: undefined }))
+              }}
+            />
+          </div>
+          <span className={styles.hint}>
+            시작일과 종료일 모두 그 날을 포함합니다. 종료일을 비우면 무기한입니다.
+          </span>
+          {errors.period && <span className={styles.error}>{errors.period}</span>}
+        </div>
+
+        <Field label="노출 순서" required error={errors.sortOrder}>
+          <input
+            type="number"
+            inputMode="numeric"
+            min={-9999}
+            max={9999}
+            step={1}
+            value={sortOrder}
+            disabled={submitting}
+            onChange={(event) => {
+              setSortOrder(event.target.value)
+              setErrors((previous) => ({ ...previous, sortOrder: undefined }))
+            }}
+          />
+          <span className={styles.hint}>작을수록 위에 옵니다.</span>
+        </Field>
+
+        <Field label="기한 안내">
+          <input
+            value={dueText}
+            maxLength={254}
+            disabled={submitting}
+            placeholder="예: 이번 주 금요일까지"
+            onChange={(event) => setDueText(event.target.value)}
+          />
+        </Field>
+
+        <div className={`${styles.field} ${styles.isWide}`}>
+          <label className={styles.switch}>
+            <input
+              type="checkbox"
+              checked={hidden}
+              disabled={submitting}
+              onChange={(event) => setHidden(event.target.checked)}
+            />
+            <span>숨기기</span>
+          </label>
+          <span className={styles.hint}>
+            켜면 이 목록에만 남고 대시보드에서 빠집니다. 글은 지워지지 않습니다.
+          </span>
+        </div>
+
+        {submitError && (
+          <p className={`${styles.error} ${styles.isWide}`} role="alert">
+            {submitError}
+          </p>
+        )}
+      </div>
+    </Modal>
+  )
+}
+
+/** 수정 폼이 실제로 바꾼 항목만 골라냅니다. */
+function changedFields(
+  initial: NoticeManageResponse,
+  next: NoticeCreateRequest,
+): NoticePatchRequest {
+  const patch: NoticePatchRequest = {}
+  if (next.type !== initial.type) patch.type = next.type
+  if (next.title !== initial.title) patch.title = next.title
+  if (next.body !== initial.body) patch.body = next.body
+  if (next.tag !== initial.tag) patch.tag = next.tag
+  if (next.due_text !== initial.due_text) patch.due_text = next.due_text
+  if (next.display_start_date !== initial.display_start_date) {
+    patch.display_start_date = next.display_start_date
+  }
+  if (next.display_end_date !== initial.display_end_date) {
+    patch.display_end_date = next.display_end_date
+  }
+  if (next.is_hidden !== initial.is_hidden) patch.is_hidden = next.is_hidden
+  if (next.sort_order !== initial.sort_order) patch.sort_order = next.sort_order
+
+  const nextTargets = next.target_member_ids ?? []
+  const sameTargets =
+    nextTargets.length === initial.target_member_ids.length &&
+    nextTargets.every((id, index) => id === initial.target_member_ids[index])
+  // 공지로 바뀌면 서버가 수신자를 비웁니다. 목록을 따로 보내지 않습니다.
+  if (next.type === 'DIRECTIVE' && !sameTargets) patch.target_member_ids = nextTargets
+
+  return patch
+}
+
+interface DayPickerProps {
+  selected: Date | null
+  onChange: (date: Date | null) => void
+  label: string
+  minDate?: Date
+  isClearable?: boolean
+  disabled?: boolean
+}
+
+function DayPicker({ selected, onChange, label, minDate, isClearable, disabled }: DayPickerProps) {
+  return (
+    <div className={styles.pickerCell}>
+      <DatePicker
+        selected={selected}
+        onChange={onChange}
+        minDate={minDate}
+        isClearable={isClearable}
+        disabled={disabled}
+        locale="ko"
+        dateFormat="yyyy-MM-dd"
+        placeholderText={isClearable ? '무기한' : undefined}
+        // date-fns 의 ko 로케일은 달 제목을 '8월 2026' 으로 냅니다. 우리말 차례로 뒤집습니다.
+        dateFormatCalendar="yyyy년 M월"
+        customInput={<input aria-label={label} className={styles.picker} />}
+        popperPlacement="bottom-start"
+        // 모달이 overflow: hidden 이라, 아래쪽에서 열린 달력이 잘리지 않게 띄웁니다.
+        popperProps={{ strategy: 'fixed' }}
+      />
+    </div>
+  )
+}
+
+interface FieldProps {
+  label: string
+  required?: boolean
+  error?: string
+  wide?: boolean
+  children: ReactNode
+}
+
+function Field({ label, required, error, wide, children }: FieldProps) {
+  return (
+    <label className={`${styles.field} ${wide ? styles.isWide : ''}`}>
+      <span className={styles.label}>
+        {label}
+        {required && <b aria-hidden="true">*</b>}
+      </span>
+      {children}
+      {error && <span className={styles.error}>{error}</span>}
+    </label>
+  )
+}

--- a/frontend/src/pages/Notices/components/NoticeRowActions.tsx
+++ b/frontend/src/pages/Notices/components/NoticeRowActions.tsx
@@ -1,0 +1,36 @@
+// 표 한 줄의 관리 버튼. 수정·숨김 전환·삭제를 묶습니다.
+import Button from '@/components/Button'
+import type { NoticeManageListResponse } from '@/types'
+
+import styles from '../Notices.module.scss'
+
+interface Props {
+  row: NoticeManageListResponse
+  busy: boolean
+  onEdit: () => void
+  onToggleHidden: () => void
+  onDelete: () => void
+}
+
+export default function NoticeRowActions({ row, busy, onEdit, onToggleHidden, onDelete }: Props) {
+  return (
+    <div className={styles.rowActions}>
+      <Button type="button" variant="outline" size="sm" disabled={busy} onClick={onEdit}>
+        수정
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={busy}
+        aria-pressed={row.is_hidden}
+        onClick={onToggleHidden}
+      >
+        {row.is_hidden ? '보이기' : '숨기기'}
+      </Button>
+      <button type="button" className={styles.remove} disabled={busy} onClick={onDelete}>
+        삭제
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/pages/Notices/index.ts
+++ b/frontend/src/pages/Notices/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Notices'

--- a/frontend/src/pages/Notices/noticeCatalog.ts
+++ b/frontend/src/pages/Notices/noticeCatalog.ts
@@ -1,0 +1,56 @@
+// 공지관리 화면이 쓰는 어휘와 표 정의. 화면 이름과 판정 규칙을 한곳에 둡니다.
+import type { StatusTone } from '@/components/StatusBadge'
+import type { NoticeManageListResponse, NoticeType } from '@/types'
+import { iso, TODAY } from '@/utils/date'
+
+export const TYPE_TABS: { value: NoticeType; label: string }[] = [
+  { value: 'NOTICE', label: '공지사항' },
+  { value: 'DIRECTIVE', label: '팀장 지시사항' },
+]
+
+export function typeLabel(type: NoticeType): string {
+  return type === 'DIRECTIVE' ? '팀장 지시사항' : '공지사항'
+}
+
+export const COLUMNS = [
+  { id: 'sortOrder', header: '순서', width: 64 },
+  { id: 'title', header: '제목', width: 300 },
+  { id: 'tag', header: '태그', width: 96 },
+  { id: 'targets', header: '수신자', width: 180 },
+  { id: 'period', header: '게시기간', width: 200 },
+  { id: 'state', header: '상태', width: 88 },
+  { id: 'author', header: '작성자', width: 110 },
+  { id: 'actions', header: '관리', width: 150 },
+]
+
+export const TABLE_WIDTH = COLUMNS.reduce((sum, column) => sum + column.width, 0)
+
+export interface NoticeState {
+  label: string
+  tone: StatusTone
+}
+
+/**
+ * 표에 세우는 상태. 서버가 대시보드에 내보내는 조건과 같은 순서로 봅니다.
+ * 숨김이 가장 세고, 그다음이 아직 시작하지 않은 것, 끝난 것입니다.
+ */
+export function stateOf(row: NoticeManageListResponse, today: string = iso(TODAY)): NoticeState {
+  if (row.is_hidden) return { label: '숨김', tone: 'neutral' }
+  if (row.display_start_date > today) return { label: '예정', tone: 'blue' }
+  if (row.display_end_date !== null && row.display_end_date < today) {
+    return { label: '종료', tone: 'neutral' }
+  }
+  return { label: '게시중', tone: 'green' }
+}
+
+/** 게시기간 한 줄. 종료일이 없으면 무기한입니다. */
+export function periodLabel(row: NoticeManageListResponse): string {
+  return `${row.display_start_date} ~ ${row.display_end_date ?? '무기한'}`
+}
+
+/** 수신자 한 줄. 공지는 팀 전체가 봅니다. */
+export function targetsLabel(row: NoticeManageListResponse): string {
+  if (row.type === 'NOTICE') return '팀 전체'
+  if (row.targets.length === 0) return '-'
+  return row.targets.map((target) => target.display_name).join(', ')
+}

--- a/frontend/src/pages/Notices/useNotices.ts
+++ b/frontend/src/pages/Notices/useNotices.ts
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import { client } from '@/api/client'
+import { errorMessage } from '@/api/errorMessage'
+import type {
+  NoticeCreateRequest,
+  NoticeManageListResponse,
+  NoticeManageResponse,
+  NoticePatchRequest,
+  NoticeType,
+  PageResponse,
+} from '@/types'
+
+export interface NoticeQuery {
+  type: NoticeType
+  q: string
+  skip: number
+  limit: number
+}
+
+export default function useNotices({ type, q, skip, limit }: NoticeQuery) {
+  const [notices, setNotices] = useState<NoticeManageListResponse[]>([])
+  const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [reloadKey, setReloadKey] = useState(0)
+
+  const needle = q.trim()
+
+  useEffect(() => {
+    const controller = new AbortController()
+    setLoading(true)
+    setError(null)
+
+    void client
+      .get<PageResponse<NoticeManageListResponse>>('/notices/manage', {
+        params: {
+          type,
+          q: needle === '' ? undefined : needle.slice(0, 100),
+          skip,
+          limit,
+        },
+        signal: controller.signal,
+      })
+      .then(({ data }) => {
+        if (controller.signal.aborted) return
+        setNotices(data.items)
+        setTotal(data.total)
+      })
+      .catch((caught: unknown) => {
+        if (!controller.signal.aborted) {
+          setError(errorMessage(caught, '공지 목록을 불러오지 못했습니다.'))
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false)
+      })
+
+    return () => controller.abort()
+  }, [type, needle, skip, limit, reloadKey])
+
+  const reload = useCallback(() => setReloadKey((previous) => previous + 1), [])
+
+  /** 수정 폼을 열 때 본문을 받아 옵니다. 목록에는 본문이 없습니다. */
+  const loadNotice = useCallback(async (id: string) => {
+    const { data } = await client.get<NoticeManageResponse>(`/notices/manage/${id}`)
+    return data
+  }, [])
+
+  const addNotice = useCallback(
+    async (payload: NoticeCreateRequest) => {
+      const { data } = await client.post<NoticeManageResponse>('/notices', payload)
+      // 새 글이 이 쪽에 속하는지는 노출 순서가 정합니다. 목록에 끼워 넣지 않고 다시 받아
+      // 서버가 정한 자리에 놓습니다.
+      reload()
+      return data
+    },
+    [reload],
+  )
+
+  const editNotice = useCallback(
+    async (id: string, patch: NoticePatchRequest) => {
+      const { data } = await client.patch<NoticeManageResponse>(`/notices/${id}`, patch)
+      reload()
+      return data
+    },
+    [reload],
+  )
+
+  const removeNotice = useCallback(
+    async (id: string) => {
+      await client.delete(`/notices/${id}`)
+      reload()
+    },
+    [reload],
+  )
+
+  const toggleHidden = useCallback(
+    (row: NoticeManageListResponse) => editNotice(row.id, { is_hidden: !row.is_hidden }),
+    [editNotice],
+  )
+
+  return {
+    notices,
+    total,
+    loading,
+    error,
+    reload,
+    loadNotice,
+    addNotice,
+    editNotice,
+    removeNotice,
+    toggleHidden,
+  }
+}

--- a/frontend/src/shared/notices.ts
+++ b/frontend/src/shared/notices.ts
@@ -9,13 +9,19 @@ const DAY = 86_400_000
  */
 type NoticeLike = NoticeBrief & Partial<Pick<NoticeResponse, 'scope' | 'body' | 'image_alt'>>
 
-export function toNotice(item: NoticeLike, scope?: NoticeResponse['scope']): Notice {
+/** 종류는 서버가 준 type 이 먼저입니다. scope 는 type 이 없던 시절의 폴백입니다. */
+function isDirective(item: NoticeLike): boolean {
+  if (item.type !== undefined) return item.type === 'DIRECTIVE'
+  return item.scope === 'personal'
+}
+
+export function toNotice(item: NoticeLike): Notice {
   const published = new Date(item.published_at)
   const localDate = new Date(published.getTime() + 9 * 60 * 60_000).toISOString()
   const date = localDate.slice(0, 10)
   return {
     id: item.id,
-    tag: item.tag ?? ((item.scope ?? scope) === 'personal' ? '지시' : '공지'),
+    tag: item.tag ?? (isDirective(item) ? '지시' : '공지'),
     author: item.author_display_name,
     postedOff: Math.round((parseISO(date).getTime() - TODAY.getTime()) / DAY),
     postedAt: localDate.slice(11, 16),

--- a/frontend/src/types/dashboard.ts
+++ b/frontend/src/types/dashboard.ts
@@ -1,9 +1,11 @@
 // GET /api/dashboard 한 벌. 진입하자마자 화면에 서는 숫자와 오늘 일정만 담습니다.
 // 눌러야 열리는 드로어의 목록과 본문은 각 도메인 API 가 그때 줍니다.
 import type { ActivityRead } from './agenda'
+import type { NoticeType } from './notices'
 
 export interface NoticeBrief {
   id: string
+  type: NoticeType
   tag: string | null
   author_display_name: string
   title: string

--- a/frontend/src/types/notices.ts
+++ b/frontend/src/types/notices.ts
@@ -8,7 +8,7 @@ export interface Notice {
   postedAt: string
   /** 목록에 한 줄로 걸리는 제목 */
   text: string
-  /** 드로어에서 펼치는 본문 */
+  /** 드로어에서 펼치는 본문 HTML. 서버가 허용 태그만 남겨 보냅니다. */
   detail: string
   /** 본문에 함께 붙는 이미지. 없는 글이 더 많습니다. */
   image?: string
@@ -18,11 +18,16 @@ export interface Notice {
   due?: string
 }
 
+/** 공지는 팀 전체가, 지시는 지정된 팀원만 봅니다. */
+export type NoticeType = 'NOTICE' | 'DIRECTIVE'
+
 export interface NoticeResponse {
   id: string
   scope: 'team' | 'personal'
+  type: NoticeType
   author_member_id: string
   author_display_name: string
+  /** 수신자가 정확히 한 명일 때만 그 사람입니다. 여러 명이거나 공지면 null 입니다. */
   recipient_member_id: string | null
   tag: string | null
   title: string
@@ -31,4 +36,64 @@ export interface NoticeResponse {
   published_at: string
   due_at: string | null
   due_text: string | null
+}
+
+export interface NoticeTargetResponse {
+  id: string
+  display_name: string
+}
+
+/**
+ * 팀장 관리 목록의 한 줄. 본문(body)이 없습니다. 본문 속 사진마다 서명 주소를 발급해야 해서
+ * 목록에는 싣지 않고, 폼을 열 때 GET /notices/manage/{id} 가 줍니다.
+ */
+export interface NoticeManageListResponse {
+  id: string
+  type: NoticeType
+  author_member_id: string
+  author_display_name: string
+  tag: string | null
+  title: string
+  image_alt: string | null
+  published_at: string
+  due_at: string | null
+  due_text: string | null
+  /** YYYY-MM-DD. 시작일과 종료일 모두 그 날을 포함합니다. */
+  display_start_date: string
+  /** null 이면 무기한입니다. */
+  display_end_date: string | null
+  is_hidden: boolean
+  sort_order: number
+  targets: NoticeTargetResponse[]
+  target_member_ids: string[]
+  updated_at: string
+}
+
+/** 수정 폼이 받는 한 건. 목록 항목에 본문을 더한 것입니다. */
+export interface NoticeManageResponse extends NoticeManageListResponse {
+  body: string
+}
+
+export interface NoticeCreateRequest {
+  type: NoticeType
+  title: string
+  body: string
+  tag: string | null
+  image_alt?: string | null
+  due_at?: string | null
+  due_text: string | null
+  display_start_date: string
+  display_end_date: string | null
+  is_hidden: boolean
+  sort_order: number
+  /** 지시에만 보냅니다. 보내면 수신자 전체를 이 목록으로 바꿉니다. */
+  target_member_ids: string[] | null
+}
+
+export type NoticePatchRequest = Partial<NoticeCreateRequest>
+
+/** 본문에 넣을 사진을 올린 결과. url 은 본문에 그대로 박는 내부 참조입니다. */
+export interface NoticeImageResponse {
+  id: string
+  url: string
 }


### PR DESCRIPTION
## 변경 요약

팀장(`role_code = 'manager'`)이 공지사항과 지시사항을 직접 등록·수정·삭제하고
노출 기간·숨김·순서를 정하는 화면과 API 를 더합니다. 지금까지 공지는 읽기만
됐고(GET 두 개가 전부), 글을 넣는 경로가 아예 없었습니다.

- **스키마** (`20260825_0005_notice_management.sql`) — `notice` 에 `type`,
  `display_start_date`·`display_end_date`, `is_hidden`, `sort_order`,
  `updated_at`, `deleted_at` 을 더하고 **`recipient_member_id` 를 뗍니다.**
  지시 하나를 여러 명에게 보내야 하므로 수신자는 `notice_target` 으로 옮겼고,
  본문 사진은 `notice_image` 가 가리킵니다. 인덱스 하나를 부분 인덱스 둘로
  교체했습니다.
- **노출 기간은 `date`** 입니다. 뜻이 "게시 기간" 이지 "게시 시각" 이 아니고,
  기준 시간대가 Asia/Seoul 이라 시각까지 두면 UTC 로 비교되는 하루가 화면이
  말하는 하루와 아홉 시간 어긋납니다. 양끝을 포함하고 종료일이 없으면 무기한입니다.
- **API** — 관리 목록·관리 단건·등록·수정·삭제·사진 업로드를 더해 여덟 갈래가
  됩니다. 쓰기는 팀장만, 읽기는 팀원 그대로입니다. 삭제는 `deleted_at` 만 찍습니다.
  수신자는 조인하지 않고 `EXISTS` 로 묻습니다. 조인하면 지시 한 건이 수신자
  수만큼 늘어나 목록의 `total` 이 부풀고 같은 글이 여러 줄로 보입니다.
- **본문이 평문에서 HTML 로** 바뀝니다. 저장 직전에 `services/html_sanitize.py`
  가 `nh3` 로 허용 태그만 남깁니다. 대시보드 드로어가 그 결과를 그대로
  `innerHTML` 로 그리므로 이 한 겹이 저장형 XSS 의 방어선입니다. 서버 허용목록과
  편집기의 `valid_elements` 는 한 쌍으로 관리합니다.
- **화면** — 팀장 전용 `/notices`(탭·검색·표·쪽나눔·등록/수정 폼)와 재사용
  가능한 `RichTextEditor` 를 더했습니다. 미팅보고서의 `ReportDocument` 는 항목이
  잠긴 문서 전용이라 재사용하지 않고 따로 세웠습니다.
- 대시보드 티커·드로어가 새 응답에 맞춰 서식과 사진을 그대로 그립니다.

## 검증

- `uv run pytest` — **280 passed, 1 failed**. 실패한 하나는
  `test_models_match_configured_database` 이고, DB 에 있는 `document_chunk`
  테이블에 대응하는 ORM 모델이 없어서입니다. **이 브랜치 이전부터 `develop` 에서도
  같은 이유로 실패합니다**(stash 후 확인). 이번 변경과 무관해 손대지 않았습니다.
  이번에 건드린 `notice`·`notice_target`·`notice_image` 세 테이블은 별도 스크립트로
  ORM 과 물리 스키마를 같은 방식으로 대조해 일치를 확인했습니다.
- `uv run ruff check app tests` / `ruff format --check app tests` — 통과.
  (저장소 전체 `format --check` 는 `notebooks/*.ipynb` 3개가 걸리지만 이전 커밋
  `b428f4d` 부터 있던 것이라 두었습니다.)
- `npm run typecheck` / `npm run lint` / `npm run build` — 통과.
  `npm run format:check` 는 `src/types/customers.ts` 하나가 걸리는데 이번 변경이
  건드리지 않은 파일이라 두었습니다.
- **실제 개발 DB 에 대고 30가지 스모크 검사** — 등록·sanitize·숨김/기간에 따른
  노출·수신자 교체·팀원 403·soft delete·대시보드 반영까지 전부 통과했고, 만든
  행은 되돌렸습니다. 단위 테스트는 가짜 DB 를 쓰므로 SQL 이 Postgres 에서 실제로
  도는지 보지 못해 따로 확인했습니다.
- **브라우저 수동 확인은 못 했습니다.** Supabase 계정 비밀번호가 없어 로그인할 수
  없었습니다. TinyMCE 사진 업로드 경로와 날짜 선택기는 실제 화면에서 눌러 보지
  않았으므로 리뷰 때 확인해 주세요.

## 영향 및 주의 사항

- **마이그레이션은 개발 DB 에 이미 적용했습니다**(`sql/README.md` 적용 이력 참고).
  적용 시점 `notice` 행이 0건이라 백필 대상은 없었습니다. 다른 환경에 올릴 때는
  `recipient_member_id` 가 사라지는 변경이라 되돌리기 어렵습니다.
- `NoticeRead.recipient_member_id` 는 컬럼이 사라졌지만 "수신자가 한 명일 때 그
  사람" 으로 파생해 한 릴리스 남겨 둡니다. 화면이 `targets` 로 옮겨 간 뒤 후속
  PR 에서 뗄 것입니다.
- 백엔드에 `nh3` 의존성이 하나 늘어 배포 전에 `uv sync` 가 필요합니다.
- 후속 과제 두 가지를 코드에 `ponytail:` 로 남겼습니다 — 본문에서 지운 사진의
  저장소 객체 회수, 위의 `recipient_member_id` 제거.