### PR TITLE
feat: 보기 범위에 따라 담당자를 세우고, 보고서를 본인만 쓰게 함

### DIFF
--- a/backend/app/api/reports.py
+++ b/backend/app/api/reports.py
@@ -228,6 +228,53 @@ async def _locked_report(db: AsyncSession, member: Member, report_id: UUID) -> R
     return report
 
 
+async def _own_activity_ids(
+    db: AsyncSession,
+    member: Member,
+    activity_ids: list[UUID],
+) -> tuple[UUID, ...]:
+    """보고서에 묶을 일정이 모두 "내가 한 일"인지 확인한다.
+
+    보고는 남이 한 일을 대신 적는 문서가 아니다. 팀장이라도 팀원의 일정에 보고서를
+    달 수 없다.
+
+    이 저장소가 쓰기 권한에 404 를 쓰는 까닭은 볼 수 없는 줄의 존재를 알리지 않기
+    위해서인데, 팀장은 팀원의 일정을 이미 자기 목록에서 본다. 숨길 것이 없는 자리라
+    없는 척하지 않고 403 으로 이유를 말한다. 다른 팀이거나 지워진 일정은 그보다 먼저
+    404 로 끊으므로 남의 팀을 더듬어 볼 수는 없다.
+    """
+    if not activity_ids:
+        return ()
+    unique = tuple(dict.fromkeys(activity_ids))
+    result = await db.execute(
+        select(Activity.id, Activity.owner_member_id).where(
+            Activity.id.in_(unique),
+            Activity.team_id == member.team_id,
+            Activity.deleted_at.is_(None),
+        )
+    )
+    owners = {row[0]: row[1] for row in result.all()}
+    if set(owners) != set(unique):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="activity_not_found",
+        )
+    if any(owner_id != member.id for owner_id in owners.values()):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="activity_not_owned",
+        )
+    return unique
+
+
+async def _linked_activity_ids(db: AsyncSession, report_id: UUID) -> set[UUID]:
+    """이미 이 보고서에 묶여 있는 일정."""
+    result = await db.execute(
+        select(ReportActivity.activity_id).where(ReportActivity.report_id == report_id)
+    )
+    return set(result.scalars().all())
+
+
 async def _replace_report_activities(
     db: AsyncSession,
     report_id: UUID,
@@ -349,8 +396,8 @@ async def create_report(
             else await _visible_recipient(db, member, payload.recipient_member_id)
         )
         if payload.source_activity_id is not None:
-            await _visible_activity_ids(db, member, [payload.source_activity_id])
-        activity_ids = await _visible_activity_ids(db, member, payload.activity_ids)
+            await _own_activity_ids(db, member, [payload.source_activity_id])
+        activity_ids = await _own_activity_ids(db, member, payload.activity_ids)
 
         report = Report(
             id=uuid4(),
@@ -421,6 +468,11 @@ async def update_report(
 
         if activity_ids is not None:
             visible = await _visible_activity_ids(db, member, activity_ids)
+            # 새로 묶는 일정에만 소유를 따진다. 규칙이 생기기 전에 팀장이 팀원의
+            # 일정으로 만들어 둔 보고서가 있고, 그것을 통째로 막으면 손댈 수 없는
+            # 문서가 된다. 이미 묶여 있던 일정은 그대로 둔다.
+            linked = await _linked_activity_ids(db, report.id)
+            await _own_activity_ids(db, member, [a for a in visible if a not in linked])
             await _replace_report_activities(db, report.id, visible)
 
         await db.flush()

--- a/backend/app/api/reports.py
+++ b/backend/app/api/reports.py
@@ -225,6 +225,15 @@ async def _locked_report(db: AsyncSession, member: Member, report_id: UUID) -> R
             status_code=status.HTTP_404_NOT_FOUND,
             detail="report_not_found",
         )
+    # 보고서는 쓴 사람이 고치고 제출하고 지운다. 팀장도 남의 보고서를 대신 손대지 않는다.
+    #
+    # 팀원에게는 위 조건이 이미 본인 것만 남기므로 여기까지 오지 않는다. 팀장은 팀원의
+    # 보고서를 목록에서 보고 있어, 없는 척(404)하지 않고 403 으로 이유를 말한다.
+    if report.author_member_id != member.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="report_not_owned",
+        )
     return report
 
 

--- a/backend/tests/test_reports.py
+++ b/backend/tests/test_reports.py
@@ -533,6 +533,61 @@ def test_update_keeps_activities_linked_before_the_ownership_rule():
     assert db.commit_count == 1
 
 
+def test_manager_cannot_edit_or_submit_a_teammate_report():
+    """보고서는 쓴 사람이 고치고 제출하고 지운다. 팀장도 대신 손대지 않는다.
+
+    팀장은 팀원의 보고서를 목록에서 보고 있으므로 404 가 아니라 403 으로 답한다.
+    """
+    manager = _member(role="manager")
+    teammate = _member(team_id=manager.team_id)
+    report = _report(teammate)
+
+    for call in (
+        lambda client: client.patch(
+            f"/api/reports/{report.id}",
+            headers={"Origin": ORIGIN},
+            json={"note": "팀장이 대신 고쳐 본다"},
+        ),
+        lambda client: client.post(
+            f"/api/reports/{report.id}/submit",
+            headers={"Origin": ORIGIN},
+            json={"expected_status_code": "draft"},
+        ),
+        lambda client: client.delete(
+            f"/api/reports/{report.id}",
+            headers={"Origin": ORIGIN},
+        ),
+    ):
+        db = _Db(_Result(scalar=report))
+        with _client(db, manager) as client:
+            response = call(client)
+        assert response.status_code == 403
+        assert response.json() == {"detail": "report_not_owned"}
+        assert db.commit_count == 0
+        assert db.rollback_count == 1
+
+
+def test_manager_can_still_edit_own_report():
+    """자기가 쓴 보고서는 팀장도 그대로 고친다."""
+    manager = _member(role="manager")
+    report = _report(manager)
+
+    db = _Db(
+        _Result(scalar=report),
+        _Result(rows=[_row(report, manager)]),
+        _Result(rows=[]),
+    )
+    with _client(db, manager) as client:
+        response = client.patch(
+            f"/api/reports/{report.id}",
+            headers={"Origin": ORIGIN},
+            json={"note": "내가 쓴 보고서"},
+        )
+
+    assert response.status_code == 200
+    assert db.commit_count == 1
+
+
 def test_manager_author_filter_is_limited_to_same_team():
     member = _member(role="member")
     denied_db = _Db()

--- a/backend/tests/test_reports.py
+++ b/backend/tests/test_reports.py
@@ -418,13 +418,10 @@ def test_member_scope_hides_other_authors_report():
     assert locked_db.rollback_count == 1
 
 
-def test_member_cannot_attach_another_owners_activity():
-    member = _member()
-    foreign = _activity(_member(team_id=member.team_id))
-
-    db = _Db(_Result(scalar_values=[]))
+def _attach(db: _Db, member: Member, activity_id: UUID):
+    """일정 하나를 묶어 보고서를 만들어 본다."""
     with _client(db, member) as client:
-        response = client.post(
+        return client.post(
             "/api/reports",
             headers={"Origin": ORIGIN},
             json={
@@ -432,18 +429,108 @@ def test_member_cannot_attach_another_owners_activity():
                 "report_date": "2026-08-17",
                 "template_snapshot": TEMPLATE,
                 "content": CONTENT,
-                "activity_ids": [str(foreign.id)],
+                "activity_ids": [str(activity_id)],
             },
         )
 
-    assert response.status_code == 404
-    assert response.json() == {"detail": "activity_not_found"}
+
+def test_member_cannot_attach_another_owners_activity():
+    """남의 일정에는 보고서를 달 수 없다. 같은 팀이라 없는 척하지 않고 403 으로 답한다."""
+    member = _member()
+    foreign = _activity(_member(team_id=member.team_id))
+
+    db = _Db(_Result(rows=[(foreign.id, foreign.owner_member_id)]))
+    response = _attach(db, member, foreign.id)
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "activity_not_owned"}
     assert db.commit_count == 0
     assert db.rollback_count == 1
 
     sql = str(db.statements[0])
     assert "activity.owner_member_id" in sql
     assert "activity.deleted_at IS NULL" in sql
+
+
+def test_manager_cannot_attach_a_teammate_activity():
+    """보고는 남이 한 일을 대신 적는 문서가 아니다. 팀장도 같은 규칙을 받는다."""
+    manager = _member(role="manager")
+    teammate = _activity(_member(team_id=manager.team_id))
+
+    db = _Db(_Result(rows=[(teammate.id, teammate.owner_member_id)]))
+    response = _attach(db, manager, teammate.id)
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "activity_not_owned"}
+    assert db.commit_count == 0
+    assert db.rollback_count == 1
+
+
+def test_unknown_activity_is_reported_as_not_found_before_ownership():
+    """다른 팀이거나 지워진 일정은 소유를 따지기 전에 404 로 끊는다."""
+    manager = _member(role="manager")
+
+    db = _Db(_Result(rows=[]))
+    response = _attach(db, manager, uuid4())
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "activity_not_found"}
+    assert db.commit_count == 0
+
+
+def test_manager_can_attach_own_activity():
+    """자기가 한 일이면 팀장도 그대로 쓴다."""
+    manager = _member(role="manager")
+    own = _activity(manager)
+
+    class _OwnActivityDb(_Db):
+        async def execute(self, statement):
+            self.statements.append(statement)
+            # 첫 쿼리는 일정 소유 확인, 그 뒤 둘이 상세 조회다.
+            if len(self.statements) == 1:
+                return _Result(rows=[(own.id, own.owner_member_id)])
+            if len(self.statements) == 2:
+                report = next(value for value in self.added if isinstance(value, Report))
+                return _Result(rows=[_row(report, manager)])
+            return _Result(rows=[])
+
+    db = _OwnActivityDb()
+    response = _attach(db, manager, own.id)
+
+    assert response.status_code == 201
+    assert response.json()["author_member_id"] == str(manager.id)
+    assert db.commit_count == 1
+
+
+def test_update_keeps_activities_linked_before_the_ownership_rule():
+    """규칙이 생기기 전에 묶어 둔 남의 일정은 수정 때 그대로 둔다.
+
+    통째로 막으면 팀장이 만들어 둔 보고서가 손댈 수 없는 문서가 된다.
+    """
+    manager = _member(role="manager")
+    report = _report(manager)
+    legacy = _activity(_member(team_id=manager.team_id))
+
+    db = _Db(
+        _Result(scalar=report),
+        # _visible_activity_ids: 팀 안의 일정인지
+        _Result(scalar_values=[legacy.id]),
+        # _linked_activity_ids: 이미 묶여 있던 일정
+        _Result(scalar_values=[legacy.id]),
+        # _replace_report_activities 의 delete
+        _Result(),
+        _Result(rows=[_row(report, manager)]),
+        _Result(rows=[]),
+    )
+    with _client(db, manager) as client:
+        response = client.patch(
+            f"/api/reports/{report.id}",
+            headers={"Origin": ORIGIN},
+            json={"activity_ids": [str(legacy.id)]},
+        )
+
+    assert response.status_code == 200
+    assert db.commit_count == 1
 
 
 def test_manager_author_filter_is_limited_to_same_team():

--- a/frontend/src/api/errorMessage.ts
+++ b/frontend/src/api/errorMessage.ts
@@ -55,6 +55,7 @@ const MESSAGE_BY_DETAIL: Record<string, string> = {
   customer_contact_status_code_not_found: '고객 상태 설정을 확인해 주세요.',
   // 보고서 (/reports)
   activity_not_owned: '본인이 진행한 일정에만 보고서를 쓸 수 있습니다.',
+  report_not_owned: '본인이 쓴 보고서만 고치거나 제출할 수 있습니다.',
   // 상품 (/products)
   product_not_found: '상품을 찾을 수 없습니다. 목록을 새로 불러와 주세요.',
   product_image_not_found: '등록된 사진이 없습니다.',

--- a/frontend/src/api/errorMessage.ts
+++ b/frontend/src/api/errorMessage.ts
@@ -53,6 +53,8 @@ const MESSAGE_BY_DETAIL: Record<string, string> = {
   customer_company_not_found: '고객사를 찾지 못했습니다. 다시 시도해 주세요.',
   customer_contact_not_found: '고객을 찾지 못했습니다. 목록을 새로 불러와 주세요.',
   customer_contact_status_code_not_found: '고객 상태 설정을 확인해 주세요.',
+  // 보고서 (/reports)
+  activity_not_owned: '본인이 진행한 일정에만 보고서를 쓸 수 있습니다.',
   // 상품 (/products)
   product_not_found: '상품을 찾을 수 없습니다. 목록을 새로 불러와 주세요.',
   product_image_not_found: '등록된 사진이 없습니다.',

--- a/frontend/src/components/OrderDrawer/OrderDrawer.tsx
+++ b/frontend/src/components/OrderDrawer/OrderDrawer.tsx
@@ -10,6 +10,7 @@ import Button, { buttonClass } from '@/components/Button'
 import Drawer from '@/components/Drawer'
 import { ChevronRightIcon, TrashIcon } from '@/components/icons'
 import { isLate, orderItemLabel, orderTotal } from '@/shared/orders'
+import { useShowOwner } from '@/shared/scope'
 import type { PurchaseOrder } from '@/types'
 import { fmtDay, parseISO } from '@/utils/date'
 import { wonFull } from '@/utils/format'
@@ -29,8 +30,11 @@ interface Props {
 
 export default function OrderDrawer({ order, onBack, onEdit, onDelete, detailTo, onClose }: Props) {
   const late = isLate(order)
+  const showOwner = useShowOwner()
 
   const rows: [string, string][] = [
+    // 여러 사람의 발주가 섞여 보일 때만 누구 것인지 앞세웁니다.
+    ...(showOwner ? ([['담당 영업', order.owner]] as [string, string][]) : []),
     ['품목', orderItemLabel(order)],
     ['금액', wonFull(orderTotal(order))],
     ['공급처', order.supplier],

--- a/frontend/src/components/OrderDrawer/OrderDrawer.tsx
+++ b/frontend/src/components/OrderDrawer/OrderDrawer.tsx
@@ -11,14 +11,15 @@ import Drawer from '@/components/Drawer'
 import { ChevronRightIcon, TrashIcon } from '@/components/icons'
 import { isLate, orderItemLabel, orderTotal } from '@/shared/orders'
 import { useShowOwner } from '@/shared/scope'
-import type { PurchaseOrder } from '@/types'
+import type { ApiPurchaseOrder } from '@/types'
 import { fmtDay, parseISO } from '@/utils/date'
 import { wonFull } from '@/utils/format'
 
 import styles from './OrderDrawer.module.scss'
 
 interface Props {
-  order: PurchaseOrder
+  /** 담당 영업을 세우려면 서버가 채워 주는 owner 가 있어야 해 API 형을 받습니다. */
+  order: ApiPurchaseOrder
   /** 목록에서 들어왔을 때만 있습니다. */
   onBack?: () => void
   onEdit?: () => void

--- a/frontend/src/components/OwnerName/OwnerName.module.scss
+++ b/frontend/src/components/OwnerName/OwnerName.module.scss
@@ -1,0 +1,14 @@
+// 흐린 글씨가 아니라 알약입니다. 이 이름표가 서는 자리에는 이미 고객 쪽 정보가
+// 흐린 글씨로 앉아 있어, 같은 크기·같은 색을 하나 더 두면 구분되지 않습니다.
+// 옅은 바탕은 "이건 우리 쪽 사람" 이라는 다른 부류로 읽힙니다.
+.owner {
+  @include tag-pill;
+
+  flex: 0 0 auto;
+  max-width: 8em;
+  padding: 1px 7px;
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/frontend/src/components/OwnerName/OwnerName.module.scss
+++ b/frontend/src/components/OwnerName/OwnerName.module.scss
@@ -8,6 +8,7 @@
   max-width: 8em;
   padding: 1px 7px;
   font-size: 11px;
+  letter-spacing: normal;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/frontend/src/components/OwnerName/OwnerName.tsx
+++ b/frontend/src/components/OwnerName/OwnerName.tsx
@@ -1,0 +1,23 @@
+import styles from './OwnerName.module.scss'
+
+interface Props {
+  /** 담당자 이름. 비어 있으면 아무것도 세우지 않습니다. */
+  name?: string | null
+}
+
+/**
+ * 이 줄이 누구 것인지 알리는 이름표입니다.
+ *
+ * 아바타를 두지 않습니다. 여기서 알아야 하는 것은 "누구"이지 "누구의 얼굴"이 아니고,
+ * 팀 하나가 한 화면에 다 들어오는 규모라 이름 넉 자면 충분합니다.
+ *
+ * 세울지 말지는 부르는 쪽이 useShowOwner() 로 정합니다. 여기서 다시 묻지 않는 까닭은
+ * 이 이름표가 목록 줄에도 서고 카드 아래에도 서기 때문입니다.
+ *
+ * 표 안에서는 쓰지 않습니다. 표의 담당자 칸은 DataColumn.text() 가 정렬·검색·CSV 를
+ * 함께 먹이므로 그쪽 규칙을 따릅니다. 이 이름표는 표 바깥 표면에만 씁니다.
+ */
+export default function OwnerName({ name }: Props) {
+  if (!name) return null
+  return <span className={styles.owner}>{name}</span>
+}

--- a/frontend/src/components/OwnerName/index.ts
+++ b/frontend/src/components/OwnerName/index.ts
@@ -1,0 +1,1 @@
+export { default } from './OwnerName'

--- a/frontend/src/components/layout/Topbar/ScopeSwitcher/ScopeSwitcher.tsx
+++ b/frontend/src/components/layout/Topbar/ScopeSwitcher/ScopeSwitcher.tsx
@@ -7,6 +7,10 @@
  * 여러 명을 동시에 고를 수 있어야 해서 FilterSelect(단일 선택, 고르면 닫힘)를 그대로
  * 쓰지 못했습니다. 대신 그 파일의 바깥 클릭·Escape·화살표 이동 처리를 옮겨 왔고,
  * 다른 점은 Enter/Space 가 닫지 않고 토글한다는 것뿐입니다.
+ *
+ * 열려 있는 동안 고른 것은 초안으로만 들고 있다가 닫을 때 한 번에 넘깁니다. 체크마다
+ * 바로 넘기면 화면 전체가 그때마다 다시 그려지고 다시 요청합니다. 세 사람을 고르는 것은
+ * 한 번의 마음이므로 요청도 한 번이면 됩니다.
  */
 import { useEffect, useId, useRef, useState, type KeyboardEvent } from 'react'
 
@@ -43,6 +47,9 @@ export default function ScopeSwitcher() {
 function ManagerScopeSwitcher({ ownMemberId }: { ownMemberId: string }) {
   const scope = useScope()
   const [open, setOpen] = useState(false)
+  // 열려 있는 동안의 초안입니다. null 이면 지금 쓰이고 있는 범위를 그대로 봅니다.
+  const [draft, setDraft] = useState<Scope | null>(null)
+  const view = draft ?? scope
   // 닫혀 있어도 고른 사람이 있으면 이름을 보여 줘야 하므로 미리 받아 둡니다.
   const { members } = useTeamMembers(open || scope.mode === 'users')
 
@@ -52,33 +59,50 @@ function ManagerScopeSwitcher({ ownMemberId }: { ownMemberId: string }) {
   const listboxId = `scope-${useId().replaceAll(':', '')}`
   const [activeIndex, setActiveIndex] = useState(0)
 
-  // 팀에서 빠진 사람이 선택에 남아 있으면 서버가 목록 전체를 거절합니다.
+  // 팀에서 빠진 사람이 선택에 남아 있으면 서버가 목록 전체를 거절합니다. 열어 둔 채로
+  // 명부가 도착할 수 있으므로 초안도 같은 기준으로 걸러 둡니다.
   useEffect(() => {
-    if (members.length > 0) reconcileScope(members.map((member) => member.id))
+    if (members.length === 0) return
+    const available = members.map((member) => member.id)
+    reconcileScope(available)
+    setDraft((current) => {
+      if (current === null || current.mode !== 'users') return current
+      const next = current.memberIds.filter((id) => available.includes(id))
+      if (next.length === current.memberIds.length) return current
+      return next.length === 0 ? { mode: 'all', memberIds: [] } : { mode: 'users', memberIds: next }
+    })
   }, [members])
 
   const teamIds = members.map((member) => member.id)
   // '팀 전체' 는 명부 전체를 고른 것과 같습니다. 거기서 한 명만 빼려면 나머지가 이름으로
   // 남아 있어야 하므로, 계산할 때는 팀 전체를 명부로 펼쳐 둡니다.
-  const chosen = scope.mode === 'all' ? teamIds : scope.memberIds
+  const chosen = view.mode === 'all' ? teamIds : view.memberIds
   // 명부가 아직 오지 않았어도 팀 전체면 체크로 보입니다. 뜨는 순간 깜빡이지 않게 합니다.
-  const picked = (id: string) => scope.mode === 'all' || chosen.includes(id)
-  const coversTeam = scope.mode === 'all' || (teamIds.length > 0 && teamIds.every(picked))
+  const picked = (id: string) => view.mode === 'all' || chosen.includes(id)
+  const coversTeam = view.mode === 'all' || (teamIds.length > 0 && teamIds.every(picked))
 
   const toggle = (id: string) => {
     if (!chosen.includes(id)) {
-      setScopeMembers([...chosen, id])
+      setDraft({ mode: 'users', memberIds: [...chosen, id] })
       return
     }
     // 마지막 한 명까지 끄면 볼 것이 없어집니다. 팀 전체로 튕겨 보내는 대신 그 클릭을
     // 받지 않습니다. 한 사람만 보려던 의도가 전체 보기로 뒤집히지 않게 합니다.
     if (chosen.length <= 1) return
-    setScopeMembers(chosen.filter((memberId) => memberId !== id))
+    setDraft({ mode: 'users', memberIds: chosen.filter((memberId) => memberId !== id) })
+  }
+
+  // 켜져 있을 때 다시 누르면 전부 풀고 본인만 남깁니다. 팀 전체에서 한 사람으로 좁히려고
+  // 나머지를 하나씩 끄던 길을 한 번으로 줄입니다. 아무도 없는 상태는 볼 것이 없으므로
+  // 만들지 않습니다.
+  const chooseAll = () => {
+    setDraft(
+      coversTeam ? { mode: 'users', memberIds: [ownMemberId] } : { mode: 'all', memberIds: [] },
+    )
   }
 
   const rows: Row[] = [
-    // 전체 선택 체크박스입니다. 누르면 아래 줄이 모두 켜집니다.
-    { key: 'all', label: ALL_LABEL, selected: coversTeam, choose: setScopeAll },
+    { key: 'all', label: ALL_LABEL, selected: coversTeam, choose: chooseAll },
     // 본인은 '내 현황' 한 줄로만 둡니다. 아래 팀원 목록에 또 넣으면 같은 사람이 두 줄이 됩니다.
     {
       key: ownMemberId,
@@ -97,6 +121,24 @@ function ManagerScopeSwitcher({ ownMemberId }: { ownMemberId: string }) {
       })),
   ]
 
+  // 초안을 넘기고 닫습니다. 닫는 길은 모두 여기를 지나므로 취소로 빠지는 문은 없습니다.
+  // 이 앱의 다른 필터도 고른 것을 되돌리지 않아, 여기만 다르게 두면 헷갈립니다.
+  const close = () => {
+    if (draft !== null) {
+      if (draft.mode === 'all') setScopeAll()
+      else setScopeMembers(draft.memberIds)
+      setDraft(null)
+    }
+    setOpen(false)
+  }
+
+  // 바깥 클릭 listener 는 열 때 한 번만 붙는데 초안은 그 뒤로도 바뀌므로, 최신 close 를
+  // 여기에 담아 둡니다.
+  const closeRef = useRef(close)
+  useEffect(() => {
+    closeRef.current = close
+  })
+
   // 열 때 맨 위로 잡습니다. 여러 명을 이어서 고르는 동안에는 포커스를 다시 옮기지 않으므로
   // 이 effect 는 open 에만 반응하면 됩니다.
   useEffect(() => {
@@ -106,7 +148,8 @@ function ManagerScopeSwitcher({ ownMemberId }: { ownMemberId: string }) {
     const frame = requestAnimationFrame(() => optionRefs.current[0]?.focus())
 
     const onPointerDown = (event: PointerEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) setOpen(false)
+      // 초안은 매 렌더 바뀌므로 최신 close 를 ref 로 집습니다.
+      if (!rootRef.current?.contains(event.target as Node)) closeRef.current()
     }
 
     document.addEventListener('pointerdown', onPointerDown)
@@ -122,13 +165,13 @@ function ManagerScopeSwitcher({ ownMemberId }: { ownMemberId: string }) {
   }
 
   const closeAndFocusTrigger = () => {
-    setOpen(false)
+    close()
     requestAnimationFrame(() => triggerRef.current?.focus())
   }
 
   const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'Tab' && open) {
-      setOpen(false)
+      close()
       return
     }
 
@@ -166,7 +209,8 @@ function ManagerScopeSwitcher({ ownMemberId }: { ownMemberId: string }) {
     }
   }
 
-  const label = coversTeam ? ALL_LABEL : triggerLabel(scope, ownMemberId, members)
+  // 고르는 즉시 라벨이 따라와야 무엇을 고르고 있는지 보입니다. 아직 넘기기 전이라도 초안을 읽습니다.
+  const label = coversTeam ? ALL_LABEL : triggerLabel(view, ownMemberId, members)
 
   return (
     <div className={styles.root} ref={rootRef} onKeyDown={onKeyDown}>
@@ -178,7 +222,7 @@ function ManagerScopeSwitcher({ ownMemberId }: { ownMemberId: string }) {
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-controls={open ? listboxId : undefined}
-        onClick={() => setOpen(!open)}
+        onClick={() => (open ? close() : setOpen(true))}
       >
         <span className={styles.triggerLabel}>{label}</span>
         <ChevronDownIcon className={styles.chevron} width={14} height={14} />

--- a/frontend/src/mocks/meetings.ts
+++ b/frontend/src/mocks/meetings.ts
@@ -58,7 +58,18 @@ export const meetingReportSeed: MeetingReportSeed[] = [
   },
 ]
 
+/** 시연용 구성원 번호입니다. 실제 계정과 이어지지 않고 이름끼리만 구분합니다. */
+const MEMBER_IDS: Record<string, string> = {
+  김지훈: 'mock-member-kim',
+  박도윤: 'mock-member-park',
+}
+
 /** offset 을 실제 날짜로 편 미팅 기록. 최근 것이 앞에 옵니다. */
 export const fallbackMeetingReports: MeetingReport[] = meetingReportSeed
-  .map((seed) => ({ ...seed, date: iso(addDays(TODAY, seed.off)), template: meetingTemplate }))
+  .map((seed) => ({
+    ...seed,
+    date: iso(addDays(TODAY, seed.off)),
+    ownerMemberId: MEMBER_IDS[seed.owner] ?? seed.owner,
+    template: meetingTemplate,
+  }))
   .sort((a, b) => b.date.localeCompare(a.date))

--- a/frontend/src/mocks/reports.ts
+++ b/frontend/src/mocks/reports.ts
@@ -164,11 +164,15 @@ export const reportSeed: DailyReportSeed[] = [
   },
 ]
 
+/** 시연용 구성원 번호입니다. 실제 계정과 이어지지 않고 이름끼리만 구분합니다. */
+const MEMBER_IDS: Record<string, string> = { 김지훈: 'mock-member-kim' }
+
 /** offset 을 실제 날짜로 편 제출 이력. 최근 것이 앞에 옵니다. */
 export const fallbackDailyReports: DailyReport[] = reportSeed
   .map((seed) => ({
     ...seed,
     date: iso(addDays(TODAY, seed.off)),
+    ownerMemberId: MEMBER_IDS[seed.owner] ?? seed.owner,
     template: templateFor(seed.kind),
   }))
   .sort((a, b) => b.date.localeCompare(a.date))

--- a/frontend/src/pages/Calendar/components/DayCell/DayCell.tsx
+++ b/frontend/src/pages/Calendar/components/DayCell/DayCell.tsx
@@ -3,6 +3,7 @@ import { useState, type PointerEvent as ReactPointerEvent } from 'react'
 import { PlusIcon } from '@/components/icons'
 import Popover from '@/components/Popover'
 import { KIND_LABEL } from '@/shared/agenda'
+import { useShowOwner } from '@/shared/scope'
 import type { AgendaKind, CalendarEvent } from '@/types'
 
 import { CELL_ATTR, type Dragging } from '../../dragging'
@@ -73,6 +74,7 @@ export default function DayCell({
   onGrabEvent,
 }: Props) {
   const [listOpen, setListOpen] = useState(false)
+  const showOwner = useShowOwner()
 
   const dow = date.getDay()
   const visible = events.slice(0, MAX_CHIPS)
@@ -131,6 +133,9 @@ export default function DayCell({
         onOpenEvent(event)
       }}
       onDoubleClick={(e) => e.stopPropagation()}
+      // 칸이 좁아 이름표를 세울 자리가 없습니다. 여러 사람이 섞여 보일 때만
+      // 마우스를 올려 누구 일정인지 확인할 수 있게 둡니다. 아래 '+N' 목록에는 글자로 섭니다.
+      title={showOwner && event.owner ? `${event.title} · ${event.owner}` : undefined}
     >
       <span className={`${styles.chipTime} tnum`}>{event.time}</span>
       <span className={styles.chipTitle}>{event.title}</span>
@@ -225,6 +230,7 @@ export default function DayCell({
                     <span>
                       {KIND_LABEL[event.kind]}
                       {event.hospital ? ` · ${event.hospital}` : ''}
+                      {showOwner && event.owner ? ` · ${event.owner}` : ''}
                     </span>
                   </span>
                 </button>

--- a/frontend/src/pages/Contracts/Contracts.tsx
+++ b/frontend/src/pages/Contracts/Contracts.tsx
@@ -14,6 +14,7 @@ import SearchInput from '@/components/SearchInput'
 import { InlineLoader, ListPageSkeleton } from '@/components/Skeleton'
 import { chipOr } from '@/components/StageChip'
 import StageTabs from '@/components/StageTabs'
+import { useShowOwner } from '@/shared/scope'
 import SalesDealDrawer from '@/pages/Deals/SalesDealDrawer'
 import useSalesDeals, { type SalesDeal } from '@/pages/Deals/useSalesDeals'
 import { addDays, fmtDot, iso, parseISO, TODAY } from '@/utils/date'
@@ -50,6 +51,8 @@ export default function Contracts() {
 
   const requestedPipelineId = params.get('pipeline') ?? ''
   const { isManager } = useCurrentUser()
+  // 칸은 여러 사람이 섞일 때만 세웁니다. 아래 담당자 필터는 조작이라 팀장에게 늘 둡니다.
+  const showOwner = useShowOwner()
   // 담당자 선택지. 받아 둔 목록에서 뽑으면 지금 쪽에 있는 사람만 나옵니다.
   const { members: teamMembers } = useTeamMembers(isManager)
 
@@ -123,11 +126,11 @@ export default function Contracts() {
   // 정렬 API가 붙기 전에 현재 쪽만 정렬하면 전체 순서를 오해하게 됩니다.
   const columns = useMemo(
     () =>
-      CONTRACT_COLUMNS.filter((column) => column.id !== 'owner' || isManager).map((column) => ({
+      CONTRACT_COLUMNS.filter((column) => column.id !== 'owner' || showOwner).map((column) => ({
         ...column,
         sortable: false,
       })),
-    [isManager],
+    [showOwner],
   )
   const ownerOptions = useMemo(
     () => [
@@ -290,7 +293,7 @@ export default function Contracts() {
                   ? fmtDot(parseISO(contract.contractSignedOn))
                   : '계약일 미정'}
               </span>,
-              ...(isManager ? [contract.owner] : []),
+              ...(showOwner ? [contract.owner] : []),
             ],
           }
         }}

--- a/frontend/src/pages/Customers/Customers.tsx
+++ b/frontend/src/pages/Customers/Customers.tsx
@@ -3,11 +3,10 @@ import { isAxiosError } from 'axios'
 
 import { client } from '@/api/client'
 import { errorMessage, transportMessage } from '@/api/errorMessage'
-import { useCurrentUser } from '@/auth/sessionContext'
 import ErrorToast from '@/components/ErrorToast'
 import Pagination, { PAGE_SIZE } from '@/components/Pagination'
 import { InlineLoader, ListPageSkeleton } from '@/components/Skeleton'
-import { useScopeOwnerIds } from '@/shared/scope'
+import { useScopeOwnerIds, useShowOwner } from '@/shared/scope'
 import type { Customer, CustomerContactResponse, PageResponse } from '@/types'
 
 import type { BusinessCardDraft } from './businessCard'
@@ -54,10 +53,10 @@ export default function Customers() {
   const [notice, setNotice] = useState<string | null>(null)
 
   const { prefs, toggleColumn, moveColumn, setWidth, reset } = useColumnPrefs()
-  // 팀원에게는 자기가 담당인 고객만 보여, 담당자 칸이 늘 자기 이름입니다. 아예 감춥니다.
-  // 저장된 설정은 건드리지 않습니다. 팀장으로 다시 들어오면 그대로 돌아와야 합니다.
-  const { isManager } = useCurrentUser()
-  const hiddenColumns = useMemo(() => (isManager ? [] : ['owner']), [isManager])
+  // 한 사람만 보고 있으면 담당자 칸이 줄마다 같은 이름이라 아예 감춥니다. 팀원은 늘 그렇습니다.
+  // 저장된 설정은 건드리지 않습니다. 범위를 넓히면 그대로 돌아와야 합니다.
+  const showOwner = useShowOwner()
+  const hiddenColumns = useMemo(() => (showOwner ? [] : ['owner']), [showOwner])
   const deferredQuery = useDeferredValue(query)
   const ownerIds = useScopeOwnerIds()
 

--- a/frontend/src/pages/Customers/cells.tsx
+++ b/frontend/src/pages/Customers/cells.tsx
@@ -34,6 +34,8 @@ export function PlainNumber({ value }: { value: string }) {
 }
 
 /**
+ * 고객 한 명에게 붙은 담당자들입니다. 한 사람만 보여 주는 이름표는 components/OwnerName 입니다.
+ *
  * 담당자가 여럿이면 대표 한 명과 나머지 수만 보여 줍니다. 좁은 칸에 이름을 다 늘어놓으면
  * 어느 것도 읽히지 않습니다. 전체 이름은 마우스를 올리면 나옵니다.
  */

--- a/frontend/src/pages/Daily/Daily.module.scss
+++ b/frontend/src/pages/Daily/Daily.module.scss
@@ -180,6 +180,14 @@
     color: var(--muted);
     font-size: 12px;
   }
+
+  // 작성자 이름표가 앞에 설 수 있어 한 줄로 늘어놓습니다.
+  .rowMeta {
+    display: flex;
+    align-items: center;
+    gap: var(--s2);
+    min-width: 0;
+  }
 }
 
 .approver,

--- a/frontend/src/pages/Daily/Daily.tsx
+++ b/frontend/src/pages/Daily/Daily.tsx
@@ -9,10 +9,12 @@ import { Link, useNavigate, useSearchParams } from 'react-router'
 import Button, { buttonClass } from '@/components/Button'
 import ErrorToast from '@/components/ErrorToast'
 import { ChevronLeftIcon, ChevronRightIcon } from '@/components/icons'
+import OwnerName from '@/components/OwnerName'
 import Skeleton from '@/components/Skeleton'
 import Tabs from '@/components/Tabs'
 import WeekStrip from '@/components/WeekStrip'
 import { dailyComposePath, meetingPickPath } from '@/constants/routes'
+import { useShowOwner } from '@/shared/scope'
 import {
   addDays,
   addMonths,
@@ -53,6 +55,7 @@ export default function Daily() {
   const [params, setParams] = useSearchParams()
   const navigate = useNavigate()
   const period = toPeriod(params.get('tab'))
+  const showOwner = useShowOwner()
   const kind = PERIOD_KIND[period]
 
   /**
@@ -339,7 +342,11 @@ export default function Daily() {
                     {row.title}
                   </Link>
                 </strong>
-                <span>{row.meta}</span>
+                <span className={styles.rowMeta}>
+                  {/* 여러 사람의 보고서가 섞여 보일 때만 누가 썼는지 세웁니다. */}
+                  {showOwner && <OwnerName name={row.author} />}
+                  {row.meta}
+                </span>
               </div>
 
               <span className={styles.approver}>{row.aside}</span>

--- a/frontend/src/pages/Daily/Daily.tsx
+++ b/frontend/src/pages/Daily/Daily.tsx
@@ -201,7 +201,9 @@ export default function Daily() {
           onChange={setPeriod}
         />
 
-        {/* 탭이 종류를 이미 골랐으면 한 번 더 묻지 않고 그 화면으로 바로 갑니다. */}
+        {/* 탭이 종류를 이미 골랐으면 한 번 더 묻지 않고 그 화면으로 바로 갑니다.
+            일정에 붙는 업무보고서와 달리 기간 보고서는 언제나 본인 것이라 소유를 따지지
+            않습니다. 서버도 작성자를 로그인한 사람으로 박습니다. */}
         {composeTo ? (
           <Link className={buttonClass()} to={composeTo}>
             보고서 작성하기

--- a/frontend/src/pages/Daily/Detail.tsx
+++ b/frontend/src/pages/Daily/Detail.tsx
@@ -1,5 +1,6 @@
 import { Link, useParams } from 'react-router'
 
+import { useCurrentUser } from '@/auth/sessionContext'
 import AttachmentPanel from '@/components/AttachmentPanel'
 import Button from '@/components/Button'
 import ReportFields from '@/components/ReportFields'
@@ -25,6 +26,9 @@ export default function Detail() {
   )
 
   const report = item ? toReport(item) : undefined
+  // 보고서는 쓴 사람만 고칩니다. 팀장이 팀원의 보고서를 열어도 고치는 길은 서지 않습니다.
+  const { memberId } = useCurrentUser()
+  const isMine = report?.ownerMemberId === memberId
 
   if (loading)
     return (
@@ -69,7 +73,7 @@ export default function Detail() {
         <ReportStatusBadge status={report.status} />
         <span className={styles.approver}>보고 대상 {report.approver}</span>
 
-        {report.status === '반려' && (
+        {report.status === '반려' && isMine && (
           <Link className={styles.rewrite} to={dailyComposePath(report.date, report.kind)}>
             수정해서 다시 제출
           </Link>

--- a/frontend/src/pages/Daily/components/ReportDrawer/ReportDrawer.tsx
+++ b/frontend/src/pages/Daily/components/ReportDrawer/ReportDrawer.tsx
@@ -6,9 +6,11 @@ import { useEffect, useId, useRef } from 'react'
 import { Link } from 'react-router'
 
 import { buttonClass } from '@/components/Button'
+import OwnerName from '@/components/OwnerName'
 import { ChevronRightIcon, CloseIcon } from '@/components/icons'
 import { dailyComposePath } from '@/constants/routes'
 import { agendaFor } from '@/shared/agenda'
+import { useShowOwner } from '@/shared/scope'
 import type { ReportKind } from '@/types'
 import { fmtDot, parseISO, TODAY_ISO } from '@/utils/date'
 
@@ -31,6 +33,7 @@ interface Props {
 
 export default function ReportDrawer({ dateISO, rows, kind, onClose }: Props) {
   const bodyRef = useRef<HTMLDivElement>(null)
+  const showOwner = useShowOwner()
   const titleId = useId()
 
   // Modal 과 같은 처리입니다. Escape 로 닫고 배경은 스크롤을 멈추며,
@@ -108,6 +111,7 @@ export default function ReportDrawer({ dateISO, rows, kind, onClose }: Props) {
                   <span className={styles.kind}>{row.kindLabel}</span>
                   <ReportStatusBadge status={row.status} />
                   <span className={styles.approver}>{row.aside}</span>
+                  {showOwner && <OwnerName name={row.author} />}
                 </div>
 
                 <h3 className={styles.title}>{row.title}</h3>

--- a/frontend/src/pages/Daily/rows.ts
+++ b/frontend/src/pages/Daily/rows.ts
@@ -30,6 +30,8 @@ export interface ListRow {
   haystack: string
   /** 미팅만 갖습니다. 고객사 필터가 봅니다. */
   hospital?: string
+  /** 이 보고서를 쓴 사람. 여러 사람이 섞여 보일 때만 화면에 섭니다. */
+  author: string
 }
 
 const lower = (parts: (string | undefined)[]) => parts.filter(Boolean).join(' ').toLowerCase()
@@ -51,12 +53,14 @@ export function fromDailyReport(report: DailyReport): ListRow {
         ? `활동 ${acts}건${files > 0 ? ` · 첨부 ${files}건` : ''}`
         : report.note,
     aside: report.approver,
+    author: report.owner,
     status: report.status,
     to: dailyReportPath(report.id),
     haystack: lower([
       reportTitle(report),
       report.note,
       report.approver,
+      report.owner,
       report.kind,
       ...Object.values(report.values),
     ]),
@@ -77,11 +81,13 @@ export function fromMeetingReport(report: MeetingReport): ListRow {
       .filter(Boolean)
       .join(' · '),
     aside: report.hospital,
+    author: report.owner,
     status: report.status,
     to: meetingReportPath(report.id),
     haystack: lower([
       report.hospital,
       report.title,
+      report.owner,
       report.dept,
       report.contact,
       report.product,

--- a/frontend/src/pages/Daily/useDailyReports.ts
+++ b/frontend/src/pages/Daily/useDailyReports.ts
@@ -76,6 +76,7 @@ export function toReport(item: ReportResponse): DailyReport {
   return {
     id: item.id,
     owner: item.author_display_name,
+    ownerMemberId: item.author_member_id,
     off: Math.round((parseISO(item.report_date).getTime() - TODAY.getTime()) / DAY),
     date: item.report_date,
     kind,

--- a/frontend/src/pages/Dashboard/components/DayAgenda/DayAgenda.module.scss
+++ b/frontend/src/pages/Dashboard/components/DayAgenda/DayAgenda.module.scss
@@ -283,6 +283,13 @@
   }
 }
 
+// 받아 오는 동안 아이콘 하나만 가운데에 둡니다. '없음' 과 같은 높이라 답이
+// 오는 순간 카드가 늘었다 줄지 않습니다.
+.loading {
+  justify-content: center;
+  padding: var(--s8) var(--s4);
+}
+
 .empty {
   padding: var(--s8) var(--s4);
   text-align: center;

--- a/frontend/src/pages/Dashboard/components/DayAgenda/DayAgenda.tsx
+++ b/frontend/src/pages/Dashboard/components/DayAgenda/DayAgenda.tsx
@@ -6,6 +6,7 @@ import DayHeader from '@/components/DayHeader'
 import { CalendarIcon, DailyReportIcon, EditIcon, MoreIcon, TrashIcon } from '@/components/icons'
 import OwnerName from '@/components/OwnerName'
 import Popover from '@/components/Popover'
+import { InlineLoader } from '@/components/Skeleton'
 import { useCurrentUser } from '@/auth/sessionContext'
 import { meetingComposePath } from '@/constants/routes'
 import { useMeetingReportsOn } from '@/pages/Meetings/useMeetingReports'
@@ -31,7 +32,7 @@ const DayAgenda = forwardRef<HTMLElement, Props>(function DayAgenda(
   { dateISO, onOpen, onAddSchedule, onEdit, onDelete, flash },
   ref,
 ) {
-  const list = useAgendaFor(dateISO)
+  const { items: list, loading } = useAgendaFor(dateISO)
   const showOwner = useShowOwner()
   const { memberId, isManager } = useCurrentUser()
   /** 메뉴를 펴 둔 줄. 한 번에 한 줄만 폅니다. */
@@ -164,7 +165,11 @@ const DayAgenda = forwardRef<HTMLElement, Props>(function DayAgenda(
         </Button>
       </DayHeader>
 
-      {list.length === 0 ? (
+      {/* 아직 받아 오는 중이면 '없음' 을 세우지 않습니다. 세웠다가 목록으로 바뀌면
+          일정이 있는 날에도 없다는 문구가 한 번 스칩니다. */}
+      {loading ? (
+        <InlineLoader label="일정을 불러오는 중입니다." className={styles.loading} />
+      ) : list.length === 0 ? (
         <div className={styles.empty}>
           <CalendarIcon width={34} height={34} strokeWidth={1.5} />
           <p>이 날짜에는 등록된 일정이 없습니다.</p>

--- a/frontend/src/pages/Dashboard/components/DayAgenda/DayAgenda.tsx
+++ b/frontend/src/pages/Dashboard/components/DayAgenda/DayAgenda.tsx
@@ -4,10 +4,12 @@ import { Link } from 'react-router'
 import Button from '@/components/Button'
 import DayHeader from '@/components/DayHeader'
 import { CalendarIcon, DailyReportIcon, EditIcon, MoreIcon, TrashIcon } from '@/components/icons'
+import OwnerName from '@/components/OwnerName'
 import Popover from '@/components/Popover'
 import { meetingComposePath } from '@/constants/routes'
 import { useMeetingReportsOn } from '@/pages/Meetings/useMeetingReports'
 import { useAgendaFor } from '@/shared/agenda'
+import { useShowOwner } from '@/shared/scope'
 import type { AgendaItem } from '@/types'
 
 import styles from './DayAgenda.module.scss'
@@ -29,6 +31,7 @@ const DayAgenda = forwardRef<HTMLElement, Props>(function DayAgenda(
   ref,
 ) {
   const list = useAgendaFor(dateISO)
+  const showOwner = useShowOwner()
   /** 메뉴를 펴 둔 줄. 한 번에 한 줄만 폅니다. */
   const [menuId, setMenuId] = useState<string | null>(null)
   // 아직 보고서를 안 쓴 줄에만 '보고서 작성' 을 세웁니다. 줄마다 따로 물으면 요청이
@@ -130,6 +133,9 @@ const DayAgenda = forwardRef<HTMLElement, Props>(function DayAgenda(
             >
               {it.hospital || it.title}
             </button>
+            {/* 여러 사람의 일정이 섞여 보일 때만 섭니다. 옆의 흐린 글씨는 고객 쪽
+                부서·담당자라, 우리 쪽 사람은 다른 모양으로 세워 구분합니다. */}
+            {showOwner && <OwnerName name={it.owner} />}
             {(it.dept || it.contact) && (
               <span className={styles.who}>
                 {[it.dept, it.contact].filter(Boolean).join(' · ')}

--- a/frontend/src/pages/Dashboard/components/DayAgenda/DayAgenda.tsx
+++ b/frontend/src/pages/Dashboard/components/DayAgenda/DayAgenda.tsx
@@ -6,9 +6,10 @@ import DayHeader from '@/components/DayHeader'
 import { CalendarIcon, DailyReportIcon, EditIcon, MoreIcon, TrashIcon } from '@/components/icons'
 import OwnerName from '@/components/OwnerName'
 import Popover from '@/components/Popover'
+import { useCurrentUser } from '@/auth/sessionContext'
 import { meetingComposePath } from '@/constants/routes'
 import { useMeetingReportsOn } from '@/pages/Meetings/useMeetingReports'
-import { useAgendaFor } from '@/shared/agenda'
+import { isOwnAgendaItem, useAgendaFor } from '@/shared/agenda'
 import { useShowOwner } from '@/shared/scope'
 import type { AgendaItem } from '@/types'
 
@@ -32,6 +33,7 @@ const DayAgenda = forwardRef<HTMLElement, Props>(function DayAgenda(
 ) {
   const list = useAgendaFor(dateISO)
   const showOwner = useShowOwner()
+  const { memberId, isManager } = useCurrentUser()
   /** 메뉴를 펴 둔 줄. 한 번에 한 줄만 폅니다. */
   const [menuId, setMenuId] = useState<string | null>(null)
   // 아직 보고서를 안 쓴 줄에만 '보고서 작성' 을 세웁니다. 줄마다 따로 물으면 요청이
@@ -45,7 +47,11 @@ const DayAgenda = forwardRef<HTMLElement, Props>(function DayAgenda(
     const done = it.done
     // 아직 안 쓴 줄에만 세웁니다. 답을 받기 전에도 세우지 않습니다.
     // 세웠다가 거두면 이미 쓴 줄에서 깜빡입니다.
-    const needsReport = !reportsLoading && !writtenIds.has(it.id)
+    //
+    // 내가 한 일에만 섭니다. 보고는 남이 한 일을 대신 적는 문서가 아니라서,
+    // 팀 전체를 보고 있는 팀장에게도 팀원의 일정에는 이 길이 서지 않습니다.
+    const needsReport =
+      !reportsLoading && !writtenIds.has(it.id) && isOwnAgendaItem(it, memberId, isManager)
 
     return (
       // 줄 어디를 눌러도 상세가 열립니다. 안쪽 버튼들은 각자 할 일이

--- a/frontend/src/pages/Dashboard/components/ListDrawer/ListDrawer.tsx
+++ b/frontend/src/pages/Dashboard/components/ListDrawer/ListDrawer.tsx
@@ -3,7 +3,9 @@
 // 발주 타일이면 위에 필터 칩을 달고 같은 표면을 씁니다.
 import Button from '@/components/Button'
 import Drawer from '@/components/Drawer'
+import OwnerName from '@/components/OwnerName'
 import { InlineLoader } from '@/components/Skeleton'
+import { useShowOwner } from '@/shared/scope'
 
 import type { DrawerList, DrawerListRow } from '../../drawerLists'
 import type { OrderFilterKey } from '../../orderFilters'
@@ -28,7 +30,7 @@ interface Props {
   onClose: () => void
 }
 
-function Row({ row }: { row: DrawerListRow }) {
+function Row({ row, showOwner }: { row: DrawerListRow; showOwner: boolean }) {
   return (
     <>
       <div className={styles.main}>
@@ -37,8 +39,9 @@ function Row({ row }: { row: DrawerListRow }) {
           {row.titleNote && <span>{row.titleNote}</span>}
         </h3>
         <p>{row.note}</p>
-        {row.tags.length > 0 && (
+        {(row.tags.length > 0 || (showOwner && row.owner)) && (
           <div className={styles.tags}>
+            {showOwner && <OwnerName name={row.owner} />}
             {row.tags.map((t) => (
               <i key={t.text} className={`${styles.pill} ${t.tone ? styles[t.tone] : ''}`}>
                 {t.text}
@@ -80,6 +83,8 @@ export default function ListDrawer({
   onOpenOrder,
   onClose,
 }: Props) {
+  const showOwner = useShowOwner()
+
   return (
     <Drawer
       wide
@@ -127,11 +132,11 @@ export default function ListDrawer({
                 className={`${styles.row} ${styles.clickable}`}
                 onClick={() => onOpenOrder(no)}
               >
-                <Row row={row} />
+                <Row row={row} showOwner={showOwner} />
               </button>
             ) : (
               <div key={row.key} className={styles.row}>
-                <Row row={row} />
+                <Row row={row} showOwner={showOwner} />
               </div>
             )
           })}

--- a/frontend/src/pages/Dashboard/components/RecordDrawer/RecordDrawer.tsx
+++ b/frontend/src/pages/Dashboard/components/RecordDrawer/RecordDrawer.tsx
@@ -127,17 +127,18 @@ export default function RecordDrawer({ item, onClose, onEdit, onDelete }: Props)
           )}
         </>
       }
+      // 남이 한 일이고 아직 보고서도 없으면(blocked) 갈 곳이 없어 아무것도 세우지 않습니다.
       footer={
         reportState.error ? (
           <Button variant="outline" onClick={reportState.reload}>
             보고서 다시 조회
           </Button>
-        ) : reportState.link ? (
+        ) : !reportState.link ? (
+          <InlineLoader label="보고서 연결을 확인하는 중입니다." />
+        ) : reportState.link.blocked ? null : (
           <Link className={buttonClass()} to={reportState.link.to}>
             {reportState.link.label}
           </Link>
-        ) : (
-          <InlineLoader label="보고서 연결을 확인하는 중입니다." />
         )
       }
     >

--- a/frontend/src/pages/Dashboard/components/RecordDrawer/RecordDrawer.tsx
+++ b/frontend/src/pages/Dashboard/components/RecordDrawer/RecordDrawer.tsx
@@ -52,7 +52,7 @@ export default function RecordDrawer({ item, onClose, onEdit, onDelete }: Props)
   const facts: [string, string][] = (
     [
       ['부서', item.dept],
-      ['담당자', at < 0 ? item.contact : item.contact.slice(0, at)],
+      ['고객 담당자', at < 0 ? item.contact : item.contact.slice(0, at)],
       ['직책', item.contact && at >= 0 ? item.contact.slice(at + 1) : ''],
       ['제품', item.product],
       ['장소', item.place],

--- a/frontend/src/pages/Dashboard/components/RecordDrawer/RecordDrawer.tsx
+++ b/frontend/src/pages/Dashboard/components/RecordDrawer/RecordDrawer.tsx
@@ -10,6 +10,7 @@ import { orderPath } from '@/constants/routes'
 import { statusScope } from '@/shared/agenda'
 import { useAgendaReportLink } from '@/shared/agendaReport'
 import { RISK_LABEL } from '@/shared/riskLabels'
+import { useShowOwner } from '@/shared/scope'
 import type { AgendaItem } from '@/types'
 import { fmtDay, parseISO } from '@/utils/date'
 import { won } from '@/utils/format'
@@ -46,11 +47,14 @@ export default function RecordDrawer({ item, onClose, onEdit, onDelete }: Props)
     error: briefingError,
   } = useAiBriefing({ activityId: item.id, eligible: !!item.customerContactId })
   const [menuOpen, setMenuOpen] = useState(false)
+  const showOwner = useShowOwner()
   // 드로어는 눌러야 열리므로 여기서 물어보는 것이 곧 온디맨드입니다.
   const reportState = useAgendaReportLink(item)
   const at = item.contact.lastIndexOf(' ')
   const facts: [string, string][] = (
     [
+      // 여러 사람의 일정이 섞여 보일 때만, 이것이 누구 일정인지 먼저 말합니다.
+      ...(showOwner ? ([['담당 영업', item.owner]] as [string, string][]) : []),
       ['부서', item.dept],
       ['고객 담당자', at < 0 ? item.contact : item.contact.slice(0, at)],
       ['직책', item.contact && at >= 0 ? item.contact.slice(at + 1) : ''],

--- a/frontend/src/pages/Dashboard/drawerLists.ts
+++ b/frontend/src/pages/Dashboard/drawerLists.ts
@@ -15,6 +15,8 @@ export interface DrawerListRow {
   titleNote?: string
   note: string
   tags: { text: string; tone?: DrawerListTone }[]
+  /** 이 건의 담당자. 여러 사람이 섞여 보일 때만 드로어가 세웁니다. */
+  owner?: string
   side: {
     strong: string
     late?: boolean
@@ -52,6 +54,7 @@ export function csList(requests: SupportRequestResponse[]): DrawerList {
         key: request.id,
         title: request.title,
         titleNote: `${request.customer_company_name} · ${request.contract_no ?? request.deal_no}`,
+        owner: request.assignee_display_name,
         note: request.body,
         tags: [
           ...(request.is_urgent ? [{ text: '긴급', tone: 'risk' as const }] : []),
@@ -80,7 +83,7 @@ export function renewalList(deals: SalesDealResponse[]): DrawerList {
       return {
         key: deal.id,
         title: deal.customer_company_name,
-        titleNote: deal.owner_display_name,
+        owner: deal.owner_display_name,
         note: deal.description ?? deal.memo ?? '등록된 메모가 없습니다.',
         tags: [
           { text: deal.deal_type_name },

--- a/frontend/src/pages/Deals/DealBoard.tsx
+++ b/frontend/src/pages/Deals/DealBoard.tsx
@@ -16,6 +16,7 @@ import Modal from '@/components/Modal'
 import SearchInput from '@/components/SearchInput'
 import { InlineLoader, SkeletonBlocks } from '@/components/Skeleton'
 import usePointerDrag from '@/hooks/usePointerDrag'
+import { useShowOwner } from '@/shared/scope'
 import { addDays, iso, TODAY } from '@/utils/date'
 
 import { DROP_ATTR, parseSlot, type BoardDeal } from './board'
@@ -52,6 +53,8 @@ export default function DealBoard() {
   const [openId, setOpenId] = useState<string | null>(null)
   const [params, setParams] = useSearchParams()
   const requestedPipelineId = params.get('pipeline') ?? ''
+  // 카드마다 묻지 않고 보드가 한 번 정해 컬럼으로 내려 줍니다.
+  const showOwner = useShowOwner()
   const {
     pipelines,
     dealPipelineId,
@@ -340,6 +343,7 @@ export default function DealBoard() {
                 cards={shownByColumn.get(column.id) ?? []}
                 identityOf={pipelineIdentity}
                 editableStages={false}
+                showOwner={showOwner}
                 readOnly={readOnly}
                 dropSlot={dropKey}
                 draggingIdentity={dragging?.id ?? null}

--- a/frontend/src/pages/Deals/Deals.tsx
+++ b/frontend/src/pages/Deals/Deals.tsx
@@ -2,7 +2,6 @@
 import { useCallback, useDeferredValue, useMemo, useState } from 'react'
 import { useSearchParams } from 'react-router'
 
-import { useCurrentUser } from '@/auth/sessionContext'
 import Button from '@/components/Button'
 import DataTable from '@/components/DataTable'
 import ErrorToast from '@/components/ErrorToast'
@@ -14,6 +13,7 @@ import SearchInput from '@/components/SearchInput'
 import { InlineLoader, ListPageSkeleton } from '@/components/Skeleton'
 import StageChip, { chipOr } from '@/components/StageChip'
 import StageTabs from '@/components/StageTabs'
+import { useShowOwner } from '@/shared/scope'
 import { addDays, fmtDot, iso, parseISO, TODAY } from '@/utils/date'
 import { won } from '@/utils/format'
 
@@ -44,9 +44,9 @@ export default function Deals() {
   const [openId, setOpenId] = useState<string | null>(null)
   const [params, setParams] = useSearchParams()
   const requestedPipelineId = params.get('pipeline') || DEFAULT_PIPELINE
-  const { isManager } = useCurrentUser()
-  // 팀원은 서버가 본인 데이터로 제한하므로 담당자 스코프를 요청에 싣지 않습니다.
-  const showOwner = isManager
+  // 여러 사람이 섞여 보일 때만 담당 영업 칸을 세웁니다. 한 명만 보고 있으면 모든 줄이
+  // 같은 이름이고, 팀원은 서버가 본인 것만 돌려줍니다.
+  const showOwner = useShowOwner()
 
   const query = params.get('q') ?? ''
   const range = params.get('range') ?? DEFAULT_RANGE

--- a/frontend/src/pages/Deals/components/DealCard/DealCard.module.scss
+++ b/frontend/src/pages/Deals/components/DealCard/DealCard.module.scss
@@ -136,3 +136,10 @@
   color: var(--muted);
   font-size: 12px;
 }
+
+// 담당 영업과 날짜는 오른쪽에 나란히 섭니다.
+.metaEnd {
+  display: flex;
+  align-items: center;
+  gap: var(--s2);
+}

--- a/frontend/src/pages/Deals/components/DealCard/DealCard.tsx
+++ b/frontend/src/pages/Deals/components/DealCard/DealCard.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from 'react'
 import { createPortal } from 'react-dom'
 
+import OwnerName from '@/components/OwnerName'
+
 import type { BoardDeal } from '../../board'
 import { fmtDotShort, parseISO } from '@/utils/date'
 
@@ -17,6 +19,8 @@ interface Props {
   onNudge: (identity: string, delta: -1 | 1) => void
   onEdit: (identity: string) => void
   onDelete: (identity: string) => void
+  /** 여러 사람의 딜이 섞여 보일 때만 담당 영업을 세웁니다. 보드가 한 번 정해 내려 줍니다. */
+  showOwner?: boolean
   readOnly?: boolean
 }
 
@@ -29,6 +33,7 @@ export default function DealCard({
   onNudge,
   onEdit,
   onDelete,
+  showOwner = false,
   readOnly = false,
 }: Props) {
   return (
@@ -54,7 +59,10 @@ export default function DealCard({
 
         <span className={styles.meta}>
           <span>{deal.product}</span>
-          <span className="tnum">{fmtDotShort(parseISO(deal.date))}</span>
+          <span className={styles.metaEnd}>
+            {showOwner && <OwnerName name={deal.owner} />}
+            <span className="tnum">{fmtDotShort(parseISO(deal.date))}</span>
+          </span>
         </span>
       </button>
 

--- a/frontend/src/pages/Deals/components/StageColumn/StageColumn.tsx
+++ b/frontend/src/pages/Deals/components/StageColumn/StageColumn.tsx
@@ -21,6 +21,8 @@ interface Props {
   identityOf?: (deal: BoardDeal) => string
   /** 실제 API에는 단계 CRUD가 없으므로 그 화면에서는 설정 메뉴를 숨깁니다. */
   editableStages?: boolean
+  /** 카드마다 담당 영업을 세울지. 보드가 보기 범위를 보고 정합니다. */
+  showOwner?: boolean
   readOnly?: boolean
   /** 지금 가리키고 있는 자리. `<컬럼 id>:<자리>` */
   dropSlot: string | null
@@ -43,6 +45,7 @@ export default function StageColumn({
   cards,
   identityOf = (deal) => deal.no,
   editableStages = true,
+  showOwner = false,
   readOnly = false,
   dropSlot,
   draggingIdentity,
@@ -107,6 +110,7 @@ export default function StageColumn({
                 onNudge={onNudge}
                 onEdit={onEditCard}
                 onDelete={onDeleteCard}
+                showOwner={showOwner}
                 readOnly={readOnly}
               />
             </li>

--- a/frontend/src/pages/Documents/Documents.tsx
+++ b/frontend/src/pages/Documents/Documents.tsx
@@ -14,6 +14,7 @@ import { UploadIcon } from '@/components/icons'
 import Pagination, { PAGE_SIZE } from '@/components/Pagination'
 import SearchInput from '@/components/SearchInput'
 import { InlineLoader, ListPageSkeleton } from '@/components/Skeleton'
+import { useShowOwner } from '@/shared/scope'
 import type { DocumentCategory } from '@/types'
 import { addDays, iso, TODAY } from '@/utils/date'
 
@@ -37,13 +38,14 @@ const RANGES = [
 const DEFAULT_RANGE = '12'
 
 export default function Documents() {
-  // 자료는 팀원도 올립니다. 등록자 필터·열은 팀장에게만 보입니다.
+  // 자료는 팀원도 올립니다. 등록자 칸은 여러 사람이 섞여 보일 때만 세웁니다.
+  // 등록자 필터는 보여 주는 것이 아니라 대상을 좁히는 조작이라 팀장에게 늘 둡니다.
   const { profile, isManager } = useCurrentUser()
-  const showOwner = isManager
+  const showOwner = useShowOwner()
 
   const [params, setParams] = useSearchParams()
   const query = params.get('q') ?? ''
-  const owner = showOwner ? (params.get('owner') ?? '') : ''
+  const owner = isManager ? (params.get('owner') ?? '') : ''
   const range = params.get('range') ?? DEFAULT_RANGE
 
   const category = params.get('category') ?? ''
@@ -185,7 +187,7 @@ export default function Documents() {
           onChange={(next) => setParam('q', next)}
         />
 
-        {showOwner && (
+        {isManager && (
           <FilterSelect
             label="등록자"
             value={owner}

--- a/frontend/src/pages/Meetings/Detail.tsx
+++ b/frontend/src/pages/Meetings/Detail.tsx
@@ -1,6 +1,7 @@
 // 제출한 미팅 기록을 읽는 화면입니다. 작성 화면과 같은 컴포넌트를 읽기 모드로 씁니다.
 import { Link, useParams } from 'react-router'
 
+import { useCurrentUser } from '@/auth/sessionContext'
 import AttachmentPanel from '@/components/AttachmentPanel'
 import Button, { buttonClass } from '@/components/Button'
 import { EditIcon } from '@/components/icons'
@@ -26,6 +27,9 @@ export default function Detail() {
   )
 
   const report = item ? toMeetingReport(item) : undefined
+  // 보고서는 쓴 사람만 고칩니다. 팀장이 팀원의 보고서를 열어도 고치는 길은 서지 않습니다.
+  const { memberId } = useCurrentUser()
+  const isMine = report?.ownerMemberId === memberId
 
   if (loading)
     return (
@@ -125,7 +129,7 @@ export default function Detail() {
               <span className={`${styles.sealed} ${styles.trailing}`}>
                 팀장 확인이 끝나 수정할 수 없습니다
               </span>
-            ) : (
+            ) : isMine ? (
               <Link
                 className={buttonClass({}, styles.trailing)}
                 to={meetingComposePath(report.agendaId)}
@@ -133,7 +137,7 @@ export default function Detail() {
                 <EditIcon width={15} height={15} />
                 수정하기
               </Link>
-            )}
+            ) : null}
           </div>
         </div>
 

--- a/frontend/src/pages/Meetings/components/MeetingFacts/MeetingFacts.tsx
+++ b/frontend/src/pages/Meetings/components/MeetingFacts/MeetingFacts.tsx
@@ -21,7 +21,7 @@ export default function MeetingFacts({ dept, contact, place, hospital, when }: P
   const facts: [string, string][] = [
     ...(hospital === undefined ? [] : ([['회사', hospital]] as [string, string][])),
     ['부서', dept],
-    ['담당자', contact],
+    ['고객 담당자', contact],
     ['장소', place],
     ...(when === undefined ? [] : ([['일시', when]] as [string, string][])),
   ]

--- a/frontend/src/pages/Meetings/useMeetingReports.ts
+++ b/frontend/src/pages/Meetings/useMeetingReports.ts
@@ -65,6 +65,7 @@ export function toMeetingReport(item: ReportResponse): MeetingReport {
   return {
     id: item.id,
     owner: item.author_display_name,
+    ownerMemberId: item.author_member_id,
     agendaId: item.source_activity_id ?? '',
     off: Math.round((parseISO(item.report_date).getTime() - TODAY.getTime()) / DAY),
     date: item.report_date,

--- a/frontend/src/pages/Orders/Orders.tsx
+++ b/frontend/src/pages/Orders/Orders.tsx
@@ -6,7 +6,6 @@
 import { useCallback, useDeferredValue, useMemo, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router'
 
-import { useCurrentUser } from '@/auth/sessionContext'
 import Button from '@/components/Button'
 import DataTable from '@/components/DataTable'
 import ErrorToast from '@/components/ErrorToast'
@@ -21,6 +20,7 @@ import StageChip from '@/components/StageChip'
 import StageTabs from '@/components/StageTabs'
 import { orderNewPath, orderPath } from '@/constants/routes'
 import { isLate, orderItemLabel, orderTotal } from '@/shared/orders'
+import { useShowOwner } from '@/shared/scope'
 import type { ApiPurchaseOrder } from '@/types'
 import { addDays, fmtDotShort, iso, parseISO, TODAY } from '@/utils/date'
 import { won } from '@/utils/format'
@@ -44,7 +44,7 @@ const DEFAULT_RANGE = '6'
 
 export default function Orders() {
   const navigate = useNavigate()
-  const { isManager } = useCurrentUser()
+  const showOwner = useShowOwner()
 
   const [params, setParams] = useSearchParams()
   const query = params.get('q') ?? ''
@@ -67,11 +67,11 @@ export default function Orders() {
   // 같은 처리로 헤더 정렬을 끕니다.
   const columns = useMemo(
     () =>
-      ORDER_COLUMNS.filter((col) => col.id !== 'owner' || isManager).map((col) => ({
+      ORDER_COLUMNS.filter((col) => col.id !== 'owner' || showOwner).map((col) => ({
         ...col,
         sortable: false,
       })),
-    [isManager],
+    [showOwner],
   )
 
   // 기본값은 쿼리에서 지웁니다. 주소를 복사했을 때 조건이 그대로 살아나되 짧게 남습니다.

--- a/frontend/src/pages/Quotes/Quotes.tsx
+++ b/frontend/src/pages/Quotes/Quotes.tsx
@@ -13,6 +13,7 @@ import SearchInput from '@/components/SearchInput'
 import { InlineLoader, ListPageSkeleton } from '@/components/Skeleton'
 import { chipOr } from '@/components/StageChip'
 import StageTabs from '@/components/StageTabs'
+import { useShowOwner } from '@/shared/scope'
 import SalesDealDrawer from '@/pages/Deals/SalesDealDrawer'
 import useSalesDeals, { type SalesDeal } from '@/pages/Deals/useSalesDeals'
 import { addDays, fmtDot, fmtDotShort, iso, parseISO, TODAY, TODAY_ISO } from '@/utils/date'
@@ -50,6 +51,9 @@ export default function Quotes() {
 
   const requestedPipelineId = params.get('pipeline') ?? ''
   const { isManager } = useCurrentUser()
+  // 칸은 여러 사람이 섞일 때만 세우고, 아래 담당자 필터는 팀장에게 늘 둡니다.
+  // 필터는 보여 주는 것이 아니라 대상을 바꾸는 조작이라 한 명만 보고 있을 때도 필요합니다.
+  const showOwner = useShowOwner()
   // 담당자 선택지. 받아 둔 목록에서 뽑으면 지금 쪽에 있는 사람만 나옵니다.
   const { members: teamMembers } = useTeamMembers(isManager)
 
@@ -123,11 +127,11 @@ export default function Quotes() {
   // 정렬 API가 붙기 전에 현재 쪽만 정렬하면 전체 순서를 오해하게 됩니다.
   const columns = useMemo(
     () =>
-      QUOTE_COLUMNS.filter((column) => column.id !== 'owner' || isManager).map((column) => ({
+      QUOTE_COLUMNS.filter((column) => column.id !== 'owner' || showOwner).map((column) => ({
         ...column,
         sortable: false,
       })),
-    [isManager],
+    [showOwner],
   )
   const ownerOptions = useMemo(
     () => [

--- a/frontend/src/shared/agenda.ts
+++ b/frontend/src/shared/agenda.ts
@@ -440,8 +440,13 @@ export function useAgendaItem(id: string) {
 /**
  * 하루치만 받아 옵니다. 대시보드가 첫 응답으로 심어 둔 날은 캐시에 걸려 다시 받지 않습니다.
  */
-export function useAgendaFor(dateISO: string): AgendaItem[] {
-  useAgendaState(dateISO, dateISO)
+export function useAgendaFor(dateISO: string): { items: AgendaItem[]; loading: boolean } {
+  const { loading, error } = useAgendaState(dateISO, dateISO)
   const snapshot = useCallback(() => agendaFor(dateISO), [dateISO])
-  return useSyncExternalStore(subscribeAgenda, snapshot, snapshot)
+  const list = useSyncExternalStore(subscribeAgenda, snapshot, snapshot)
+  // 날짜가 바뀐 뒤 요청을 띄우는 것은 effect 라, 그 앞의 렌더에서는 아직 store 의
+  // loading 이 false 입니다. 그대로 두면 '일정 없음' 이 한 번 스쳤다가 목록으로
+  // 바뀝니다. 이 날짜를 실제로 받아 두었는지까지 함께 봅니다.
+  const settled = loadedKey === `${getScopeKey()}|${dateISO}:${dateISO}` || error !== null
+  return { items: list, loading: loading || !settled }
 }

--- a/frontend/src/shared/agenda.ts
+++ b/frontend/src/shared/agenda.ts
@@ -374,6 +374,23 @@ export function useAgendaState(
 }
 
 /**
+ * 이 일정이 내가 한 일인지. '보고서 작성' 이 설 자리를 정합니다.
+ *
+ * ownerMemberId 가 비는 것은 서버를 거치지 않은 줄뿐입니다. 팀원 목록은 서버가 본인
+ * 것만 돌려주므로 비어 있어도 본인 일정으로 봅니다. 팀장은 남의 줄이 섞여 있어,
+ * 확인할 수 없으면 세우지 않습니다. 세웠다가 서버가 403 을 돌려주는 것보다
+ * 처음부터 없는 편이 낫습니다.
+ */
+export function isOwnAgendaItem(
+  item: Pick<AgendaItem, 'ownerMemberId'>,
+  memberId: string,
+  isManager: boolean,
+): boolean {
+  if (item.ownerMemberId !== undefined) return item.ownerMemberId === memberId
+  return !isManager
+}
+
+/**
  * 활동 하나만 받아 옵니다. 보고서 작성 화면이 주소의 활동 번호로 바로 들어올 때 씁니다.
  *
  * 목록에서 찾으면 그 활동이 언제 것인지 모르는 채로 전 기간을 받아야 합니다. 번호를 아는

--- a/frontend/src/shared/agendaReport.ts
+++ b/frontend/src/shared/agendaReport.ts
@@ -9,8 +9,10 @@
 import { useCallback, useEffect, useState } from 'react'
 
 import { errorMessage } from '@/api/errorMessage'
+import { useCurrentUser } from '@/auth/sessionContext'
 import { meetingComposePath, meetingReportPath } from '@/constants/routes'
 import { savedForAgenda } from '@/pages/Meetings/useMeetingReports'
+import { isOwnAgendaItem } from '@/shared/agenda'
 import type { AgendaItem } from '@/types'
 
 export interface AgendaReportLink {
@@ -18,6 +20,13 @@ export interface AgendaReportLink {
   label: string
   /** 이미 쓴 보고서가 있는지. '보고서 미작성' 표시가 이 값을 봅니다. */
   written: boolean
+  /**
+   * 아직 보고서가 없는데 내가 쓸 수 있는 일정도 아닌 경우입니다. 갈 곳이 없습니다.
+   *
+   * null 로 두면 부르는 쪽이 아직 답을 못 받은 것과 구분하지 못해 로딩 표시가
+   * 영영 남습니다. 확인이 끝났다는 것과 갈 곳이 없다는 것을 함께 말합니다.
+   */
+  blocked?: true
 }
 
 /**
@@ -29,8 +38,12 @@ export function useAgendaReportLink(item: AgendaItem | null) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [reloadKey, setReloadKey] = useState(0)
+  const { memberId, isManager } = useCurrentUser()
   // item 은 렌더마다 새 객체일 수 있어 보는 값만 꺼내 둡니다.
   const id = item?.id
+  const ownerMemberId = item?.ownerMemberId
+  // 이미 쓴 보고서는 팀장도 엽니다. 조회이기 때문입니다. 막는 것은 '작성' 뿐입니다.
+  const canWrite = item === null || isOwnAgendaItem({ ownerMemberId }, memberId, isManager)
 
   useEffect(() => {
     setLink(null)
@@ -46,7 +59,9 @@ export function useAgendaReportLink(item: AgendaItem | null) {
         setLink(
           row
             ? { to: meetingReportPath(row.id), label: '업무보고서 열기', written: true }
-            : { to: meetingComposePath(id), label: '업무보고서 작성', written: false },
+            : canWrite
+              ? { to: meetingComposePath(id), label: '업무보고서 작성', written: false }
+              : { to: '', label: '', written: false, blocked: true },
         )
       })
       .catch((reason: unknown) => {
@@ -58,7 +73,7 @@ export function useAgendaReportLink(item: AgendaItem | null) {
         if (!controller.signal.aborted) setLoading(false)
       })
     return () => controller.abort()
-  }, [id, reloadKey])
+  }, [id, canWrite, reloadKey])
 
   const reload = useCallback(() => setReloadKey((value) => value + 1), [])
   return { link, loading, error, reload }

--- a/frontend/src/shared/scope.ts
+++ b/frontend/src/shared/scope.ts
@@ -43,6 +43,7 @@ let isManager = false
 // 돌려받아야 하므로 getSnapshot 안에서 새 배열을 만들면 안 됩니다.
 let ownerIds: readonly string[] | undefined
 let scopeKey = 'all'
+let ownerVisible = false
 
 const listeners = new Set<Listener>()
 
@@ -66,6 +67,18 @@ function computeOwnerIds(): readonly string[] | undefined {
 function computeScopeKey(): string {
   if (!isManager || ownMemberId === null) return 'all'
   return scope.mode === 'all' ? 'all' : `users:${scope.memberIds.join(',')}`
+}
+
+/**
+ * 줄마다 담당자 이름을 세울지입니다. 지금 화면에 여러 사람이 섞일 수 있을 때만 참입니다.
+ *
+ * 한 사람만 골라 두면 모든 줄이 같은 이름이라 자리만 차지합니다. 누구를 보고 있는지는
+ * 이미 Topbar 스위처가 이름으로 말하고 있어 줄마다 되풀이할 까닭이 없습니다.
+ * 팀원은 남의 줄을 받지 않으므로 언제나 거짓입니다.
+ */
+function computeOwnerVisible(): boolean {
+  if (!isManager || ownMemberId === null) return false
+  return scope.mode === 'all' || scope.memberIds.length > 1
 }
 
 function persist() {
@@ -100,6 +113,7 @@ function commit(next: Scope, { save = true } = {}) {
   scope = next
   ownerIds = computeOwnerIds()
   scopeKey = computeScopeKey()
+  ownerVisible = computeOwnerVisible()
   if (save) persist()
   for (const listener of listeners) listener()
 }
@@ -144,6 +158,10 @@ export function getScopeKey(): string {
   return scopeKey
 }
 
+export function getOwnerVisible(): boolean {
+  return ownerVisible
+}
+
 export function getOwnMemberIds(): readonly string[] | undefined {
   return isManager && ownMemberId !== null ? [ownMemberId] : undefined
 }
@@ -184,6 +202,16 @@ export function useScope(): Scope {
 /** 목록을 부르는 모든 훅이 쓰는 하나뿐인 입구입니다. */
 export function useScopeOwnerIds(): readonly string[] | undefined {
   return useSyncExternalStore(subscribeScope, getScopeOwnerIds, getScopeOwnerIds)
+}
+
+/**
+ * 목록·카드·드로어가 담당자 이름을 세울지 묻는 하나뿐인 자리입니다.
+ *
+ * 화면마다 `isManager` 로 판단하면 팀장이 한 명만 골라 둔 동안에도 같은 이름이
+ * 줄마다 되풀이됩니다. 역할이 아니라 지금 보는 범위가 정합니다.
+ */
+export function useShowOwner(): boolean {
+  return useSyncExternalStore(subscribeScope, getOwnerVisible, getOwnerVisible)
 }
 
 /**

--- a/frontend/src/shared/scope.ts
+++ b/frontend/src/shared/scope.ts
@@ -176,10 +176,24 @@ export function setScopeAll() {
  * 어떤 집합이 되어야 하는지는 팀 명부를 아는 화면이 정합니다. 스토어는 명부를 들고
  * 있지 않아서 '팀 전체에서 한 명만 빼기' 같은 계산을 여기서 할 수 없습니다.
  * 빈 목록은 보여 줄 것이 없다는 뜻이라 팀 전체로 되돌립니다.
+ *
+ * 같은 선택이면 조용히 돌아섭니다. 커밋 한 번이 화면 전체를 다시 그리고 다시 요청하게
+ * 하므로(AppShell 의 Outlet key), 고른 것이 그대로인데 커밋하면 헛일이 큽니다.
  */
 export function setScopeMembers(memberIds: readonly string[]) {
   const next = [...new Set(memberIds)]
-  commit(next.length === 0 ? ALL : { mode: 'users', memberIds: next })
+  if (next.length === 0) {
+    setScopeAll()
+    return
+  }
+  if (
+    scope.mode === 'users' &&
+    scope.memberIds.length === next.length &&
+    next.every((id, index) => scope.memberIds[index] === id)
+  ) {
+    return
+  }
+  commit({ mode: 'users', memberIds: next })
 }
 
 /**

--- a/frontend/src/types/meetings.ts
+++ b/frontend/src/types/meetings.ts
@@ -74,5 +74,7 @@ export interface MeetingReportSeed {
 export interface MeetingReport extends MeetingReportSeed {
   /** YYYY-MM-DD */
   date: string
+  /** 작성자의 구성원 번호. 고칠 수 있는 사람인지 이 값으로 가립니다. */
+  ownerMemberId: string
   template: ReportTemplate
 }

--- a/frontend/src/types/reports.ts
+++ b/frontend/src/types/reports.ts
@@ -94,6 +94,8 @@ export interface DailyReportSeed {
 export interface DailyReport extends DailyReportSeed {
   /** YYYY-MM-DD */
   date: string
+  /** 작성자의 구성원 번호. 고칠 수 있는 사람인지 이 값으로 가립니다. */
+  ownerMemberId: string
   template: ReportTemplate
 }
 


### PR DESCRIPTION
## 변경 요약

담당자 표시 · 보고서 권한 · 보기 범위 스위처 UX 세 갈래입니다. 모두 "지금 누구의 것을 보고 있는가" 라는 한 축 위에 있습니다.

**담당자 표시 — 역할이 아니라 보기 범위로 정함**

- `useShowOwner()` 를 두어 담당자 칸을 세울지 한 곳에서 정합니다. 화면마다 `isManager` 로 판단하면 팀장이 한 명만 골라 둔 동안에도 같은 이름이 줄마다 되풀이됩니다. 지금 화면에 여러 사람이 섞일 수 있을 때만 세웁니다.
- `OwnerName` 컴포넌트를 두고, 대시보드 일정 줄과 여러 사람이 섞여 보이는 나머지 화면에 담당 영업을 세웁니다.
- 고객 쪽 연락처에 잘못 붙어 있던 '담당자' 라벨을 바로잡습니다.

**보고서 권한 — 쓴 사람만**

- 보고서를 일정 담당자 본인만 쓰게 막고, 수정·제출·삭제도 쓴 사람만 하게 막습니다. 백엔드가 막습니다.
- 남의 일정에는 보고서 작성 진입점을 세우지 않습니다. 막힌 문을 보여 주지 않기 위해서입니다.

**보기 범위 스위처 — 고르는 동안 다시 받지 않음**

- '팀 전체' 에서 한 사람만 보려면 나머지를 하나씩 다 꺼야 했고, 끌 때마다 화면 전체가 다시 요청했습니다. 체크 한 번이 곧바로 스토어를 커밋했고 `AppShell` 의 `<Outlet key={scopeKey}>` 가 페이지를 통째로 재마운트했기 때문입니다. 네 명을 끄면 목록·대시보드·아젠다가 네 번 다시 받았습니다.
- 열려 있는 동안의 선택을 초안으로만 들고 닫을 때 한 번만 넘깁니다. 고르는 사이 요청은 나가지 않습니다.
- '팀 전체' 가 켜져 있을 때 다시 누르면 전부 풀고 '내 현황' 만 남깁니다. 좁히는 길을 한 번으로 줄입니다.
- `setScopeMembers` 에 같은 선택이면 커밋하지 않는 가드를 넣었습니다. 드롭다운을 열었다 아무것도 고치지 않고 닫아도 화면이 다시 받던 것을 막습니다.

**일정 로딩 표시**

- 대시보드 하루 일정 카드가 응답을 기다리는 동안 '일정 없음' 을 그렸습니다. 일정이 있는 날에도 없다는 문구가 한 번 스쳤습니다. 받아 오는 동안은 `InlineLoader` 를 세웁니다.

**타입 정리**

- 담당자 필드를 더하면서 쓰는 쪽을 함께 고치지 않아 `tsc` 가 3건에서 멈춰 있었습니다. `npm run build` 가 `tsc -b` 로 시작하므로 CI 와 배포가 막히던 것을 풀었습니다. 화면 동작에 영향이 있던 것은 없습니다.
  - `OrderDrawer` 의 `order` prop 을 `PurchaseOrder` → `ApiPurchaseOrder` 로 넓힘. 담당 영업 줄이 읽는 `owner` 는 API 형에만 있고, 부르는 곳(`Orders`)은 이미 `ApiPurchaseOrder` 를 넘기고 있었습니다.
  - `mocks/reports.ts` · `mocks/meetings.ts` 가 seed 를 펼 때 `ownerMemberId` 를 채우게 함.

## 검증

**통과**

- `npm run build` (`tsc -b` + `vite build`) — 통과
- `npm run typecheck` — 통과
- `npm run lint` (oxlint) — 통과
- `npm run format:check` — 통과
- `cd backend && uv run ruff check .` — 통과

**실패 — 이 브랜치와 무관해 보이는 것**

- `cd backend && uv run pytest` — **364 통과, 1 실패.** `test_models.py::test_models_match_configured_database` 가 `document_file_audit` · `contract_next_meeting_suggestion` · `document_chunk` 테이블이 로컬 DB 에 없다며 실패합니다. 이 브랜치는 모델을 건드리지 않았고 로컬 DB 스키마가 뒤처진 것으로 보입니다. develop 에서 재현되는지는 확인하지 않았습니다.

**미실행**

- 브라우저 수동 확인. 스위처를 열어 여러 명을 고르는 동안 요청이 실제로 0건인지, 닫을 때 1파만 나가는지는 아직 눈으로 보지 않았습니다.

## 영향 및 주의 사항

- 보기 범위가 바뀌는 시점이 "체크할 때" 에서 "드롭다운을 닫을 때" 로 옮겨졌습니다. 스위처를 열어 둔 채로는 뒤 화면이 바뀌지 않습니다. 취소 버튼은 두지 않았고, 닫는 네 길(바깥 클릭·Escape·Tab·트리거 재클릭) 모두 고른 것을 반영합니다.
- 보고서 권한은 백엔드가 막습니다. 프런트의 진입점 감춤은 안내일 뿐 권한이 아닙니다.
- `mocks/` 의 구성원 번호는 시연용 합성 값이라 실제 계정과 이어지지 않습니다. 이 두 파일은 현재 어디서도 import 하지 않습니다.
- DB 마이그레이션·환경 변수 등 수동 작업은 없습니다.