### PR TITLE
미팅 보고서 초안 저장 오류 수정

### DIFF
--- a/backend/app/models/content.py
+++ b/backend/app/models/content.py
@@ -48,7 +48,9 @@ class ReportDeal(Base):
     )
     deal_snapshot: Mapped[Any] = mapped_column(JSONB, nullable=False)
     content: Mapped[Any] = mapped_column(JSONB, nullable=False)
-    ai_evidence: Mapped[Any] = mapped_column(JSONB, nullable=True)
+    # DB CHECK 는 SQL NULL 또는 JSON object 만 허용한다. 기본 JSONB 는 Python None 을
+    # JSON null 로 직렬화하므로 none_as_null 을 켜야 초안 딜을 저장할 수 있다.
+    ai_evidence: Mapped[Any] = mapped_column(JSONB(none_as_null=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(server_default=text("now()"))
     updated_at: Mapped[datetime] = mapped_column(server_default=text("now()"))
 

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -4,12 +4,14 @@ from pathlib import Path
 
 import pytest
 from sqlalchemy import inspect, text
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm import configure_mappers
 
 from app.core.config import settings
 from app.db.base import Base
 from app.models.agent import AgentRun
+from app.models.content import ReportDeal
 
 EXPECTED_COLUMN_COUNTS = {
     # 20260823_0002 로 team 에 company_name/department/business_no, member 에 email 이 늘었다.
@@ -91,6 +93,17 @@ KNOWN_LEGACY_DATABASE_COLUMNS = {
     "report": {"sales_deal_id"},
     "sales_deal": {"source_code"},
 }
+
+
+def test_report_deal_none_ai_evidence_binds_as_sql_null():
+    """초안의 None 은 DB CHECK 를 깨는 JSON null 이 아니라 SQL NULL 이어야 한다."""
+    column_type = ReportDeal.__table__.c.ai_evidence.type
+    bind = column_type.bind_processor(postgresql.dialect())
+
+    assert bind is not None
+    assert bind(None) is None
+
+
 KNOWN_LEGACY_DATABASE_FOREIGN_KEYS = {
     "document": {("product_id", "public", "product", "id", None)},
     "report": {("sales_deal_id", "public", "sales_deal", "id", None)},


### PR DESCRIPTION
## 변경 요약

- `ai_evidence=None`을 JSON `null`이 아닌 SQL `NULL`로 저장
- 미팅 보고서 생성 전 초안 저장의 DB CHECK 오류 수정
- PostgreSQL 바인딩 회귀 테스트 추가

## 검증

- 백엔드 테스트: 871 passed, 8 skipped
- Ruff 통과
- 동일 일정·딜 입력으로 실제 DB flush 성공 후 rollback 확인

## 영향 및 주의 사항

- 백엔드만 변경
- DB 마이그레이션 없음
- 병합 후 백엔드만 배포

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 초안 딜 저장 시 증거 정보가 올바른 SQL `NULL`로 저장되도록 개선했습니다.
  * 데이터베이스 제약조건 위반으로 저장에 실패하던 문제를 해결했습니다.

* **테스트**
  * 증거 정보가 없는 경우에도 올바르게 저장되는 동작을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->