### PR TITLE
서버 기동 시 중단된 에이전트 실행을 failed 로 회수

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,6 @@
+import logging
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI, Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
@@ -6,11 +9,30 @@ from fastapi.responses import JSONResponse
 
 from app.api import api_router
 from app.core.config import settings
+from app.services import agent_runs as agent_run_service
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    """이전 프로세스가 남긴 실행 이력을 정리한 뒤 요청을 받는다."""
+    try:
+        recovered = await agent_run_service.recover_interrupted_runs()
+    except Exception:
+        # 정리는 뒷정리일 뿐이라, 실패해도 서버 기동 자체를 막지 않는다.
+        logger.exception("중단된 실행 이력 회수 실패")
+    else:
+        if recovered:
+            logger.info("중단된 실행 이력 %d 건을 failed 로 회수했습니다.", recovered)
+    yield
+
 
 app = FastAPI(
     title="SalesLuv API",
     description="고객·딜·일정·미팅 기록을 연결하는 다중 에이전트 기반 영업 업무 자동화 API",
     version="0.1.0",
+    lifespan=lifespan,
 )
 
 app.add_middleware(

--- a/backend/app/services/agent_runs.py
+++ b/backend/app/services/agent_runs.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
@@ -22,6 +22,11 @@ _SEOUL = ZoneInfo("Asia/Seoul")
 
 # 프로세스가 사라져 결과를 기록하지 못한 실행에 남기는 사유.
 INTERRUPTED_ERROR = "interrupted_by_restart"
+
+# 이 시간이 지나도 running 인 실행은 결과를 쓸 주체가 사라진 것으로 본다.
+# 무중단 배포는 새 컨테이너를 띄운 뒤 헬스체크(최대 60초)와 드레인(10초)을 거쳐야
+# 옛 컨테이너를 내린다. 그동안 옛 컨테이너가 돌리는 실행을 끊지 않도록 넉넉히 잡는다.
+RECOVERY_GRACE = timedelta(minutes=10)
 
 
 def _seoul(value: datetime | None) -> datetime | None:
@@ -269,24 +274,35 @@ async def create(
 
 
 async def recover_interrupted_runs() -> int:
-    """서버가 뜰 때, 이전 프로세스가 남긴 queued/running 실행을 failed 로 회수한다.
+    """서버가 뜰 때, 이전 프로세스가 남긴 running 실행을 failed 로 회수한다.
 
     실행은 BackgroundTasks 로 이 프로세스 안에서만 돈다. 프로세스가 사라지면 결과를 기록할
-    주체도 함께 사라져서 행이 queued/running 인 채로 남는다. 도는 것은 없는데 화면에는
-    계속 "실행 중"으로 보이므로, 뜨는 시점에 정리하고 요청을 받는다.
+    주체도 함께 사라져서 행이 running 인 채로 남는다. 도는 것은 없는데 화면에는 계속
+    "실행 중"으로 보이므로, 뜨는 시점에 정리하고 요청을 받는다.
 
-    ponytail: execute() 와 같은 단일 프로세스 전제. 다중 worker 에서는 다른 worker 가
-    처리 중인 실행까지 끊으므로, heartbeat 나 소유 worker 식별로 대상을 좁혀야 한다.
+    회수 대상은 started_at 이 RECOVERY_GRACE 보다 오래된 행뿐이다. 무중단 배포는 새
+    컨테이너를 띄운 채 옛 컨테이너로 트래픽을 계속 보내므로, 기동 시점에 남의 실행이
+    돌고 있을 수 있다. 방금 시작한 실행까지 끊으면 살아 있는 작업을 죽인다.
+
+    ponytail: queued 는 대상이 아니다. agent_run 에 생성 시각이 없어 나이를 못 재는데,
+    회수했다가 틀리면 execute() 가 선점 실패로 보고 그냥 반환해 요청이 유실된다. API 도
+    파이프라인도 커밋 직후 execute() 를 부르므로 queued 로 머무는 구간은 1초 미만이라
+    고아 행 자체가 드물다. 확실히 덮으려면 created_at 컬럼이 필요하다.
     """
+    now = datetime.now(UTC)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
         result = await session.execute(
             update(AgentRun)
-            .where(AgentRun.status_code.in_(("queued", "running")))
+            .where(
+                AgentRun.status_code == "running",
+                AgentRun.started_at.is_not(None),
+                AgentRun.started_at < now - RECOVERY_GRACE,
+            )
             .values(
                 status_code="failed",
                 error_message=INTERRUPTED_ERROR,
-                finished_at=datetime.now(UTC),
+                finished_at=now,
             )
         )
         await session.commit()
@@ -359,6 +375,9 @@ async def execute(run_id: UUID) -> None:
         else:
             run.status_code = "completed"
             run.output_snapshot = output.model_dump()
+            # 회수가 이 실행을 failed 로 앞질렀어도 결과는 여기서 확정된다.
+            # 사유를 지우지 않으면 completed 행에 회수 흔적이 남는다.
+            run.error_message = None
             if run.agent_code == "report_writing":
                 # 제안일 뿐이다. 사람이 확인해 보고서에 반영하기 전에는 report 를 고치지 않는다.
                 run.evidence = {

--- a/backend/app/services/agent_runs.py
+++ b/backend/app/services/agent_runs.py
@@ -4,7 +4,7 @@ from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
 from fastapi import HTTPException, status
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agents import contract_management, meeting_analysis, report_writing, schedule_management
@@ -19,6 +19,9 @@ from app.services import contract_schedule_snapshots
 from app.services.llm import LLMError
 
 _SEOUL = ZoneInfo("Asia/Seoul")
+
+# 프로세스가 사라져 결과를 기록하지 못한 실행에 남기는 사유.
+INTERRUPTED_ERROR = "interrupted_by_restart"
 
 
 def _seoul(value: datetime | None) -> datetime | None:
@@ -263,6 +266,31 @@ async def create(
         raise
 
     return read, run.id
+
+
+async def recover_interrupted_runs() -> int:
+    """서버가 뜰 때, 이전 프로세스가 남긴 queued/running 실행을 failed 로 회수한다.
+
+    실행은 BackgroundTasks 로 이 프로세스 안에서만 돈다. 프로세스가 사라지면 결과를 기록할
+    주체도 함께 사라져서 행이 queued/running 인 채로 남는다. 도는 것은 없는데 화면에는
+    계속 "실행 중"으로 보이므로, 뜨는 시점에 정리하고 요청을 받는다.
+
+    ponytail: execute() 와 같은 단일 프로세스 전제. 다중 worker 에서는 다른 worker 가
+    처리 중인 실행까지 끊으므로, heartbeat 나 소유 worker 식별로 대상을 좁혀야 한다.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            update(AgentRun)
+            .where(AgentRun.status_code.in_(("queued", "running")))
+            .values(
+                status_code="failed",
+                error_message=INTERRUPTED_ERROR,
+                finished_at=datetime.now(UTC),
+            )
+        )
+        await session.commit()
+    return result.rowcount
 
 
 async def execute(run_id: UUID) -> None:

--- a/backend/tests/test_agent_runs.py
+++ b/backend/tests/test_agent_runs.py
@@ -14,7 +14,7 @@ from app.api import agent_runs
 from app.api.deps import get_current_member
 from app.core.config import settings
 from app.db.session import get_db
-from app.main import app
+from app.main import app, lifespan
 from app.ml.deal_baseline import DealModelError
 from app.models.agent import AgentRun
 from app.models.content import Report
@@ -40,8 +40,9 @@ class _Secret:
 
 
 class _Result:
-    def __init__(self, *, scalar=_MISSING):
+    def __init__(self, *, scalar=_MISSING, rowcount=0):
         self.scalar = scalar
+        self.rowcount = rowcount
 
     def scalar_one(self):
         assert self.scalar is not _MISSING
@@ -327,6 +328,52 @@ def test_meeting_analysis_requires_transcript(llm_ready):
 
     assert response.status_code == 422
     assert response.json() == {"detail": "transcript_required"}
+
+
+@pytest.mark.anyio
+async def test_recover_interrupted_runs_fails_orphaned_rows(monkeypatch):
+    """프로세스가 사라져 남은 queued/running 행을 기동 시 failed 로 회수한다."""
+    db = _Db(_Result(rowcount=2))
+    monkeypatch.setattr(
+        agent_run_service,
+        "get_sessionmaker",
+        lambda: lambda: _SessionContext(db),
+    )
+
+    recovered = await agent_run_service.recover_interrupted_runs()
+
+    assert recovered == 2
+    assert db.commit_count == 1
+    statement = str(db.statements[0].compile(compile_kwargs={"literal_binds": True}))
+    assert "UPDATE public.agent_run" in statement
+    assert "status_code IN ('queued', 'running')" in statement
+    assert agent_run_service.INTERRUPTED_ERROR in statement
+
+
+@pytest.mark.anyio
+async def test_recover_interrupted_runs_leaves_settled_rows_alone(monkeypatch):
+    """이미 completed/failed 로 끝난 행은 회수 대상이 아니다."""
+    db = _Db(_Result(rowcount=0))
+    monkeypatch.setattr(
+        agent_run_service,
+        "get_sessionmaker",
+        lambda: lambda: _SessionContext(db),
+    )
+
+    assert await agent_run_service.recover_interrupted_runs() == 0
+
+
+@pytest.mark.anyio
+async def test_startup_recovery_failure_does_not_block_boot(monkeypatch):
+    """회수가 실패해도 서버는 떠야 한다. 뒷정리가 기동을 막지 않는다."""
+
+    async def boom():
+        raise RuntimeError("db unreachable")
+
+    monkeypatch.setattr(agent_run_service, "recover_interrupted_runs", boom)
+
+    async with lifespan(app):
+        pass
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_agent_runs.py
+++ b/backend/tests/test_agent_runs.py
@@ -40,15 +40,20 @@ class _Secret:
 
 
 class _Result:
+    """SQLAlchemy Result 대체. 조회 결과와 UPDATE 영향 행 수를 함께 흉내 낸다."""
+
     def __init__(self, *, scalar=_MISSING, rowcount=0):
+        """조회로 돌려줄 값과 UPDATE 가 바꾼 행 수를 받는다."""
         self.scalar = scalar
         self.rowcount = rowcount
 
     def scalar_one(self):
+        """단일 행을 돌려준다. 준비된 값이 없으면 테스트를 실패시킨다."""
         assert self.scalar is not _MISSING
         return self.scalar
 
     def scalar_one_or_none(self):
+        """단일 행 또는 None 을 돌려준다. 준비된 값이 없으면 테스트를 실패시킨다."""
         assert self.scalar is not _MISSING
         return self.scalar
 
@@ -330,15 +335,20 @@ def test_meeting_analysis_requires_transcript(llm_ready):
     assert response.json() == {"detail": "transcript_required"}
 
 
-@pytest.mark.anyio
-async def test_recover_interrupted_runs_fails_orphaned_rows(monkeypatch):
-    """프로세스가 사라져 남은 queued/running 행을 기동 시 failed 로 회수한다."""
-    db = _Db(_Result(rowcount=2))
+def _patch_sessionmaker(monkeypatch, db: _Db) -> None:
+    """서비스가 자체 세션을 열 때 가짜 세션을 쓰게 한다."""
     monkeypatch.setattr(
         agent_run_service,
         "get_sessionmaker",
         lambda: lambda: _SessionContext(db),
     )
+
+
+@pytest.mark.anyio
+async def test_recover_interrupted_runs_fails_orphaned_rows(monkeypatch):
+    """프로세스가 사라져 남은 running 행을 기동 시 failed 로 회수한다."""
+    db = _Db(_Result(rowcount=2))
+    _patch_sessionmaker(monkeypatch, db)
 
     recovered = await agent_run_service.recover_interrupted_runs()
 
@@ -346,19 +356,52 @@ async def test_recover_interrupted_runs_fails_orphaned_rows(monkeypatch):
     assert db.commit_count == 1
     statement = str(db.statements[0].compile(compile_kwargs={"literal_binds": True}))
     assert "UPDATE public.agent_run" in statement
-    assert "status_code IN ('queued', 'running')" in statement
+    assert "status_code = 'running'" in statement
     assert agent_run_service.INTERRUPTED_ERROR in statement
+
+
+@pytest.mark.anyio
+async def test_recover_interrupted_runs_spares_freshly_started_runs(monkeypatch):
+    """무중단 배포로 컨테이너가 겹치는 동안 옛 컨테이너가 돌리는 실행은 건드리지 않는다.
+
+    새 컨테이너가 기동하면서 방금 시작된 running 행까지 failed 로 바꾸면, 살아 있는
+    작업을 죽이고 사용자 화면에는 실패로 남는다. started_at 기준 유예가 이를 막는다.
+    """
+    db = _Db(_Result(rowcount=0))
+    _patch_sessionmaker(monkeypatch, db)
+
+    await agent_run_service.recover_interrupted_runs()
+
+    params = db.statements[0].compile().params
+    moments = sorted(value for value in params.values() if isinstance(value, datetime))
+    # 회수 시각(finished_at)과 기준 시각(cutoff) 두 개가 들어간다.
+    assert len(moments) == 2
+    cutoff, finished_at = moments
+    # 기준 시각은 딱 유예만큼 과거다. 방금 시작한 실행은 이 조건에 걸리지 않는다.
+    assert finished_at - cutoff == agent_run_service.RECOVERY_GRACE
+
+
+@pytest.mark.anyio
+async def test_recover_interrupted_runs_leaves_queued_rows_alone(monkeypatch):
+    """queued 는 회수하지 않는다. 선점을 앞지르면 실행이 통째로 유실된다.
+
+    execute() 는 queued 인 행만 running 으로 바꾼다. 회수가 먼저 failed 로 바꿔버리면
+    옛 컨테이너의 백그라운드 작업이 그대로 반환해 요청이 사라진다.
+    """
+    db = _Db(_Result(rowcount=0))
+    _patch_sessionmaker(monkeypatch, db)
+
+    await agent_run_service.recover_interrupted_runs()
+
+    statement = str(db.statements[0].compile(compile_kwargs={"literal_binds": True}))
+    assert "queued" not in statement
 
 
 @pytest.mark.anyio
 async def test_recover_interrupted_runs_leaves_settled_rows_alone(monkeypatch):
     """이미 completed/failed 로 끝난 행은 회수 대상이 아니다."""
     db = _Db(_Result(rowcount=0))
-    monkeypatch.setattr(
-        agent_run_service,
-        "get_sessionmaker",
-        lambda: lambda: _SessionContext(db),
-    )
+    _patch_sessionmaker(monkeypatch, db)
 
     assert await agent_run_service.recover_interrupted_runs() == 0
 
@@ -368,6 +411,7 @@ async def test_startup_recovery_failure_does_not_block_boot(monkeypatch):
     """회수가 실패해도 서버는 떠야 한다. 뒷정리가 기동을 막지 않는다."""
 
     async def boom():
+        """회수가 DB 에 닿지 못하는 상황을 만든다."""
         raise RuntimeError("db unreachable")
 
     monkeypatch.setattr(agent_run_service, "recover_interrupted_runs", boom)
@@ -421,6 +465,49 @@ async def test_execute_dispatches_meeting_analysis_and_saves_result(monkeypatch)
     }
     assert first.commit_count == 1
     assert second.commit_count == 1
+
+
+@pytest.mark.anyio
+async def test_execute_clears_recovery_error_on_success(monkeypatch):
+    """회수가 앞질러 failed 로 바꿔놨어도 성공한 실행에 회수 사유를 남기지 않는다."""
+    member = _member()
+    run = _run(member)
+    run.agent_code = "meeting_analysis"
+    run.input_snapshot = {"transcript": "고객이 다음 달 예산 승인을 검토합니다."}
+    first = _Db(_Result(scalar=run))
+    second = _Db(_Result(scalar=run))
+    sessions = iter((first, second))
+    monkeypatch.setattr(
+        agent_run_service,
+        "get_sessionmaker",
+        lambda: lambda: _SessionContext(next(sessions)),
+    )
+
+    async def fake_run(snapshot):
+        """미팅 분석 결과를 고정해 결과 기록 단계만 본다."""
+        return SimpleNamespace(
+            deal_assessment=SimpleNamespace(model_version="test-deal-model-v1"),
+            model_dump=dict,
+        )
+
+    monkeypatch.setattr(meeting_analysis, "run", fake_run)
+
+    # LLM 을 부르는 동안 다른 컨테이너가 기동해 이 행을 회수해 간 상황을 만든다.
+    # 결과 기록 단계에서 행을 다시 읽는 시점이 회수 직후가 된다.
+    original_execute = second.execute
+
+    async def execute_after_recovery(statement):
+        """결과를 다시 읽기 직전에 회수가 끼어든 상태로 만든다."""
+        run.status_code = "failed"
+        run.error_message = agent_run_service.INTERRUPTED_ERROR
+        return await original_execute(statement)
+
+    second.execute = execute_after_recovery
+
+    await agent_run_service.execute(run.id)
+
+    assert run.status_code == "completed"
+    assert run.error_message is None
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## 변경 요약

에이전트 실행(`agent_runs.execute()`)은 `BackgroundTasks` 로 API 서버와 **같은 프로세스**에서
돕니다. `running` 을 커밋한 뒤 LLM 을 호출하고, 돌아와서 `completed` / `failed` 를 씁니다.
2단계 도중 프로세스가 사라지면 3단계를 실행할 주체도 함께 사라져, `agent_run` 행이
`queued` / `running` 인 채로 남습니다. 기동 시 이를 회수하는 코드가 없어 이 상태가
영구히 유지됐습니다.

- `recover_interrupted_runs()` 추가 — `started_at` 이 10분(`RECOVERY_GRACE`)보다 오래된
  `running` 행을 `failed` 로 바꾸고 `error_message = "interrupted_by_restart"`,
  `finished_at` 을 채웁니다. 단일 UPDATE 라 행 수와 무관하게 쿼리 한 번입니다.
- `main.py` 에 `lifespan` 추가 — 요청을 받기 전에 한 번 돌립니다. 회수가 실패해도
  기동 자체는 막지 않습니다.

무중단 배포는 새 컨테이너를 띄운 뒤 헬스체크와 드레인을 거쳐야 옛 컨테이너를 내립니다.
그동안 옛 컨테이너가 돌리는 실행이 있으므로 10분 유예를 둡니다. LLM 호출 상한이 300초라
정상 실행은 이 조건에 걸리지 않습니다.

`queued` 는 회수하지 않습니다. `execute()` 가 `queued` 인 행만 선점해서, 회수가 앞지르면
요청이 통째로 유실됩니다.

## 검증

- `pytest` — 411건 통과. 신규 6건(회수 동작 / 종료된 행 미대상 / 회수 실패 시 기동 유지 /
  유예 적용 / `queued` 미포함 / 회수 이후 성공 기록).
- 남은 실패 2건(`test_models.py`)과 에러 1건(`test_deal_baseline.py`)은 **`develop` 에서도
  동일하게 발생**합니다. 같은 커밋을 stash 하고 재실행해 이 변경과 무관함을 확인했습니다.
- `ruff check` / `ruff format --check` 통과.
- 실제 서버를 재기동해 운영 DB 에서 회수되는 것까지는 확인하지 않았습니다.

## 영향 및 주의 사항

- **스키마 변경 없음.** 마이그레이션 불필요합니다.
- 표시 문제로 보이지만 실질적인 영향이 하나 더 있습니다.
  `contract_next_meeting_pipeline._ran_recently()` 는 `queued` / `running` 행을 발견하면
  **시각과 무관하게** 중복 실행으로 보고 차단합니다(쿨다운과 달리 시간이 지나도 안 풀립니다).
  `contract_management_next_meeting` 실행이 이렇게 끊기면 해당 딜은 이후 제안을 받지
  못합니다. `running` 으로 막힌 경우는 이 PR 이 기동 시 풀어줍니다.
- **10분 유예가 있어 배포 중 컨테이너가 겹쳐도 안전합니다.** 옛 컨테이너가 방금 시작한
  실행은 회수 대상이 아닙니다. worker 를 늘려도 같은 근거로 동작합니다. 다만 실행이 정말
  10분 넘게 살아 있을 수 있는 구조로 바뀌면(재시도 도입, LLM 타임아웃 상향) 유예도 함께
  올려야 합니다.
- 제보된 `d2b988ce-2d30-4d38-9b0c-bab2b627348a` 행은 상태에 따라 갈립니다. `running` 이면
  이 PR 병합 후 서버가 다음에 뜰 때 자동으로 `failed` 처리됩니다. `queued` 면 회수 대상이
  아니라 수동 정리가 필요합니다.

## 관련 이슈

- #96


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 서버 재시작 후 10분 이상 실행 중인 작업만 자동으로 실패 처리됩니다.
  * 새로 시작된 실행과 대기 중인 실행은 복구 대상에서 제외됩니다.
  * 복구된 실행이 정상 완료되면 실패 표시가 자동으로 정리됩니다.
  * 실행 복구 중 오류가 발생해도 서버가 정상적으로 시작됩니다.

* **테스트**
  * 실행 복구 기준과 정상 완료 시 상태 정리에 대한 테스트를 보강했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
