### PR TITLE
feat: 고객을 고치고 지우는 길과 사업자등록증 등록을 연다

### DIFF
--- a/backend/app/api/activities.py
+++ b/backend/app/api/activities.py
@@ -256,6 +256,8 @@ async def _contact_info(
 ) -> tuple[CustomerContact, UUID, str]:
     conditions = [
         CustomerContact.id == contact_id,
+        # 지운 고객은 새 일정의 대상으로 고를 수 없다. 이미 걸려 있던 일정은 그대로 둔다.
+        CustomerContact.deleted_at.is_(None),
         CustomerCompany.team_id == member.team_id,
         Member.team_id == member.team_id,
         Member.active.is_(True),

--- a/backend/app/api/business_cards.py
+++ b/backend/app/api/business_cards.py
@@ -159,6 +159,8 @@ async def archive_business_card(
             .join(CustomerCompany, CustomerContact.company_id == CustomerCompany.id)
             .where(
                 CustomerContact.id == contact_id,
+                # 지운 고객에는 명함 원본을 새로 보관하지 않는다.
+                CustomerContact.deleted_at.is_(None),
                 CustomerCompany.team_id == member.team_id,
             )
         )

--- a/backend/app/api/customers.py
+++ b/backend/app/api/customers.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from typing import Annotated
 from uuid import UUID, uuid4
 
@@ -81,6 +82,8 @@ def _assigned_to(member_ids: tuple[UUID, ...]):
 
 def _contact_scope(member: Member, owner_ids: tuple[UUID, ...] | None = None):
     conditions = [
+        # 지운 고객은 목록에도 상세에도 나오지 않는다. 수정·삭제도 여기서 404 가 된다.
+        CustomerContact.deleted_at.is_(None),
         CustomerCompany.team_id == member.team_id,
         Member.team_id == member.team_id,
         Member.active.is_(True),
@@ -601,3 +604,39 @@ async def update_customer_contact(
         created_by_display_name,
         assignees,
     )
+
+
+@router.delete("/customer-contacts/{contact_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_customer_contact(
+    contact_id: UUID,
+    member: CurrentMember,
+    db: DbSession,
+) -> None:
+    """고객을 지운다. 팀장만 할 수 있다.
+
+    역할을 쿼리보다 먼저 본다. 그래야 팀원이 남의 팀 고객 id 를 넣어도 404 대신 403 을
+    받고, 그 id 가 있는지 없는지가 새지 않는다. update_customer_company 와 같은 순서다.
+
+    행은 남기고 deleted_at 만 채운다. activity, sales_deal, sales_deal_participant 가
+    이 고객을 참조하고 있어 실제 DELETE 는 외래키에 막히고, 참조를 먼저 끊으면 지난 딜과
+    일정에서 누구를 만났는지가 사라진다. 담당자 행도 그대로 둔다.
+    """
+    if member.role_code != "manager":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="manager_required",
+        )
+    result = await db.execute(
+        select(CustomerContact)
+        .join(CustomerCompany, CustomerContact.company_id == CustomerCompany.id)
+        .join(Member, CustomerContact.owner_member_id == Member.id)
+        .where(CustomerContact.id == contact_id, *_contact_scope(member))
+    )
+    contact = result.scalar_one_or_none()
+    if contact is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="customer_contact_not_found",
+        )
+    contact.deleted_at = datetime.now(UTC)
+    await _flush_and_commit(db)

--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -284,6 +284,8 @@ async def _validate_links(db: AsyncSession, member: Member, values: dict) -> Non
                 .join(CustomerCompany, CustomerContact.company_id == CustomerCompany.id)
                 .where(
                     CustomerContact.id == contact_id,
+                    # 지운 고객에는 자료를 새로 걸 수 없다.
+                    CustomerContact.deleted_at.is_(None),
                     CustomerCompany.team_id == member.team_id,
                 )
             )

--- a/backend/app/api/sales_deals.py
+++ b/backend/app/api/sales_deals.py
@@ -512,6 +512,8 @@ async def _team_contact(
         .join(Member, CustomerContact.owner_member_id == Member.id)
         .where(
             CustomerContact.id == customer_contact_id,
+            # 지운 고객은 딜의 담당자로 새로 세울 수 없다.
+            CustomerContact.deleted_at.is_(None),
             CustomerCompany.team_id == member.team_id,
             Member.team_id == member.team_id,
             Member.active.is_(True),
@@ -605,6 +607,8 @@ async def _team_participants(
         .join(CustomerCompany, CustomerContact.company_id == CustomerCompany.id)
         .where(
             CustomerContact.id.in_(unique_ids),
+            # 지운 고객은 미팅 대상자로 새로 넣을 수 없다.
+            CustomerContact.deleted_at.is_(None),
             CustomerContact.company_id == company_id,
             CustomerCompany.team_id == member.team_id,
         )

--- a/backend/app/models/crm.py
+++ b/backend/app/models/crm.py
@@ -46,6 +46,9 @@ class CustomerContact(Base):
     # 담당자가 직접 켜고 끄는 표시. 활동 기록에서 파생하지 않는다.
     visited: Mapped[bool] = mapped_column(server_default=text("false"))
     registered_at: Mapped[datetime] = mapped_column(server_default=text("now()"))
+    # 팀장이 지운 시각. 행은 남는다. 딜·일정이 이 고객을 참조하고 있어 지울 수 없고,
+    # 지난 기록에서 만난 사람의 이름이 사라져서도 안 된다.
+    deleted_at: Mapped[datetime | None]
 
 
 class CustomerContactAssignee(Base):

--- a/backend/app/services/business_cards.py
+++ b/backend/app/services/business_cards.py
@@ -110,7 +110,12 @@ async def find_matches(
     result = await db.execute(
         select(CustomerContact, CustomerCompany)
         .join(CustomerCompany, CustomerContact.company_id == CustomerCompany.id)
-        .where(CustomerCompany.team_id == member.team_id, or_(*conditions))
+        # 지운 고객은 중복 후보로 내놓지 않는다. 다시 등록하려는 참이다.
+        .where(
+            CustomerContact.deleted_at.is_(None),
+            CustomerCompany.team_id == member.team_id,
+            or_(*conditions),
+        )
         .limit(limit)
     )
     matches: list[dict[str, object]] = []

--- a/backend/sql/20260903_0021_customer_contact_soft_delete.sql
+++ b/backend/sql/20260903_0021_customer_contact_soft_delete.sql
@@ -1,0 +1,24 @@
+-- 고객을 지울 수 있게 한다. 지우는 건 팀장뿐이다.
+--
+-- 행을 실제로 지우면 안 된다. activity, sales_deal, sales_deal_participant 가 ON DELETE
+-- 옵션 없이 customer_contact 를 참조하므로 DELETE 는 외래키 오류로 막히고, 참조를 먼저
+-- 끊으면 딜과 일정에서 누구를 만난 기록인지가 조용히 사라진다.
+--
+-- sales_deal, purchase_order, report, notice 가 이미 쓰는 deleted_at 방식을 따른다.
+-- 고르는 자리(목록, 일정·딜의 고객 선택)는 deleted_at IS NULL 만 보고, 이미 연결된 것을
+-- 보여 주는 자리는 걸러내지 않아 지난 기록이 그대로 남는다.
+
+BEGIN;
+
+ALTER TABLE public.customer_contact
+    ADD COLUMN deleted_at timestamptz;
+
+COMMENT ON COLUMN public.customer_contact.deleted_at IS
+    '삭제 시각. NULL 이면 살아 있는 고객이다. 팀장만 채울 수 있다.';
+
+-- 목록과 상세가 늘 살아 있는 고객만 찾는다. 지운 고객이 쌓여도 그쪽은 훑지 않는다.
+CREATE INDEX customer_contact_active_idx
+    ON public.customer_contact (id)
+    WHERE deleted_at IS NULL;
+
+COMMIT;

--- a/backend/sql/README.md
+++ b/backend/sql/README.md
@@ -240,6 +240,13 @@
   **개발 DB에는 검토 전 초안이 적용됐지만 현재 PR의 최종 SQL은 적용하지 않았습니다.
   운영 DB에도 적용하지 않았습니다. 적용 전 백업/PITR 확인이 필수입니다.**
 
+- `20260903_0021_customer_contact_soft_delete.sql`: `customer_contact`에 `deleted_at`과
+  살아 있는 행만 담는 부분 인덱스를 더합니다. 고객 삭제(팀장 전용)를 행 삭제가 아니라
+  `deleted_at` 표시로 처리하기 위한 것입니다. `activity`·`sales_deal`·`sales_deal_participant`가
+  `ON DELETE` 옵션 없이 이 표를 참조해 실제 DELETE는 외래키에 막히고, 참조를 먼저 끊으면
+  딜·일정에서 만난 사람의 기록이 사라집니다. 기존 행은 전부 `NULL`(살아 있음)이라 백필이
+  없습니다. **아직 어느 DB에도 적용하지 않았습니다.**
+
 `20260819_0001`은 빈 `public` 스키마에 처음부터 만드는 것을 전제로 합니다. 되돌리는 마이그레이션이
 아니므로 적용 전에 아래 런북의 1~2단계를 먼저 수행합니다.
 
@@ -280,6 +287,7 @@
 | 2026-09-01 | 현재 연결된 개발 DB | `20260901_0018_agent_run_queue.sql` | session pooler | 성공. 정리 후 agent_run 537행을 유지하고 큐 컬럼·제약조건·인덱스를 추가. `agent_worker --check-schema` 통과 |
 | 2026-09-03 | 현재 연결된 개발 DB | `20260902_0019_transient_report_generation.sql` | session pooler | 성공. 생성 payload 만료·재접속 scope·멱등 확정 컬럼과 보호 함수를 추가하고 `agent_worker --check-schema` 통과 |
 | 2026-09-03 | 현재 연결된 개발 DB | `20260903_0020_report_freeform_body.sql` 검토 전 초안 | session pooler | 일일 204·주간 51·월간 20건을 본문으로 이관하고 report_deal 본문 83→453건. 현재 PR의 fail-closed 검증과 구 단일 딜 미팅 이관이 들어가기 전 SQL이므로, 개발 반영 때는 0020 직전 백업으로 복구한 뒤 최종 SQL을 적용해야 함 |
+| 2026-09-03 | — | `20260903_0021_customer_contact_soft_delete.sql` | — | 대기. 고객 삭제용 `customer_contact.deleted_at`과 부분 인덱스. 적용 요청을 아직 받지 않았습니다 |
 
 ## 개발 DB 재구축 런북
 

--- a/backend/tests/test_customers.py
+++ b/backend/tests/test_customers.py
@@ -1012,3 +1012,82 @@ def test_write_still_rejects_an_unknown_source_code():
             phone="010-0000-0000",
             source_code="manual",
         )
+
+
+def test_member_cannot_delete_a_customer_before_any_query():
+    """팀원의 삭제는 조회 전에 막힌다. 있는 고객인지가 응답으로 새면 안 된다."""
+    member = _member()
+    db = _Db()
+
+    with _client(db, member) as client:
+        response = client.delete(
+            f"/api/customer-contacts/{uuid4()}",
+            headers={"Origin": ORIGIN},
+        )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "manager_required"}
+    assert not db.statements
+    assert db.commit_count == 0
+
+
+def test_manager_deleting_an_unknown_customer_gets_404():
+    manager = _member(role="manager")
+    db = _Db(_Result(scalar=None))
+
+    with _client(db, manager) as client:
+        response = client.delete(
+            f"/api/customer-contacts/{uuid4()}",
+            headers={"Origin": ORIGIN},
+        )
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "customer_contact_not_found"}
+    assert db.commit_count == 0
+
+
+def test_manager_delete_marks_the_customer_and_keeps_the_row():
+    """행을 지우지 않고 deleted_at 만 채운다. 딜·일정이 이 고객을 참조하고 있다."""
+    manager = _member(role="manager")
+    company = _company(manager.team_id)
+    contact = _contact(company.id, manager.id)
+    db = _Db(_Result(scalar=contact))
+
+    with _client(db, manager) as client:
+        response = client.delete(
+            f"/api/customer-contacts/{contact.id}",
+            headers={"Origin": ORIGIN},
+        )
+
+    assert response.status_code == 204
+    assert contact.deleted_at is not None
+    assert db.commit_count == 1
+    assert db.rollback_count == 0
+    # 담당자 행은 그대로 둔다. 지우는 문장이 나가지 않아야 한다.
+    assert len(db.statements) == 1
+    assert "DELETE" not in str(db.statements[0])
+
+
+def test_deleted_customers_are_hidden_from_list_and_detail():
+    manager = _member(role="manager")
+    company = _company(manager.team_id)
+    contact = _contact(company.id, manager.id)
+    contact_status = _contact_status(manager.team_id, status_id=contact.customer_contact_status_id)
+
+    list_db = _Db(
+        _Result(scalar=1),
+        _Result(rows=[_contact_row(contact, company, manager, contact_status)]),
+        _assignee_result((contact, manager)),
+    )
+    with _client(list_db, manager) as client:
+        assert client.get("/api/customer-contacts").status_code == 200
+
+    detail_db = _Db(
+        _Result(rows=[_contact_row(contact, company, manager, contact_status)]),
+        _assignee_result((contact, manager)),
+    )
+    with _client(detail_db, manager) as client:
+        assert client.get(f"/api/customer-contacts/{contact.id}").status_code == 200
+
+    for statement in (list_db.statements[0], list_db.statements[1], detail_db.statements[0]):
+        assert "customer_contact.deleted_at IS NULL" in str(statement)

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -22,7 +22,7 @@ EXPECTED_COLUMN_COUNTS = {
     # 20260826_0009 로 customer_company 에 postcode/address/address_detail 이 늘었다.
     "customer_company": 9,
     # 20260824_0004 로 customer_contact 에 visited 가 늘었다.
-    "customer_contact": 14,
+    "customer_contact": 15,
     "customer_contact_assignee": 3,
     "customer_contact_status": 9,
     # 20260824_0004 로 product 에 category_code/unit_price/shelf_life_months/memo/
@@ -122,7 +122,7 @@ def test_all_database_tables_are_mapped():
     assert {
         table.name: len(table.columns) for table in Base.metadata.sorted_tables
     } == EXPECTED_COLUMN_COUNTS
-    assert sum(len(table.columns) for table in Base.metadata.tables.values()) == 442
+    assert sum(len(table.columns) for table in Base.metadata.tables.values()) == 443
 
     foreign_key_constraints = [
         foreign_key

--- a/docs/database/tables/customer_contact.md
+++ b/docs/database/tables/customer_contact.md
@@ -20,6 +20,7 @@
 | `customer_contact_status_id` | UUID | FK → customer_contact_status.id | YES | – | 담당자 상태 ID |
 | `created_by_member_id` | UUID | FK → member.id | NO | – | 등록한 구성원 ID (등록 후 변경 없음) |
 | `visited` | BOOLEAN | – | NO | `false` | 방문 여부 (수동 표시) |
+| `deleted_at` | TIMESTAMPTZ | – | YES | – | 삭제 시각 (팀장 전용 소프트 삭제). NULL이면 살아 있는 고객 |
 
 ## Constraints
 
@@ -35,6 +36,7 @@
 
 - `customer_contact_company_name_idx` — `btree (company_id, name)`
 - `customer_contact_owner_idx` — `btree (owner_member_id)`
+- `customer_contact_active_idx` — `btree (id) WHERE deleted_at IS NULL`
 
 ## Relations
 

--- a/docs/technical/backend/api-conventions.md
+++ b/docs/technical/backend/api-conventions.md
@@ -278,7 +278,7 @@ GET /api/activities?owner_member_id=9f64618b-8ed8-4aed-9560-78b25228dbe5&owner_m
 | 인증 | `POST /api/auth/login`, `GET /api/auth/me`, `POST /api/auth/logout` | `SessionRead`; logout `204` |
 | 고객 상태 선택지 | `GET /api/customer-contact-statuses` | active 팀 설정, `position` 순 |
 | 고객사 | `GET/POST /api/customer-companies`, `GET/PATCH /api/customer-companies/{company_id}` | 목록은 `q,skip,limit`; 회사 수정은 manager |
-| 고객 담당자 | `GET/POST /api/customer-contacts`, `GET/PATCH /api/customer-contacts/{contact_id}` | 요청은 `status_code`, 응답은 상태 UUID·code·name·tone 포함 |
+| 고객 담당자 | `GET/POST /api/customer-contacts`, `GET/PATCH/DELETE /api/customer-contacts/{contact_id}` | 요청은 `status_code`, 응답은 상태 UUID·code·name·tone 포함. `DELETE`는 팀장만(아니면 403 `manager_required`) 이고 행을 지우지 않고 `deleted_at`을 채운다 |
 | 일정 선택지 | `GET /api/activity-categories`, `GET /api/activity-action-tags` | active 팀 설정만, `position` 순 |
 | 일정 | `GET/POST /api/activities`, `GET/PATCH/DELETE /api/activities/{activity_id}` | 목록은 `start_date` 필수, `end_date,owner_member_id,skip,limit`; 응답에 category/tag UUID·code·name·tone |
 | 파이프라인 | `GET /api/sales-pipelines`, `GET /api/sales-pipelines/{sales_pipeline_id}/stages` | published와 archived 조회; default 우선, 단계는 `position` 순 |

--- a/frontend/src/pages/Customers/Customers.module.scss
+++ b/frontend/src/pages/Customers/Customers.module.scss
@@ -76,3 +76,17 @@
   font-size: 12px;
   line-height: 1.6;
 }
+
+/* 삭제 확인 모달. 되돌릴 수 없다는 말을 본문에 한 줄로 둡니다. */
+.confirm {
+  color: var(--ink-2);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.confirmError {
+  margin-top: var(--s2);
+  color: var(--red-ink);
+  font-size: 12px;
+  line-height: 1.6;
+}

--- a/frontend/src/pages/Customers/Customers.tsx
+++ b/frontend/src/pages/Customers/Customers.tsx
@@ -3,10 +3,14 @@ import { isAxiosError } from 'axios'
 
 import { client } from '@/api/client'
 import { errorMessage, transportMessage } from '@/api/errorMessage'
+import { useCurrentUser } from '@/auth/sessionContext'
+import Button from '@/components/Button'
 import ErrorToast from '@/components/ErrorToast'
+import Modal from '@/components/Modal'
 import Pagination, { PAGE_SIZE } from '@/components/Pagination'
 import { InlineLoader, ListPageSkeleton } from '@/components/Skeleton'
 import { useScopeOwnerIds, useShowOwner } from '@/shared/scope'
+import { showToast } from '@/shared/toast'
 import type { Customer, CustomerContactResponse, PageResponse } from '@/types'
 
 import type { BusinessCardDraft } from './businessCard'
@@ -51,6 +55,13 @@ export default function Customers() {
   const [reloadKey, setReloadKey] = useState(0)
   const [exporting, setExporting] = useState(false)
   const [notice, setNotice] = useState<string | null>(null)
+  const [editing, setEditing] = useState<Customer | null>(null)
+  const [deleting, setDeleting] = useState<Customer | null>(null)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+
+  // 삭제는 팀장만 합니다. 메뉴에서 감추기만 하고 실제로 막는 일은 백엔드가 합니다.
+  const { isManager } = useCurrentUser()
 
   const { prefs, toggleColumn, moveColumn, setWidth, reset } = useColumnPrefs()
   // 한 사람만 보고 있으면 담당자 칸이 줄마다 같은 이름이라 아예 감춥니다. 팀원은 늘 그렇습니다.
@@ -185,6 +196,47 @@ export default function Customers() {
     [reload],
   )
 
+  /**
+   * 고친 줄만 갈아 끼웁니다. 목록을 다시 받으면 열려 있던 상세가 닫히는데
+   * (아래 로딩 효과가 openId 를 비웁니다), 방금 고친 값은 그 자리에서 보여야 합니다.
+   */
+  const onCustomerUpdated = useCallback((contact: CustomerContactResponse) => {
+    const updated = toCustomer(contact)
+    setRows((previous) => previous.map((row) => (row.id === updated.id ? updated : row)))
+    setEditing(null)
+    showToast('고객 정보를 수정했습니다.')
+  }, [])
+
+  const closeDeleteModal = useCallback(() => {
+    if (isDeleting) return
+    setDeleting(null)
+    setDeleteError(null)
+  }, [isDeleting])
+
+  const confirmDelete = useCallback(() => {
+    if (deleting === null || isDeleting) return
+    const target = deleting
+
+    setIsDeleting(true)
+    setDeleteError(null)
+
+    void client
+      .delete(`/customer-contacts/${target.id}`)
+      .then(() => {
+        setDeleting(null)
+        setOpenId(null)
+        // 눈앞에서 먼저 지우고, 쪽수와 합계는 다시 받아 맞춥니다.
+        setRows((previous) => previous.filter((row) => row.id !== target.id))
+        setTotal((previous) => Math.max(0, previous - 1))
+        setReloadKey((value) => value + 1)
+        showToast('고객을 삭제했습니다.')
+      })
+      .catch((error: unknown) => {
+        setDeleteError(errorMessage(error, '고객을 삭제하지 못했습니다.'))
+      })
+      .finally(() => setIsDeleting(false))
+  }, [deleting, isDeleting])
+
   // 내보내기는 화면 밖의 줄까지 모두 모읍니다. 페이지 한 장만 담으면 파일이 거짓말을 합니다.
   const exportRef = useRef<AbortController | null>(null)
   useEffect(() => () => exportRef.current?.abort(), [])
@@ -287,15 +339,15 @@ export default function Customers() {
           duplicateMatches={cardDraft?.matches}
           archiveImage={cardDraft?.sourceImage}
           initial={
-            cardDraft === null
-              ? undefined
-              : {
+            cardDraft
+              ? {
                   name: cardDraft.name,
                   dept: cardDraft.dept,
                   title: cardDraft.title,
                   email: cardDraft.email,
                   phone: cardDraft.phone,
                 }
+              : undefined
           }
           initialCompany={
             cardDraft?.org.trim() ? { kind: 'new', name: cardDraft.org.trim() } : undefined
@@ -313,7 +365,57 @@ export default function Customers() {
         />
       )}
 
-      {openCustomer && <CustomerDrawer customer={openCustomer} onClose={() => setOpenId(null)} />}
+      {openCustomer && (
+        <CustomerDrawer
+          customer={openCustomer}
+          canDelete={isManager}
+          onEdit={() => setEditing(openCustomer)}
+          onDelete={() => {
+            setDeleteError(null)
+            setDeleting(openCustomer)
+          }}
+          onClose={() => setOpenId(null)}
+        />
+      )}
+
+      {editing && (
+        <CustomerFormModal
+          customer={editing}
+          onClose={() => setEditing(null)}
+          onCreated={onCustomerCreated}
+          onUpdated={onCustomerUpdated}
+        />
+      )}
+
+      {deleting && (
+        <Modal
+          title="고객을 삭제하시겠습니까?"
+          description={`${deleting.org} · ${deleting.name}`}
+          onClose={closeDeleteModal}
+          footer={
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={isDeleting}
+                onClick={closeDeleteModal}
+              >
+                취소
+              </Button>
+              <Button type="button" disabled={isDeleting} onClick={confirmDelete}>
+                {isDeleting ? '삭제 중…' : '삭제'}
+              </Button>
+            </>
+          }
+        >
+          <p className={styles.confirm}>삭제한 고객 정보는 복구할 수 없습니다.</p>
+          {deleteError && (
+            <p className={styles.confirmError} role="alert">
+              {deleteError}
+            </p>
+          )}
+        </Modal>
+      )}
     </section>
   )
 }

--- a/frontend/src/pages/Customers/Customers.tsx
+++ b/frontend/src/pages/Customers/Customers.tsx
@@ -14,11 +14,13 @@ import { showToast } from '@/shared/toast'
 import type { Customer, CustomerContactResponse, PageResponse } from '@/types'
 
 import type { BusinessCardDraft } from './businessCard'
+import type { BusinessLicenseDraft } from './businessLicense'
 import { COLUMN_BY_ID } from './columns'
 import { toCustomer } from './contact'
 import { exportCustomers, TooManyCustomersError } from './exportCustomers'
 import useColumnPrefs from './useColumnPrefs'
 import BusinessCardModal from './components/BusinessCardModal'
+import BusinessLicenseModal from './components/BusinessLicenseModal'
 import CustomerDrawer from './components/CustomerDrawer'
 import CustomerFormModal from './components/CustomerFormModal'
 import CustomerTable from './components/CustomerTable'
@@ -30,8 +32,11 @@ import styles from './Customers.module.scss'
 
 export type SortState = { id: string; dir: 'asc' | 'desc' } | null
 
-/** 한 번에 하나만 열립니다. 명함으로 읽은 값은 그대로 등록 폼으로 넘어갑니다. */
-type OpenDialog = 'create' | 'import' | 'card' | null
+/**
+ * 한 번에 하나만 열립니다. 명함·사업자등록증에서 읽은 값은 그대로 등록 폼으로 넘어갑니다.
+ * TableToolbar 의 등록 메뉴가 돌려주는 말과 같은 값입니다.
+ */
+type OpenDialog = 'create' | 'import' | 'card' | 'license' | null
 
 function loadErrorMessage(error: unknown): string {
   const fallback = '고객 목록을 불러오지 못했습니다.'
@@ -49,6 +54,7 @@ export default function Customers() {
   const [page, setPage] = useState(1)
   const [dialog, setDialog] = useState<OpenDialog>(null)
   const [cardDraft, setCardDraft] = useState<BusinessCardDraft | null>(null)
+  const [licenseDraft, setLicenseDraft] = useState<BusinessLicenseDraft | null>(null)
   const [openId, setOpenId] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState<string | null>(null)
@@ -163,6 +169,7 @@ export default function Customers() {
   const closeDialog = useCallback(() => {
     setDialog(null)
     setCardDraft(null)
+    setLicenseDraft(null)
   }, [])
 
   /** 목록을 처음부터 다시 받습니다. 방금 넣은 고객이 검색어에 걸리지 않을 수 있습니다. */
@@ -185,6 +192,13 @@ export default function Customers() {
   // 명함에서 읽은 값은 바로 저장하지 않습니다. 사람이 등록 폼에서 확인하고 고칩니다.
   const onRecognized = useCallback((draft: BusinessCardDraft) => {
     setCardDraft(draft)
+    setDialog('create')
+  }, [])
+
+  // 사업자등록증에서 읽은 값도 바로 저장하지 않습니다. 담당자 이름·연락처는
+  // 등록증에 없으므로 등록 폼에서 사람이 채웁니다.
+  const onLicenseDrafted = useCallback((draft: BusinessLicenseDraft) => {
+    setLicenseDraft(draft)
     setDialog('create')
   }, [])
 
@@ -289,9 +303,7 @@ export default function Customers() {
         onMoveColumn={moveColumn}
         onResetColumns={reset}
         hiddenColumns={hiddenColumns}
-        onCreate={() => setDialog('create')}
-        onImport={() => setDialog('import')}
-        onScanCard={() => setDialog('card')}
+        onAdd={setDialog}
         onExport={onExport}
         exporting={exporting}
         canExport={total > 0}
@@ -338,6 +350,7 @@ export default function Customers() {
           onCreated={onCustomerCreated}
           duplicateMatches={cardDraft?.matches}
           archiveImage={cardDraft?.sourceImage}
+          // 등록증에는 담당자가 없습니다. 사람 칸은 명함일 때만 채웁니다.
           initial={
             cardDraft
               ? {
@@ -350,12 +363,27 @@ export default function Customers() {
               : undefined
           }
           initialCompany={
-            cardDraft?.org.trim() ? { kind: 'new', name: cardDraft.org.trim() } : undefined
+            cardDraft?.org.trim()
+              ? { kind: 'new', name: cardDraft.org.trim() }
+              : licenseDraft?.company.trim()
+                ? { kind: 'new', name: licenseDraft.company.trim() }
+                : undefined
+          }
+          initialBusinessNo={licenseDraft?.businessNo}
+          // 등록증의 소재지는 한 줄로 옵니다. 우편번호가 필요하면 주소 검색으로 다시 고릅니다.
+          initialAddress={
+            licenseDraft?.address.trim()
+              ? { postcode: '', address: licenseDraft.address.trim(), addressDetail: '' }
+              : undefined
           }
         />
       )}
 
       {dialog === 'import' && <ImportModal onClose={closeDialog} onImported={onImported} />}
+
+      {dialog === 'license' && (
+        <BusinessLicenseModal onClose={closeDialog} onDrafted={onLicenseDrafted} />
+      )}
 
       {dialog === 'card' && (
         <BusinessCardModal

--- a/frontend/src/pages/Customers/businessLicense.ts
+++ b/frontend/src/pages/Customers/businessLicense.ts
@@ -1,0 +1,65 @@
+// 사업자등록증(PDF)으로 고객을 넣는 길의 화면 밖 부분입니다.
+//
+// 읽어 낸 값은 명함과 같은 방식으로 고객 등록 폼에 그대로 채워집니다.
+// 아직 읽어 주는 서버가 없습니다. 그래서 화면은 extractBusinessLicense 의 Promise 만
+// 보게 두고, 실제 OCR 이 붙을 때 이 파일 한 곳만 고치면 되도록 갈라 둡니다.
+import { sizeLabel } from '@/utils/attachment'
+
+/** 명함(10MB)과 같은 한도입니다. 사업자등록증 한 장은 이보다 훨씬 작습니다. */
+export const MAX_PDF_BYTES = 10 * 1024 * 1024
+
+/** 사업자등록증에서 읽어 낼 값들. 등록 폼의 회사 칸에 그대로 들어갑니다. */
+export interface BusinessLicenseDraft {
+  /** 상호(법인명) */
+  company: string
+  /** 등록번호. 화면에서는 123-45-67890 모양으로 적습니다. */
+  businessNo: string
+  /** 사업장 소재지 */
+  address: string
+}
+
+export const EMPTY_DRAFT: BusinessLicenseDraft = {
+  company: '',
+  businessNo: '',
+  address: '',
+}
+
+/**
+ * 올린 파일의 문제. 없으면 null 입니다.
+ *
+ * 브라우저가 확장자만 보고 type 을 비워 보내는 경우가 있어 둘 중 하나만 맞아도 PDF 로 봅니다.
+ */
+export function pdfProblem(file: File): string | null {
+  const isPdf = file.type === 'application/pdf' || /\.pdf$/i.test(file.name)
+  if (!isPdf) return 'PDF 파일만 올릴 수 있습니다. 사업자등록증 PDF를 골라 주세요.'
+  if (file.size > MAX_PDF_BYTES) {
+    return `파일이 ${sizeLabel(file.size)} 입니다. ${sizeLabel(MAX_PDF_BYTES)} 까지 올릴 수 있습니다.`
+  }
+  if (file.size === 0) return '내용이 없는 파일입니다. 다른 파일을 골라 주세요.'
+  return null
+}
+
+/** 읽기가 실패했을 때. 화면은 message 를 그대로 보여 줍니다. */
+export class BusinessLicenseReadError extends Error {}
+
+const MOCK_DELAY_MS = 1200
+
+/**
+ * 사업자등록증에서 값을 읽습니다.
+ *
+ * TODO: 백엔드가 생기면 이 안을 `POST /business-licenses/scan` 호출로 바꿉니다.
+ * 지금은 읽는 데 걸리는 시간만 흉내 내고 빈 초안을 돌려줍니다. 사람이 등록 폼에서
+ * 직접 채우게 두는 편이, 그럴듯한 가짜 값을 채워 넣어 진짜로 오해하게 하는 것보다 낫습니다.
+ */
+export function extractBusinessLicense(file: File): Promise<BusinessLicenseDraft> {
+  return new Promise((resolve, reject) => {
+    window.setTimeout(() => {
+      const problem = pdfProblem(file)
+      if (problem !== null) {
+        reject(new BusinessLicenseReadError(problem))
+        return
+      }
+      resolve({ ...EMPTY_DRAFT })
+    }, MOCK_DELAY_MS)
+  })
+}

--- a/frontend/src/pages/Customers/components/AddCustomerMenu/AddCustomerMenu.module.scss
+++ b/frontend/src/pages/Customers/components/AddCustomerMenu/AddCustomerMenu.module.scss
@@ -1,0 +1,56 @@
+.menu {
+  display: flex;
+  flex-direction: column;
+  min-width: 272px;
+
+  @include sm {
+    min-width: 0;
+    width: min(84vw, 272px);
+  }
+}
+
+/*
+ * 한 줄이 곧 그 방식으로 가는 버튼입니다. 아이콘은 왼쪽 한 칸을 지키고, 제목과 설명은
+ * 그 오른쪽에 쌓입니다. 카드로 키우면 판이 화면을 가리므로 줄 높이만 씁니다.
+ */
+.item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  column-gap: var(--s3);
+  row-gap: 1px;
+  padding: var(--s2) var(--s3);
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--fill);
+  }
+
+  &:focus-visible {
+    outline: none;
+    background: var(--fill);
+    box-shadow: 0 0 0 2px var(--blue-ring);
+  }
+}
+
+// 두 줄 높이의 가운데에 섭니다.
+.icon {
+  grid-row: 1 / 3;
+  color: var(--muted);
+}
+
+.title {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.008em;
+}
+
+.desc {
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.5;
+}

--- a/frontend/src/pages/Customers/components/AddCustomerMenu/AddCustomerMenu.tsx
+++ b/frontend/src/pages/Customers/components/AddCustomerMenu/AddCustomerMenu.tsx
@@ -1,0 +1,110 @@
+// "고객 등록" 버튼에 붙는 드롭다운입니다.
+//
+// 고객을 넣는 길이 넷이 되었습니다. 낱개 버튼으로 늘어놓으면 줄 끝이 비슷한 버튼 넷이
+// 되어 어디가 주된 길인지 사라지므로, 진입점은 버튼 하나로 두고 무엇으로 넣을지는
+// 여기서 고릅니다. 결과는 넷 다 같은 일(고객 한 줄)이라 한자리에 모입니다.
+import { useRef, useState, type KeyboardEvent } from 'react'
+
+import Button from '@/components/Button'
+import {
+  CardIcon,
+  ChevronDownIcon,
+  ContractIcon,
+  EditIcon,
+  PlusIcon,
+  SheetIcon,
+} from '@/components/icons'
+import Popover from '@/components/Popover'
+import { BP_PHONE } from '@/constants/breakpoints'
+import useMediaQuery from '@/hooks/useMediaQuery'
+
+import styles from './AddCustomerMenu.module.scss'
+
+/** 고객을 넣는 네 갈래. Customers 의 OpenDialog 값과 같은 말을 씁니다. */
+export type AddCustomerWay = 'card' | 'import' | 'create' | 'license'
+
+interface Option {
+  way: AddCustomerWay
+  Icon: typeof CardIcon
+  title: string
+  desc: string
+}
+
+const OPTIONS: Option[] = [
+  { way: 'card', Icon: CardIcon, title: '명함으로 등록', desc: '명함 이미지를 업로드합니다.' },
+  {
+    way: 'license',
+    Icon: ContractIcon,
+    title: '사업자 등록증 등록',
+    desc: '사업자등록증 PDF를 업로드합니다.',
+  },
+  { way: 'import', Icon: SheetIcon, title: '엑셀로 등록', desc: '여러 고객을 한 번에 등록합니다.' },
+  { way: 'create', Icon: EditIcon, title: '직접 등록', desc: '고객 정보를 직접 입력합니다.' },
+]
+
+interface Props {
+  onSelect: (way: AddCustomerWay) => void
+}
+
+export default function AddCustomerMenu({ onSelect }: Props) {
+  const [open, setOpen] = useState(false)
+  const itemRefs = useRef<Array<HTMLButtonElement | null>>([])
+  // 이 버튼은 줄 맨 오른쪽이라 판을 오른쪽 끝에 맞춥니다. 폰에서는 줄이 접혀 버튼이
+  // 왼쪽으로 오므로 그대로 두면 판이 화면 밖으로 나갑니다.
+  const isPhone = useMediaQuery(`(max-width: ${BP_PHONE}px)`)
+
+  // 위아래 화살표로 항목을 옮겨 다닙니다. 여닫기와 Escape 는 Popover 가 봅니다.
+  const onKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return
+    event.preventDefault()
+    const delta = event.key === 'ArrowDown' ? 1 : -1
+    itemRefs.current[(index + delta + OPTIONS.length) % OPTIONS.length]?.focus()
+  }
+
+  return (
+    <Popover
+      open={open}
+      onClose={() => setOpen(false)}
+      align={isPhone ? 'start' : 'end'}
+      compact
+      label="고객 등록 방식"
+      trigger={
+        <Button
+          type="button"
+          aria-haspopup="menu"
+          aria-expanded={open}
+          onClick={() => setOpen(!open)}
+        >
+          <PlusIcon width={16} height={16} />
+          고객 등록
+          <ChevronDownIcon width={15} height={15} />
+        </Button>
+      }
+    >
+      <div className={styles.menu} role="menu" aria-label="고객 등록 방식">
+        {OPTIONS.map(({ way, Icon, title, desc }, index) => (
+          <button
+            key={way}
+            ref={(node) => {
+              itemRefs.current[index] = node
+            }}
+            type="button"
+            role="menuitem"
+            className={styles.item}
+            // 열자마자 화살표로 이어 고를 수 있게 포커스를 옮깁니다.
+            autoFocus={index === 0}
+            onKeyDown={(event) => onKeyDown(event, index)}
+            onClick={() => {
+              setOpen(false)
+              onSelect(way)
+            }}
+          >
+            <Icon className={styles.icon} width={17} height={17} />
+            <strong className={styles.title}>{title}</strong>
+            <span className={styles.desc}>{desc}</span>
+          </button>
+        ))}
+      </div>
+    </Popover>
+  )
+}

--- a/frontend/src/pages/Customers/components/AddCustomerMenu/index.ts
+++ b/frontend/src/pages/Customers/components/AddCustomerMenu/index.ts
@@ -1,0 +1,1 @@
+export { default, type AddCustomerWay } from './AddCustomerMenu'

--- a/frontend/src/pages/Customers/components/BusinessLicenseModal/BusinessLicenseModal.module.scss
+++ b/frontend/src/pages/Customers/components/BusinessLicenseModal/BusinessLicenseModal.module.scss
@@ -1,0 +1,112 @@
+/* ---- 고르기 ---- */
+
+// Documents 의 업로드 드롭존과 같은 모양입니다. 여기서는 파일 하나만 받습니다.
+.drop {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--s2);
+  padding: var(--s7) var(--s4);
+  border: 1px dashed var(--line-2);
+  border-radius: var(--r-md);
+  background: var(--surface-2);
+  color: var(--muted);
+  text-align: center;
+  transition:
+    border-color var(--t-fast) var(--ease-out),
+    background var(--t-fast) var(--ease-out);
+
+  strong {
+    color: var(--ink);
+    font-size: 14px;
+  }
+
+  p {
+    font-size: 13px;
+  }
+}
+
+// 끌어온 파일이 이 자리에 놓인다는 것을 색으로 알립니다.
+.isDragging {
+  border-color: var(--blue);
+  background: var(--blue-tint);
+}
+
+.limit {
+  font-size: 11px;
+}
+
+/* ---- 고른 파일 한 줄 ---- */
+
+.picked {
+  display: flex;
+  align-items: center;
+  gap: var(--s3);
+  padding: var(--s3);
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  background: var(--surface);
+  color: var(--muted);
+}
+
+// 파일명이 길어도 오른쪽 버튼들은 자리를 잃지 않습니다.
+.file {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.meta {
+  font-size: 11px;
+}
+
+.remove {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 30px;
+  height: 30px;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: none;
+  color: var(--muted);
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    background: var(--red-tint);
+    color: var(--red-ink);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+}
+
+.progress {
+  display: grid;
+  gap: var(--s2);
+  margin-top: var(--s3);
+}
+
+.step {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.error {
+  margin-top: var(--s2);
+  color: var(--red-ink);
+  font-size: 12px;
+}

--- a/frontend/src/pages/Customers/components/BusinessLicenseModal/BusinessLicenseModal.tsx
+++ b/frontend/src/pages/Customers/components/BusinessLicenseModal/BusinessLicenseModal.tsx
@@ -1,0 +1,185 @@
+// 사업자등록증 PDF 로 고객을 넣는 화면입니다. 여기서 하는 일은 PDF 를 고르는 것뿐입니다.
+//
+// 읽어 낸 값은 여기서 저장하지도, 다시 확인받지도 않습니다. 명함과 같은 방식으로 등록 폼에
+// 넘겨, 사람이 담당자 이름까지 채우고 한 번에 등록합니다. 새 API 없이 기존 등록 길을 탑니다.
+import { useRef, useState } from 'react'
+
+import Button from '@/components/Button'
+import Modal from '@/components/Modal'
+import ProgressBar from '@/components/ProgressBar'
+import { ContractIcon, TrashIcon } from '@/components/icons'
+import { sizeLabel } from '@/utils/attachment'
+
+import {
+  extractBusinessLicense,
+  pdfProblem,
+  type BusinessLicenseDraft,
+} from '../../businessLicense'
+
+import styles from './BusinessLicenseModal.module.scss'
+
+/** 지금 어느 단계인지. 읽는 동안에는 고르기 칸이 잠깁니다. */
+type Phase = 'pick' | 'extracting'
+
+const READ_FALLBACK_MESSAGE = '사업자등록증을 읽지 못했습니다. 잠시 후 다시 시도해 주세요.'
+
+interface Props {
+  onClose: () => void
+  /** 등록증에서 읽어 낸 값. 부른 쪽이 등록 폼에 채워 넣습니다. */
+  onDrafted: (draft: BusinessLicenseDraft) => void
+}
+
+export default function BusinessLicenseModal({ onClose, onDrafted }: Props) {
+  const fileRef = useRef<HTMLInputElement>(null)
+
+  const [phase, setPhase] = useState<Phase>('pick')
+  const [file, setFile] = useState<File | null>(null)
+  const [dragging, setDragging] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const reading = phase === 'extracting'
+
+  const pick = (next: File) => {
+    const problem = pdfProblem(next)
+    if (problem !== null) {
+      setError(problem)
+      return
+    }
+    setError(null)
+    setFile(next)
+  }
+
+  const clear = () => {
+    setFile(null)
+    setError(null)
+  }
+
+  const read = async () => {
+    if (file === null || reading) return
+
+    setPhase('extracting')
+    setError(null)
+
+    try {
+      // 부른 쪽이 이 모달을 등록 폼으로 갈아 끼웁니다. 뒷정리는 필요 없습니다.
+      onDrafted(await extractBusinessLicense(file))
+    } catch (caught: unknown) {
+      setError(caught instanceof Error ? caught.message : READ_FALLBACK_MESSAGE)
+      setPhase('pick')
+    }
+  }
+
+  const close = () => {
+    if (!reading) onClose()
+  }
+
+  return (
+    <Modal
+      title="사업자 등록증으로 고객 등록"
+      description="사업자등록증 PDF를 업로드하면 읽어 낸 값이 고객 등록 폼에 채워집니다."
+      onClose={close}
+      footer={
+        <>
+          <Button type="button" variant="outline" disabled={reading} onClick={close}>
+            취소
+          </Button>
+          <Button type="button" disabled={file === null || reading} onClick={read}>
+            {reading ? '읽는 중…' : '다음'}
+          </Button>
+        </>
+      }
+    >
+      <input
+        ref={fileRef}
+        data-testid="business-license-pdf-input"
+        type="file"
+        accept="application/pdf,.pdf"
+        className="sr-only"
+        onChange={(event) => {
+          const next = event.target.files?.[0]
+          if (next) pick(next)
+          // 같은 파일을 다시 골라도 change 가 나게 비웁니다.
+          event.target.value = ''
+        }}
+      />
+
+      {file === null ? (
+        <>
+          {/* 끌어다 놓기와 고르기 둘 다 됩니다. 브라우저가 PDF 를 새 탭으로 여는 기본
+              동작을 막아야 해서 dragOver 에서도 preventDefault 를 합니다. */}
+          <div
+            className={[styles.drop, dragging ? styles.isDragging : ''].filter(Boolean).join(' ')}
+            onDragOver={(event) => {
+              event.preventDefault()
+              setDragging(true)
+            }}
+            onDragLeave={() => setDragging(false)}
+            onDrop={(event) => {
+              event.preventDefault()
+              setDragging(false)
+              const dropped = event.dataTransfer.files[0]
+              if (dropped) pick(dropped)
+            }}
+          >
+            <ContractIcon width={30} height={30} strokeWidth={1.4} />
+            <strong>사업자등록증 PDF를 업로드하세요</strong>
+            <p>PDF 파일을 여기로 끌어다 놓거나 파일을 선택해 주세요.</p>
+            <Button type="button" variant="outline" onClick={() => fileRef.current?.click()}>
+              파일 선택
+            </Button>
+            <span className={styles.limit}>PDF 파일만 올릴 수 있습니다 · 최대 10MB</span>
+          </div>
+
+          {error && (
+            <p className={styles.error} role="alert">
+              {error}
+            </p>
+          )}
+        </>
+      ) : (
+        <>
+          <div className={styles.picked}>
+            <ContractIcon width={22} height={22} strokeWidth={1.5} />
+            <span className={styles.file}>
+              <strong className={styles.name}>{file.name}</strong>
+              <span className={styles.meta}>
+                PDF · <span className="tnum">{sizeLabel(file.size)}</span>
+              </span>
+            </span>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={reading}
+              onClick={() => fileRef.current?.click()}
+            >
+              파일 변경
+            </Button>
+            <button
+              type="button"
+              className={styles.remove}
+              aria-label={`${file.name} 삭제`}
+              disabled={reading}
+              onClick={clear}
+            >
+              <TrashIcon />
+            </button>
+          </div>
+
+          {reading && (
+            <div className={styles.progress}>
+              <ProgressBar label="사업자등록증을 읽는 중입니다." />
+              <p className={styles.step}>사업자등록증을 읽는 중…</p>
+            </div>
+          )}
+
+          {error && (
+            <p className={styles.error} role="alert">
+              {error}
+            </p>
+          )}
+        </>
+      )}
+    </Modal>
+  )
+}

--- a/frontend/src/pages/Customers/components/BusinessLicenseModal/index.ts
+++ b/frontend/src/pages/Customers/components/BusinessLicenseModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './BusinessLicenseModal'

--- a/frontend/src/pages/Customers/components/CustomerDrawer/CustomerDrawer.module.scss
+++ b/frontend/src/pages/Customers/components/CustomerDrawer/CustomerDrawer.module.scss
@@ -273,3 +273,67 @@
 }
 
 // Button 의 primary 와 같은 모양입니다. 링크라 태그만 다릅니다.
+
+// 머리말의 '…' 더보기. RecordDrawer 의 일정 메뉴와 같은 모양입니다.
+.menuBtn {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--ink-2);
+  cursor: pointer;
+
+  &:hover {
+    background: var(--fill-2);
+    color: var(--ink);
+  }
+}
+
+.menu {
+  display: flex;
+  flex-direction: column;
+  min-width: 132px;
+
+  button {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 7px 10px;
+    border: 0;
+    border-radius: var(--r-sm);
+    background: none;
+    color: var(--ink);
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 500;
+    text-align: left;
+    white-space: nowrap;
+    cursor: pointer;
+
+    svg {
+      flex: none;
+      color: var(--muted);
+    }
+
+    &:hover {
+      background: var(--fill-2);
+    }
+  }
+
+  // 지우는 것은 되돌릴 수 없어 색으로 한 번 더 세웁니다.
+  .danger {
+    color: var(--red-ink);
+
+    svg {
+      color: currentcolor;
+    }
+
+    &:hover {
+      background: var(--red-tint);
+    }
+  }
+}

--- a/frontend/src/pages/Customers/components/CustomerDrawer/CustomerDrawer.tsx
+++ b/frontend/src/pages/Customers/components/CustomerDrawer/CustomerDrawer.tsx
@@ -1,7 +1,9 @@
-import type { ReactNode } from 'react'
+import { useState, type ReactNode } from 'react'
 
 import { buttonClass } from '@/components/Button'
 import Drawer from '@/components/Drawer'
+import { EditIcon, MoreIcon, TrashIcon } from '@/components/icons'
+import Popover from '@/components/Popover'
 import type { Customer } from '@/types'
 import { fmtDay, parseISO } from '@/utils/date'
 
@@ -9,6 +11,10 @@ import styles from './CustomerDrawer.module.scss'
 
 interface Props {
   customer: Customer
+  /** 삭제는 팀장만 합니다. 아니면 메뉴에서 아예 빼고, 막는 일은 백엔드가 다시 합니다. */
+  canDelete: boolean
+  onEdit: () => void
+  onDelete: () => void
   onClose: () => void
 }
 
@@ -28,7 +34,9 @@ function Block({ title, children }: BlockProps) {
 
 const shown = (value: string | null | undefined): string => value || '—'
 
-export default function CustomerDrawer({ customer, onClose }: Props) {
+export default function CustomerDrawer({ customer, canDelete, onEdit, onDelete, onClose }: Props) {
+  const [menuOpen, setMenuOpen] = useState(false)
+
   // 담당자가 여럿이면 상세에서는 전부 보여 줍니다. 좁은 표와 달리 자리가 있습니다.
   const ownerNames =
     customer.owners !== undefined && customer.owners.length > 0
@@ -51,6 +59,52 @@ export default function CustomerDrawer({ customer, onClose }: Props) {
       sub={[customer.org, customer.dept, customer.title].filter(Boolean).join(' · ')}
       resetKey={customer.id}
       onClose={onClose}
+      actions={
+        <Popover
+          open={menuOpen}
+          onClose={() => setMenuOpen(false)}
+          align="end"
+          compact
+          label="고객 메뉴"
+          trigger={
+            <button
+              type="button"
+              className={styles.menuBtn}
+              aria-label="고객 메뉴"
+              aria-expanded={menuOpen}
+              onClick={() => setMenuOpen((value) => !value)}
+            >
+              <MoreIcon width={18} height={18} />
+            </button>
+          }
+        >
+          <div className={styles.menu}>
+            <button
+              type="button"
+              onClick={() => {
+                setMenuOpen(false)
+                onEdit()
+              }}
+            >
+              <EditIcon width={15} height={15} />
+              수정
+            </button>
+            {canDelete && (
+              <button
+                type="button"
+                className={styles.danger}
+                onClick={() => {
+                  setMenuOpen(false)
+                  onDelete()
+                }}
+              >
+                <TrashIcon width={15} height={15} />
+                삭제
+              </button>
+            )}
+          </div>
+        </Popover>
+      }
       meta={
         <>
           <i

--- a/frontend/src/pages/Customers/components/CustomerFormModal/CustomerFormModal.tsx
+++ b/frontend/src/pages/Customers/components/CustomerFormModal/CustomerFormModal.tsx
@@ -38,6 +38,16 @@ interface CustomerFormModalProps {
   initial?: Partial<Draft>
   /** 부른 쪽에서 이미 정해진 회사. 검색창에 미리 올려 둡니다. */
   initialCompany?: CompanySelection
+  /**
+   * 사업자등록증에서 읽어 온 등록번호. 새로 만드는 회사일 때만 씁니다.
+   * 이미 있는 회사는 그 회사의 값이 이깁니다.
+   */
+  initialBusinessNo?: string
+  /**
+   * 사업자등록증에서 읽어 온 주소. 새로 만드는 회사일 때만 씁니다.
+   * 이미 있는 회사는 그 회사의 값이 이깁니다.
+   */
+  initialAddress?: AddressValue
   /** 명함 인식 뒤 발견한 기존 담당자 후보. 자동 병합하지 않습니다. */
   duplicateMatches?: BusinessCardMatch[]
   /** 명함 OCR에 사용한 원본. 고객 등록 뒤 자료실에 보관합니다. */
@@ -132,6 +142,8 @@ export default function CustomerFormModal({
   onUpdated,
   initial,
   initialCompany,
+  initialBusinessNo,
+  initialAddress,
   duplicateMatches = [],
   archiveImage,
 }: CustomerFormModalProps) {
@@ -149,10 +161,12 @@ export default function CustomerFormModal({
   const [businessNo, setBusinessNo] = useState(() =>
     initialCompany?.kind === 'existing'
       ? (formatBusinessNo(initialCompany.company.business_no) ?? '')
-      : '',
+      : (initialBusinessNo ?? ''),
   )
   const [address, setAddress] = useState<AddressValue>(() =>
-    initialCompany?.kind === 'existing' ? companyAddress(initialCompany.company) : EMPTY_ADDRESS,
+    initialCompany?.kind === 'existing'
+      ? companyAddress(initialCompany.company)
+      : (initialAddress ?? EMPTY_ADDRESS),
   )
   const [assigneeIds, setAssigneeIds] = useState<string[]>(() => {
     if (!customer) return [memberId]

--- a/frontend/src/pages/Customers/components/CustomerFormModal/CustomerFormModal.tsx
+++ b/frontend/src/pages/Customers/components/CustomerFormModal/CustomerFormModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { client } from '@/api/client'
 import { errorMessage } from '@/api/errorMessage'
@@ -10,10 +10,12 @@ import MemberMultiSelect from '@/components/MemberMultiSelect'
 import Modal from '@/components/Modal'
 import { SOURCE_LABEL } from '@/pages/Customers/contact'
 import type {
+  Customer,
   CustomerCompanyCreateRequest,
   CustomerCompanyResponse,
   CustomerContactCreateRequest,
   CustomerContactResponse,
+  CustomerContactUpdateRequest,
   CustomerSourceCode,
 } from '@/types'
 import { businessNoDigits, formatBusinessNo } from '@/utils/format'
@@ -25,6 +27,13 @@ interface CustomerFormModalProps {
   onClose: () => void
   /** 방금 만든 고객. 부른 쪽이 그대로 골라 둘 수 있게 넘깁니다. */
   onCreated: (contact: CustomerContactResponse, warning?: string) => void
+  /**
+   * 고칠 고객. 주면 수정 폼이 됩니다. 항목은 등록과 같고 상태만 다루지 않습니다.
+   * 상태를 바꾸는 화면이 아직 없어 여기서 새로 만들지 않습니다.
+   */
+  customer?: Customer
+  /** 수정한 결과. 부른 쪽이 목록·상세의 그 줄만 갈아 끼웁니다. */
+  onUpdated?: (contact: CustomerContactResponse) => void
   /** 명함에서 읽어 온 값. 사람이 확인하고 고칠 수 있게 칸만 채워 둡니다. */
   initial?: Partial<Draft>
   /** 부른 쪽에서 이미 정해진 회사. 검색창에 미리 올려 둡니다. */
@@ -104,21 +113,38 @@ async function resolveCompanyId(
   return data.id
 }
 
+/** 수정 폼의 첫 값. 목록이 이미 들고 있는 고객을 입력칸 모양으로 되돌립니다. */
+function customerDraft(customer: Customer): Draft {
+  return {
+    name: customer.name,
+    dept: customer.dept,
+    title: customer.title,
+    email: customer.email,
+    phone: customer.phone,
+    memo: customer.memo,
+  }
+}
+
 export default function CustomerFormModal({
   onClose,
   onCreated,
+  customer,
+  onUpdated,
   initial,
   initialCompany,
   duplicateMatches = [],
   archiveImage,
 }: CustomerFormModalProps) {
   const { isManager, memberId } = useCurrentUser()
+  const editing = customer !== undefined
 
-  const [draft, setDraft] = useState<Draft>({ ...EMPTY, ...initial })
+  const [draft, setDraft] = useState<Draft>(
+    customer ? customerDraft(customer) : { ...EMPTY, ...initial },
+  )
   // 아직 만나기 전입니다. 방문은 담당자가 다녀온 뒤에 직접 켭니다.
-  const [visited, setVisited] = useState(false)
+  const [visited, setVisited] = useState(customer?.visited ?? false)
   // 유입경로. 빈 문자열은 미지정입니다.
-  const [sourceCode, setSourceCode] = useState<CustomerSourceCode | ''>('')
+  const [sourceCode, setSourceCode] = useState<CustomerSourceCode | ''>(customer?.sourceCode ?? '')
   const [company, setCompany] = useState<CompanySelection | null>(initialCompany ?? null)
   const [businessNo, setBusinessNo] = useState(() =>
     initialCompany?.kind === 'existing'
@@ -128,10 +154,44 @@ export default function CustomerFormModal({
   const [address, setAddress] = useState<AddressValue>(() =>
     initialCompany?.kind === 'existing' ? companyAddress(initialCompany.company) : EMPTY_ADDRESS,
   )
-  const [assigneeIds, setAssigneeIds] = useState<string[]>([memberId])
+  const [assigneeIds, setAssigneeIds] = useState<string[]>(() => {
+    if (!customer) return [memberId]
+    const owners = customer.owners?.map((owner) => owner.id) ?? []
+    return owners.length > 0 ? owners : [customer.ownerMemberId ?? memberId]
+  })
   const [errors, setErrors] = useState<Errors>({})
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
+  // 수정 폼은 회사 전체를 받아 와야 검색칸에 올릴 수 있습니다. 목록이 들고 있는 것은
+  // 회사 id 와 이름뿐이고, 사업자번호·주소는 회사에 붙어 있습니다.
+  const [companyLoading, setCompanyLoading] = useState(editing)
+
+  const companyId = customer?.companyId
+  useEffect(() => {
+    if (companyId === undefined) return
+    const controller = new AbortController()
+
+    setCompanyLoading(true)
+    void client
+      .get<CustomerCompanyResponse>(`/customer-companies/${companyId}`, {
+        signal: controller.signal,
+      })
+      .then(({ data }) => {
+        if (controller.signal.aborted) return
+        setCompany({ kind: 'existing', company: data })
+        setBusinessNo(formatBusinessNo(data.business_no) ?? '')
+        setAddress(companyAddress(data))
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return
+        setSubmitError(errorMessage(error, '고객사 정보를 불러오지 못했습니다.'))
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setCompanyLoading(false)
+      })
+
+    return () => controller.abort()
+  }, [companyId])
 
   const clearError = (key: ErrorKey) => {
     setErrors((previous) => ({ ...previous, [key]: undefined }))
@@ -156,7 +216,7 @@ export default function CustomerFormModal({
   }
 
   const submit = async () => {
-    if (submitting) return
+    if (submitting || companyLoading) return
 
     const found = validate({ draft, company, businessNo, assigneeIds })
     setErrors(found)
@@ -166,20 +226,32 @@ export default function CustomerFormModal({
     setSubmitError(null)
 
     try {
-      const payload: CustomerContactCreateRequest = {
+      const fields: CustomerContactUpdateRequest = {
         company_id: await resolveCompanyId(company, businessNo, address),
         name: draft.name.trim(),
         department: optional(draft.dept),
         job_title: optional(draft.title),
         email: optional(draft.email),
         phone: draft.phone.trim(),
-        status_code: 'new',
         source_code: sourceCode === '' ? null : sourceCode,
         memo: optional(draft.memo),
         visited,
         // 팀원은 담당자를 고를 수 없습니다. 백엔드가 등록한 사람으로 채웁니다.
         ...(isManager ? { assignee_member_ids: assigneeIds } : {}),
       }
+
+      if (customer) {
+        const { data } = await client.patch<CustomerContactResponse>(
+          `/customer-contacts/${customer.id}`,
+          fields,
+        )
+        setSubmitting(false)
+        onUpdated?.(data)
+        return
+      }
+
+      // 상태는 등록할 때만 정해집니다. 수정 폼에는 상태 칸이 없습니다.
+      const payload: CustomerContactCreateRequest = { ...fields, status_code: 'new' }
       const { data } = await client.post<CustomerContactResponse>('/customer-contacts', payload)
       let warning: string | undefined
       if (archiveImage) {
@@ -197,7 +269,12 @@ export default function CustomerFormModal({
       setSubmitting(false)
       onCreated(data, warning)
     } catch (error: unknown) {
-      setSubmitError(errorMessage(error, '고객을 등록하지 못했습니다.'))
+      setSubmitError(
+        errorMessage(
+          error,
+          editing ? '고객 정보를 수정하지 못했습니다.' : '고객을 등록하지 못했습니다.',
+        ),
+      )
       setSubmitting(false)
     }
   }
@@ -208,7 +285,7 @@ export default function CustomerFormModal({
 
   return (
     <Modal
-      title="고객 등록"
+      title={editing ? '고객 수정' : '고객 등록'}
       onClose={close}
       onSubmit={submit}
       footer={
@@ -216,8 +293,8 @@ export default function CustomerFormModal({
           <Button type="button" variant="outline" disabled={submitting} onClick={close}>
             취소
           </Button>
-          <Button type="submit" disabled={submitting}>
-            {submitting ? '등록 중…' : '고객 등록'}
+          <Button type="submit" disabled={submitting || companyLoading}>
+            {editing ? (submitting ? '저장 중…' : '저장') : submitting ? '등록 중…' : '고객 등록'}
           </Button>
         </>
       }
@@ -241,7 +318,7 @@ export default function CustomerFormModal({
             value={company}
             onChange={pickCompany}
             allowCreate
-            disabled={submitting}
+            disabled={submitting || companyLoading}
             invalid={errors.company !== undefined}
           />
         </Field>

--- a/frontend/src/pages/Customers/components/TableToolbar/TableToolbar.module.scss
+++ b/frontend/src/pages/Customers/components/TableToolbar/TableToolbar.module.scss
@@ -33,7 +33,7 @@
   }
 }
 
-// 고객을 넣는 길들. 줄 끝에 붙어 다른 도구와 확실히 갈립니다.
+// 고객을 넣는 길. 줄 끝에 붙어 다른 도구와 확실히 갈립니다.
 .add {
   flex: none;
   display: flex;
@@ -47,33 +47,5 @@
   @include sm {
     margin-left: 0;
     padding-left: 0;
-  }
-}
-
-/*
- * 손이 아닌 다른 경로로 넣는 두 가지. 낱개로 띄우면 줄 끝이 비슷한 버튼 넷이 되어
- * 어디가 주된 길인지 사라집니다. 테두리 하나를 나눠 쓰게 붙여 한 덩어리로 읽힙니다.
- */
-.segment {
-  display: flex;
-
-  // Button 의 .root 와 클래스 수가 같으면 파일 순서가 승부를 가릅니다.
-  // 클래스를 겹쳐 우선순위를 한 단계 올려 두고 순서에 기대지 않습니다.
-  &#{&} > :first-child {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-  }
-
-  &#{&} > :last-child {
-    margin-left: -1px;
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-  }
-
-  // 겹쳐 둔 테두리 탓에 호버한 쪽의 파란 선이 옆 버튼에 가립니다.
-  > :hover,
-  > :focus-visible {
-    position: relative;
-    z-index: 1;
   }
 }

--- a/frontend/src/pages/Customers/components/TableToolbar/TableToolbar.tsx
+++ b/frontend/src/pages/Customers/components/TableToolbar/TableToolbar.tsx
@@ -1,13 +1,14 @@
 import { useState } from 'react'
 
 import Button from '@/components/Button'
-import { CardIcon, ColumnsIcon, DownloadIcon, PlusIcon, SheetIcon } from '@/components/icons'
+import { ColumnsIcon, DownloadIcon } from '@/components/icons'
 import Popover from '@/components/Popover'
 import SearchInput from '@/components/SearchInput'
 import { BP_PHONE } from '@/constants/breakpoints'
 import useMediaQuery from '@/hooks/useMediaQuery'
 
 import type { ColumnPrefs } from '../../useColumnPrefs'
+import AddCustomerMenu, { type AddCustomerWay } from '../AddCustomerMenu'
 import ColumnSettings from '../ColumnSettings'
 
 import styles from './TableToolbar.module.scss'
@@ -21,9 +22,8 @@ interface TableToolbarProps {
   onResetColumns: () => void
   /** 이 화면에서 아예 쓰지 않는 컬럼. 설정 목록에도 나오지 않습니다. */
   hiddenColumns?: string[]
-  onCreate: () => void
-  onImport: () => void
-  onScanCard: () => void
+  /** 고객을 넣는 길을 골랐습니다. 어느 화면을 띄울지는 부른 쪽이 정합니다. */
+  onAdd: (way: AddCustomerWay) => void
   onExport: () => void
   /** 내보낼 줄을 모으는 동안. 버튼이 두 번 눌리지 않게 막습니다. */
   exporting?: boolean
@@ -39,9 +39,7 @@ export default function TableToolbar({
   onMoveColumn,
   onResetColumns,
   hiddenColumns,
-  onCreate,
-  onImport,
-  onScanCard,
+  onAdd,
   onExport,
   exporting = false,
   canExport = true,
@@ -102,35 +100,11 @@ export default function TableToolbar({
       </div>
 
       {/*
-        고객을 넣는 세 갈래. 결과가 같은 일이라 한 덩어리로 묶고, 손으로 넣는 길만
-        기본 버튼으로 둡니다. 넷을 따로 띄우면 무엇이 주된 길인지 사라집니다.
+        고객을 넣는 네 갈래. 결과가 같은 일이라 버튼 하나로 모으고, 무엇으로 넣을지는
+        메뉴에서 고릅니다. 넷을 따로 띄우면 무엇이 주된 길인지 사라집니다.
       */}
       <div className={styles.add}>
-        <div className={styles.segment}>
-          <Button
-            variant="outline"
-            className={styles.foldLabel}
-            aria-label="명함으로 고객 등록"
-            onClick={onScanCard}
-          >
-            <CardIcon width={15} height={15} />
-            <span>명함 등록</span>
-          </Button>
-          <Button
-            variant="outline"
-            className={styles.foldLabel}
-            aria-label="엑셀로 고객 등록"
-            onClick={onImport}
-          >
-            <SheetIcon width={15} height={15} />
-            <span>엑셀 등록</span>
-          </Button>
-        </div>
-
-        <Button onClick={onCreate}>
-          <PlusIcon width={16} height={16} />
-          고객 등록
-        </Button>
+        <AddCustomerMenu onSelect={onAdd} />
       </div>
     </div>
   )

--- a/frontend/src/pages/Customers/contact.ts
+++ b/frontend/src/pages/Customers/contact.ts
@@ -33,6 +33,12 @@ function toSourceLabel(code: string | null): CustomerSource {
   return SOURCE_LABEL[code as CustomerSourceCode] ?? '미지정'
 }
 
+/** 수정 폼이 되돌려 쓸 코드입니다. 이 앱이 모르는 값은 미지정으로 둡니다. */
+function toSourceCode(code: string | null): CustomerSourceCode | null {
+  if (code === null) return null
+  return code in SOURCE_LABEL ? (code as CustomerSourceCode) : null
+}
+
 function toStatusLabel(code: string | null): CustomerStatus {
   if (code === null) return '미지정'
   return STATUS_LABEL[code as CustomerStatusCode] ?? '미지정'
@@ -49,6 +55,7 @@ export function toCustomer(contact: CustomerContactResponse): Customer {
     phone: contact.phone,
     owner: contact.owner_display_name,
     source: toSourceLabel(contact.source_code),
+    sourceCode: toSourceCode(contact.source_code),
     status: toStatusLabel(contact.status_code),
     memo: contact.memo ?? '',
     visited: contact.visited,

--- a/frontend/src/pages/Documents/catalog.ts
+++ b/frontend/src/pages/Documents/catalog.ts
@@ -3,10 +3,10 @@ import type { DocumentCategory, DocumentFileKind, DocumentVersion, SalesDocument
 export type CategoryTone = 'blue' | 'purple' | 'green' | 'orange' | 'gray'
 
 export const DOCUMENT_CATEGORIES: DocumentCategory[] = [
+  '견적서',
   '계약서',
   '발주서',
   '상품설명서',
-  '견적서',
   '기타',
 ]
 

--- a/frontend/src/types/customers.ts
+++ b/frontend/src/types/customers.ts
@@ -46,6 +46,8 @@ export interface Customer {
   companyId?: string
   ownerMemberId?: string
   regionCode?: string | null
+  /** 유입 경로의 원래 코드. source 는 사람이 읽는 라벨이라 수정 폼이 되돌려 쓸 수 없습니다. */
+  sourceCode?: CustomerSourceCode | null
   /** 담당자 전체. 첫 번째가 owner 와 같은 대표 담당자입니다. */
   owners?: CustomerOwner[]
 }
@@ -123,6 +125,12 @@ export interface CustomerContactCreateRequest {
   /** 팀장만 보낼 수 있습니다. 비우면 등록한 사람이 담당자가 됩니다. */
   assignee_member_ids?: string[]
 }
+
+/**
+ * 고객 수정. 등록과 같은 항목을 보내되 상태는 다루지 않습니다.
+ * 보낸 칸만 바뀌므로 화면이 늘 전부 채워 보냅니다.
+ */
+export type CustomerContactUpdateRequest = Omit<CustomerContactCreateRequest, 'status_code'>
 
 export interface PageResponse<T> {
   items: T[]


### PR DESCRIPTION
## 변경 요약

- **고객 삭제(백엔드).** 팀장만 지운다. 행은 남기고 `deleted_at` 만 채운다. `activity`·`sales_deal`·`sales_deal_participant` 가 `ON DELETE` 옵션 없이 `customer_contact` 를 참조해 실제 `DELETE` 는 외래키에 막히고, 참조를 먼저 끊으면 지난 딜과 일정에서 누구를 만났는지가 사라진다. 역할은 쿼리보다 먼저 봐서 팀원이 남의 팀 고객 id 를 넣어도 404 대신 403 을 받는다.
- **고르는 자리는 살아 있는 고객만 본다.** 목록·상세, 일정·딜의 고객 선택, 딜 참석자, 자료 연결, 명함 원본 보관, 명함 중복 후보. 이미 연결된 것을 보여 주는 자리는 거르지 않아 지난 기록이 그대로 남는다.
- **고객 수정·삭제 화면.** 상세 드로어에 메뉴를 달았다. 삭제는 팀장에게만 보이고 실제로 막는 일은 백엔드가 다시 한다. 수정 폼은 등록 폼을 그대로 쓰되 상태만 다루지 않는다 — 상태를 바꾸는 화면이 아직 없어 여기서 새로 만들지 않았다.
- **사업자등록증 등록 경로.** 고객을 넣는 길이 넷이 되면서 툴바 버튼을 등록 메뉴 하나로 모았다.
- **자료 분류 순서.** 가장 자주 고르는 `견적서` 를 목록 맨 앞으로 옮겼다.

## 검증

- `pytest` — 943 passed, 7 skipped, **1 failed**. 실패한 `test_legacy_report_deal_migration_only_clears_ambiguous_links` 는 이 PR과 무관하다. 공유 개발 DB에 붙는 테스트이고 pgbouncer 의 prepared statement 오류로 떨어진다. `origin/develop` 을 별도 worktree 로 받아 같은 테스트를 돌려도 똑같이 실패하는 것을 확인했다.
- `tsc -b --noEmit` 통과.
- `oxlint` 통과.
- `prettier --check src` 통과.
- `npm test` — 51 passed, 0 failed.
- SQL 마이그레이션은 **어느 DB에도 적용하지 않았다.** 적용 이력 표에 `대기` 로만 적었다.

## 영향 및 주의 사항

- **마이그레이션 적용이 필요하다.** `backend/sql/20260903_0021_customer_contact_soft_delete.sql` 를 적용해야 `deleted_at` 이 생긴다. 적용 전에는 고객 목록 조회부터 실패한다. 기존 행은 전부 `NULL`(살아 있음)이라 백필은 없다.
- 작업 중 `#111` 이 머지되며 `0019`·`0020` 번호가 이미 차서, 이 PR의 마이그레이션은 `0021` 로 붙였다.
- **사업자등록증 경로에는 아직 백엔드가 없다.** `extractBusinessLicense` 가 걸리는 시간만 흉내 내고 빈 초안을 돌려준다. 그럴듯한 가짜 값으로 오해하게 하는 것보다 낫다고 보고, 사람이 등록 폼에서 채우게 두었다. 다만 등록 메뉴 항목은 사용자에게 그대로 보이므로, OCR 이 붙기 전까지 노출할지는 확인이 필요하다. 서버가 생기면 `frontend/src/pages/Customers/businessLicense.ts` 한 곳만 고치면 된다.
- 지운 고객이 이미 걸려 있던 일정·딜에서는 계속 보인다. 의도한 동작이다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 고객 정보를 수정하고 삭제할 수 있습니다. 삭제는 관리자 권한이 필요하며 복구 가능한 방식으로 처리됩니다.
  * 고객 등록 메뉴에서 명함, 사업자등록증, 엑셀, 직접 입력 방식을 선택할 수 있습니다.
  * 사업자등록증 PDF를 업로드해 회사명, 사업자번호, 주소를 등록 폼에 반영할 수 있습니다.
  * 고객 목록에서 수정·삭제 결과와 오류를 즉시 확인할 수 있습니다.

* **개선**
  * 삭제된 고객은 목록과 신규 일정·딜·자료 연결 대상에서 제외됩니다.
  * 고객 유입 경로 정보가 고객 데이터에 표시됩니다.

* **문서**
  * 고객 삭제 및 데이터베이스 변경 사항을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->