### PR TITLE
끝나지 않은 C/S 를 상태와 무관하게 위험 신호로 본다

### DIFF
--- a/backend/app/services/contract_schedule_snapshots.py
+++ b/backend/app/services/contract_schedule_snapshots.py
@@ -44,6 +44,10 @@ _DEFAULT_PREFERRED_WINDOW_DAYS = 7
 _MIN_PREFERRED_WINDOW_DAYS = _DEFAULT_PREFERRED_WINDOW_DAYS
 # 자료실 검색 API 의 q 상한과 맞춘다.
 _BRIEFING_QUERY_MAX_CHARS = 500
+# C/S 상태는 received·diagnosing·in_progress·completed 네 가지고(app/schemas/support.py),
+# 끝난 것은 completed 뿐이다. in_progress 만 보면 접수·원인파악 단계의 미해결 요청이
+# 위험 신호에서 통째로 빠진다.
+_OPEN_SUPPORT_STATUSES = ("received", "diagnosing", "in_progress")
 # 청크 하나가 최대 1,600자라 5건이면 문맥 블록 상한(12,000자) 안에 든다.
 _BRIEFING_DOCUMENT_LIMIT = 5
 
@@ -173,12 +177,12 @@ async def _deal_ids_with_upcoming_activity(
 async def _unresolved_support_signals(
     db: AsyncSession, member: Member, customer_company_id: UUID
 ) -> list[dict[str, Any]]:
-    """이 회사에 걸린, 아직 처리 중인 C/S 요청."""
+    """이 회사에 걸린, 아직 끝나지 않은 C/S 요청."""
     result = await db.execute(
         select(SupportRequest).where(
             SupportRequest.team_id == member.team_id,
             SupportRequest.customer_company_id == customer_company_id,
-            SupportRequest.status_code == "in_progress",
+            SupportRequest.status_code.in_(_OPEN_SUPPORT_STATUSES),
         )
     )
     signals: list[dict[str, Any]] = []

--- a/backend/tests/test_contract_schedule_snapshots.py
+++ b/backend/tests/test_contract_schedule_snapshots.py
@@ -397,6 +397,24 @@ async def test_recent_finalized_reports_are_linked_by_report_deal():
 
 
 @pytest.mark.anyio
+async def test_unresolved_support_signals_cover_every_open_status():
+    """끝나지 않은 C/S 는 상태와 무관하게 모두 위험 신호가 된다.
+
+    in_progress 만 조회하면 접수(received)·원인파악(diagnosing) 단계의 요청이 통째로 빠져,
+    브리핑과 다음 미팅 제안 양쪽에서 그 위험이 보이지 않는다.
+    """
+    member = _member()
+    company_id = uuid4()
+    db = _Db(_Result(scalar_values=[]))
+
+    await snapshots._unresolved_support_signals(db, member, company_id)
+
+    params = list(db.statements[0].compile().params.values())
+    assert ["received", "diagnosing", "in_progress"] in params
+    assert "completed" not in str(db.statements[0].compile().params)
+
+
+@pytest.mark.anyio
 async def test_recent_finalized_reports_limits_reports_before_joining_deal_sections():
     """한 보고서의 여러 딜 섹션이 최근 보고서 5건 제한을 잠식하지 않는다."""
     member = _member()


### PR DESCRIPTION
## 변경 요약

- 위험 신호 조회가 `in_progress` 상태의 C/S 만 보고 있어, 접수(`received`)·원인파악(`diagnosing`) 단계의 미해결 요청이 빠졌습니다. 끝난 상태는 `completed` 뿐입니다.
- 열린 세 상태를 `_OPEN_SUPPORT_STATUSES` 상수로 묶어 조회합니다. `SupportStatus` 가 닫힌 `Literal` 이라 새 상태를 더할 때 이 상수도 함께 고쳐야 하는 점을 주석으로 남겼습니다.
- docstring 을 "아직 처리 중인" → "아직 끝나지 않은" 으로 고쳤습니다. 원래 문구가 `in_progress` 만 뜻하는 것처럼 읽혀 이번 누락을 부른 표현입니다.

PR #130 의 CodeRabbit 지적(🟠 Major, `contract_schedule_snapshots.py:173`)을 처리합니다. 그 PR 범위 밖이라 분리했습니다.

## 검증

CI 와 동일한 환경변수로 실행했습니다. `APP_ENV=test DEBUG=false CORS_ORIGINS=http://testserver`

| 검사 | 결과 |
|---|---|
| `uv run ruff check .` | All checks passed |
| `uv run ruff format --check .` | 203 files already formatted |
| `uv run pytest` | **1162 passed, 8 skipped** |

두 에이전트를 함께 검증했습니다 — `test_contract_schedule_snapshots.py`, `test_contract_management.py`, `test_contract_next_meeting_pipeline.py`, `test_support.py` 82건 통과.

기존 테스트의 가짜 DB 는 `WHERE` 절을 무시하므로 끝단 결과만 보는 테스트로는 필터 변경을 잡을 수 없습니다. 쿼리 자체를 검증하는 회귀 테스트를 추가했고, 수정을 되돌려 실제로 실패하는 것을 확인했습니다.

```
E  AssertionError: assert ['received', 'diagnosing', 'in_progress'] in [UUID(...), UUID(...), 'in_progress']
```

## 영향 및 주의 사항

이 헬퍼는 **두 에이전트가 공유**하므로 양쪽 동작이 함께 바뀝니다.

- **계약 브리핑**: 접수·원인파악 상태의 C/S 가 `risks` 에 나타납니다.
- **다음 미팅 제안**: 같은 신호가 늘어 딜 선별 우선순위가 바뀔 수 있습니다.

원래 보여야 했던 위험이 보이는 방향이고, 신호가 늘어날 뿐 없어지지 않습니다.

대시보드의 "처리중" 건수(`api/dashboard.py:181`)에도 같은 리터럴이 있지만 뜻이 다른 집계라 그대로 두었습니다. 여기를 바꾸면 화면 숫자가 달라집니다.

## 관련 이슈

- PR #130 의 CodeRabbit 지적 후속

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 고객지원 위험 신호 수집이 접수, 원인 파악, 진행 중 상태의 미해결 요청을 모두 포함하도록 수정되었습니다.
  * 완료된 요청은 위험 신호 대상에서 제외됩니다.

* **테스트**
  * 각 미해결 상태가 올바르게 포함되고 완료 상태가 제외되는지 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->