### PR TITLE
문서 메모 입력 및 매출 그룹 상세 기능 추가

### DIFF
--- a/frontend/src/pages/Documents/components/DocumentEditModal/DocumentEditModal.tsx
+++ b/frontend/src/pages/Documents/components/DocumentEditModal/DocumentEditModal.tsx
@@ -175,9 +175,10 @@ export default function DocumentEditModal({ doc, submitting = false, onClose, on
         )}
 
         <Field label="메모" wide>
-          <input
+          <textarea
+            rows={3}
             value={description}
-            placeholder="목록에서 이 자료가 무엇인지 알아볼 한 줄"
+            placeholder="목록에서 이 자료가 무엇인지 알아볼 메모"
             onChange={(event) => setDescription(event.target.value)}
           />
         </Field>

--- a/frontend/src/pages/Documents/components/UploadModal/UploadModal.tsx
+++ b/frontend/src/pages/Documents/components/UploadModal/UploadModal.tsx
@@ -241,9 +241,10 @@ export default function UploadModal({ submitting = false, onClose, onSubmit }: P
         </Field>
 
         <Field label="메모" wide>
-          <input
+          <textarea
+            rows={3}
             value={description}
-            placeholder="목록에서 이 자료가 무엇인지 알아볼 한 줄"
+            placeholder="목록에서 이 자료가 무엇인지 알아볼 메모"
             onChange={(event) => setDescription(event.target.value)}
           />
         </Field>

--- a/frontend/src/pages/Sales/Sales.module.scss
+++ b/frontend/src/pages/Sales/Sales.module.scss
@@ -21,14 +21,9 @@
   gap: var(--s4);
   align-items: start;
 
-  // 두 칸이 나란히 서기 어려워지면 매출 패널을 위로 올립니다.
-  // 좁은 화면에서는 "얼마 닫혔나"가 계약 목록보다 먼저 읽혀야 합니다.
+  // 태블릿·모바일에서는 DOM 순서를 유지해 계약 리스트를 먼저 보여 줍니다.
   @include lg {
     grid-template-columns: minmax(0, 1fr);
-
-    > :last-child {
-      order: -1;
-    }
   }
 }
 

--- a/frontend/src/pages/Sales/Sales.tsx
+++ b/frontend/src/pages/Sales/Sales.tsx
@@ -1,10 +1,12 @@
 // 매출 분석 한 화면. 위에 기간 줄, 아래 좌우 두 칸입니다.
 // 왼쪽은 계약을 묶어 접은 리스트, 오른쪽은 같은 묶음의 매출·추세·구성입니다.
+import { useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router'
 
 import ErrorToast from '@/components/ErrorToast'
 import Skeleton from '@/components/Skeleton'
 import useSalesDeals from '@/pages/Deals/useSalesDeals'
+import { useScopeKey } from '@/shared/scope'
 
 import { downloadCsv, toCsv } from '@/utils/csv'
 
@@ -29,9 +31,11 @@ import styles from './Sales.module.scss'
 
 export default function Sales() {
   const [params, setParams] = useSearchParams()
+  const [selection, setSelection] = useState<{ context: string; key: string } | null>(null)
   const type = toPeriodType(params.get('tab'))
   const offset = toOffset(params.get('o'))
   const by = toGroupBy(params.get('by'))
+  const scopeKey = useScopeKey()
 
   const range = resolveRange(type, offset)
 
@@ -39,6 +43,20 @@ export default function Sales() {
   // 좌우 두 칸이 같은 축을 봅니다. 탭을 바꾸면 표와 패널이 함께 움직입니다.
   const grouped = useSalesSummary(cards, type, offset, by)
   const trend = useSalesTrend(cards, type, offset)
+  // 이전 기간·그룹 기준·팀원 범위에서 고른 항목은 새 데이터와 같은 이름이어도 다른
+  // 대상입니다. 이전 범위로 다시 돌아와도 옛 선택이 살아나지 않게 실제로 비웁니다.
+  const selectionContext = `${type}:${offset}:${by}:${scopeKey}`
+  useEffect(() => {
+    setSelection(null)
+  }, [selectionContext])
+  const selectedGroup =
+    selection?.context === selectionContext
+      ? (grouped.groups.find((group) => group.key === selection.key) ?? null)
+      : null
+
+  const selectGroup = (key: string | null) => {
+    setSelection(key === null ? null : { context: selectionContext, key })
+  }
 
   /** 기간 탭을 바꾸면 이동량은 의미가 달라지므로 현재 기간으로 되돌립니다. */
   const setType = (next: PeriodType) => {
@@ -125,12 +143,16 @@ export default function Sales() {
           <GroupTable
             by={by}
             onByChange={(next: GroupBy) => setParam('by', next, next === 'org')}
+            onSelectGroup={selectGroup}
+            selectedGroupKey={selectedGroup?.key ?? null}
             summary={grouped}
           />
           <RevenuePanel
             range={range}
             summary={grouped}
             by={by}
+            onSelectGroup={selectGroup}
+            selectedGroup={selectedGroup}
             trend={trend}
             trendCaption={trendCaption(type)}
           />

--- a/frontend/src/pages/Sales/components/GroupTable/GroupTable.module.scss
+++ b/frontend/src/pages/Sales/components/GroupTable/GroupTable.module.scss
@@ -47,7 +47,7 @@ $cols: minmax(0, 1fr) 56px 130px 60px;
   border-top: 1px solid var(--line);
 }
 
-/* 그룹 한 줄 전체가 펼침 버튼입니다. */
+/* 그룹 이름을 누르면 담당자 분석을 열고, 화살표는 계약 목록만 펼칩니다. */
 .row {
   display: grid;
   grid-template-columns: $cols;
@@ -55,64 +55,66 @@ $cols: minmax(0, 1fr) 56px 130px 60px;
   gap: var(--s2);
   width: 100%;
   padding: var(--s3);
-  border: 0;
   border-radius: var(--r-sm);
   background: transparent;
-  text-align: left;
-  cursor: pointer;
   transition: background var(--t-fast);
 
   &:hover {
     background: var(--fill-2);
   }
-
-  // 행 전체가 버튼이라 누를 때 줄어들면 표가 출렁입니다.
-  &:active {
-    transform: none;
-  }
 }
 
-/* 첫 칸. 묶음 이름 아래에 담당자 줄이 한 단 더 붙습니다. */
+.isSelected {
+  background: var(--blue-tint);
+}
+
+/* 첫 칸은 그룹 선택과 계약 펼치기라는 서로 다른 행동을 나눕니다. */
 .nameCell {
   display: flex;
-  flex-direction: column;
-  gap: 3px;
+  align-items: center;
   min-width: 0;
 }
 
-.name {
+.groupSelect {
   display: inline-flex;
   align-items: center;
   gap: var(--s1);
   min-width: 0;
+  overflow: hidden;
+  padding: 0;
+  border: 0;
+  background: transparent;
   font-size: 14px;
   font-weight: 600;
-}
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
 
-/* 이 묶음을 누가 얼마나 세웠는지. 이름표는 다른 화면과 같은 색을 씁니다.
-   묶음 이름의 글머리(캐럿+색점)만큼 들여써서 이름 아래에 나란히 섭니다. */
-.groupOwners {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--s1);
-  padding-left: 24px;
-  color: var(--muted);
-  font-size: 11px;
-
-  i {
-    font-style: normal;
+  &:hover,
+  &:focus-visible {
+    color: var(--blue);
   }
 }
 
-.groupOwner {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
-  min-width: 0;
+.disclosure {
+  display: grid;
+  flex: none;
+  width: 24px;
+  height: 24px;
+  margin-left: auto;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-xs);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
 
-  b {
-    font-weight: 600;
+  &:hover,
+  &:focus-visible {
+    background: var(--surface);
+    color: var(--blue);
   }
 }
 
@@ -123,7 +125,7 @@ $cols: minmax(0, 1fr) 56px 130px 60px;
   transition: transform var(--t-fast) var(--ease-out);
 }
 
-.isOpen .caret {
+.disclosure.isOpen .caret {
   transform: rotate(0deg);
   color: var(--blue);
 }

--- a/frontend/src/pages/Sales/components/GroupTable/GroupTable.tsx
+++ b/frontend/src/pages/Sales/components/GroupTable/GroupTable.tsx
@@ -7,9 +7,8 @@ import { ChevronDownIcon } from '@/components/icons'
 import OwnerName from '@/components/OwnerName'
 import Tabs from '@/components/Tabs'
 import type { SalesDeal } from '@/pages/Deals/useSalesDeals'
-import { useShowOwner } from '@/shared/scope'
 import { fmtDotShort, parseISO } from '@/utils/date'
-import { won, wonFull } from '@/utils/format'
+import { wonFull } from '@/utils/format'
 
 import { GROUP_BYS, GROUP_HEADER, GROUP_LABEL, type GroupBy } from '../../periods'
 import { colorOf } from '../../slices'
@@ -20,6 +19,8 @@ import styles from './GroupTable.module.scss'
 interface GroupTableProps {
   by: GroupBy
   onByChange: (next: GroupBy) => void
+  onSelectGroup: (key: string) => void
+  selectedGroupKey: string | null
   summary: SalesSummary
 }
 
@@ -33,40 +34,7 @@ function StatusBadge({ status }: { status: SalesDeal['status'] }) {
   )
 }
 
-/** 접힌 줄에 세울 담당자 수. 넘치면 +N 으로 접습니다. */
-const OWNER_CHIPS = 3
-
-/**
- * 이 묶음을 누가 얼마나 세웠는지. 펼치지 않고도 읽히게 접힌 줄에 붙입니다.
- *
- * 금액까지 함께 답니다. 이름만 세우면 세 사람이 나눠 가진 줄과 한 사람이 거의 다
- * 세운 줄이 똑같아 보입니다.
- */
-function GroupOwners({ owners }: { owners: SalesGroup['owners'] }) {
-  if (owners.length === 0) return null
-
-  return (
-    <span className={styles.groupOwners}>
-      {owners.slice(0, OWNER_CHIPS).map((share) => (
-        <span key={share.memberId} className={styles.groupOwner}>
-          <OwnerName name={share.name} memberId={share.memberId} />
-          <b className="tnum">{won(share.actual)}</b>
-        </span>
-      ))}
-      {owners.length > OWNER_CHIPS && <i>+{owners.length - OWNER_CHIPS}</i>}
-    </span>
-  )
-}
-
-function ContractRows({
-  group,
-  by,
-  showOwner,
-}: {
-  group: SalesGroup
-  by: GroupBy
-  showOwner: boolean
-}) {
+function ContractRows({ group, by }: { group: SalesGroup; by: GroupBy }) {
   if (group.contracts.length === 0) {
     return <p className={styles.none}>이 기간에 등록된 계약이 없습니다.</p>
   }
@@ -81,7 +49,7 @@ function ContractRows({
             {by === 'product' ? c.org : c.product}
             <small className={styles.dealMeta}>
               {c.kind}
-              {showOwner && <OwnerName name={c.owner} memberId={c.ownerMemberId} />}
+              <OwnerName name={c.owner} memberId={c.ownerMemberId} />
             </small>
           </span>
           <StatusBadge status={c.status} />
@@ -95,10 +63,15 @@ function ContractRows({
   )
 }
 
-export default function GroupTable({ by, onByChange, summary }: GroupTableProps) {
+export default function GroupTable({
+  by,
+  onByChange,
+  onSelectGroup,
+  selectedGroupKey,
+  summary,
+}: GroupTableProps) {
   // 회사 키와 지역 키가 섞이지 않게 탭을 바꾸면 펼침을 접습니다.
   const [openKeys, setOpenKeys] = useState<Set<string>>(new Set())
-  const showOwner = useShowOwner()
 
   const toggle = (key: string) => {
     const next = new Set(openKeys)
@@ -143,22 +116,30 @@ export default function GroupTable({ by, onByChange, summary }: GroupTableProps)
           // 오른쪽 패널과 같은 규칙으로 색을 뽑습니다. 한 줄과 한 조각이 같은 색이어야
           // 두 패널을 눈으로 이을 수 있습니다.
           const color = colorOf(index, group.actual)
+          const selected = group.key === selectedGroupKey
 
           return (
             <li key={group.key}>
-              <button
-                type="button"
-                className={`${styles.row} ${open ? styles.isOpen : ''}`}
-                aria-expanded={open}
-                onClick={() => toggle(group.key)}
-              >
+              <div className={`${styles.row} ${selected ? styles.isSelected : ''}`}>
                 <span className={styles.nameCell}>
-                  <span className={styles.name}>
-                    <ChevronDownIcon className={styles.caret} width={14} height={14} />
+                  <button
+                    type="button"
+                    className={styles.groupSelect}
+                    aria-pressed={selected}
+                    onClick={() => onSelectGroup(group.key)}
+                  >
                     <i className={styles.swatch} style={{ background: color }} />
                     {group.key}
-                  </span>
-                  {showOwner && <GroupOwners owners={group.owners} />}
+                  </button>
+                  <button
+                    type="button"
+                    className={`${styles.disclosure} ${open ? styles.isOpen : ''}`}
+                    aria-expanded={open}
+                    aria-label={`${group.key} 계약 ${open ? '접기' : '펼치기'}`}
+                    onClick={() => toggle(group.key)}
+                  >
+                    <ChevronDownIcon className={styles.caret} width={14} height={14} />
+                  </button>
                 </span>
                 <span className={`${styles.count} tnum`}>{group.contracts.length}건</span>
                 <span className={`${styles.amount} tnum`}>{wonFull(group.actual)}</span>
@@ -166,9 +147,9 @@ export default function GroupTable({ by, onByChange, summary }: GroupTableProps)
                   {group.share.toFixed(1)}%
                   <i style={{ background: color, transform: `scaleX(${group.share / 100})` }} />
                 </span>
-              </button>
+              </div>
 
-              {open && <ContractRows group={group} by={by} showOwner={showOwner} />}
+              {open && <ContractRows group={group} by={by} />}
             </li>
           )
         })}

--- a/frontend/src/pages/Sales/components/RevenuePanel/RevenuePanel.module.scss
+++ b/frontend/src/pages/Sales/components/RevenuePanel/RevenuePanel.module.scss
@@ -170,10 +170,22 @@
   height: 6px;
   overflow: hidden;
   border-radius: var(--r-pill);
+}
 
-  span {
-    flex-basis: 0;
-    min-width: 2px;
+.ribbonSlice {
+  flex-basis: 0;
+  min-width: 2px;
+  padding: 0;
+  border: 0;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid var(--ink);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    cursor: default;
   }
 }
 
@@ -181,27 +193,62 @@
   display: flex;
   flex-direction: column;
   gap: var(--s3);
+}
 
-  li {
-    display: grid;
-    grid-template-columns: 9px minmax(0, 1fr) minmax(48px, 88px) auto 46px;
-    align-items: center;
-    gap: var(--s2);
-    font-size: 13px;
-  }
+.rankButton,
+.rankStatic {
+  display: grid;
+  grid-template-columns: 9px minmax(0, 1fr) minmax(48px, 88px) auto 46px;
+  align-items: center;
+  gap: var(--s2);
+  width: 100%;
+  padding: var(--s1);
+  border: 0;
+  border-radius: var(--r-xs);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
 
-  > li > i {
+  > i {
     width: 9px;
     height: 9px;
     border-radius: 3px;
   }
 }
 
+.rankButton {
+  cursor: pointer;
+
+  &:hover,
+  &:focus-visible,
+  &.isSelected {
+    background: var(--blue-tint);
+  }
+
+  &:disabled {
+    cursor: default;
+  }
+}
+
 .rankName {
+  display: block;
   overflow: hidden;
+  min-width: 0;
   font-weight: 600;
   white-space: nowrap;
   text-overflow: ellipsis;
+
+  b {
+    display: block;
+  }
+
+  small {
+    display: block;
+    margin-top: 2px;
+    color: var(--muted);
+    font-size: 10px;
+  }
 }
 
 /* 1등이 꽉 찬 막대입니다. 폭 대신 scaleX 로 늘려 리플로우 없이 움직입니다. */
@@ -234,20 +281,44 @@
 
 /* ── 담당자별 ─────────────────────────────────────── */
 
-/* 위 구성과 같은 모양의 목록이라 실선으로 갈라 둡니다. 붙어 있으면 회사 목록이
-   그대로 이어지는 것처럼 읽힙니다. */
+/* 선택한 그룹의 담당자 상세입니다. */
 .owners {
   display: flex;
   flex-direction: column;
-  gap: var(--s3);
-  padding-top: var(--s5);
-  border-top: 1px solid var(--line);
+  gap: var(--s4);
 }
 
 .ownersCaption {
   color: var(--muted);
   font-size: 11px;
   font-weight: 600;
+}
+
+/* 전체 차트의 맥락을 유지한 채 선택한 항목의 담당자 구성을 이어 보여 줍니다. */
+.breakdown {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s4);
+  padding-top: var(--s5);
+  border-top: 1px solid var(--line);
+}
+
+.breakdownHead {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: var(--s3);
+
+  h3 {
+    font-size: 14px;
+    font-weight: 700;
+  }
+
+  p {
+    margin-top: 3px;
+    color: var(--muted);
+    font-size: 11px;
+  }
 }
 
 .empty {

--- a/frontend/src/pages/Sales/components/RevenuePanel/RevenuePanel.tsx
+++ b/frontend/src/pages/Sales/components/RevenuePanel/RevenuePanel.tsx
@@ -2,13 +2,13 @@
 //
 // 왼쪽 표의 탭(회사별·지역별·상품별)을 그대로 따라갑니다. 같은 화면에서 왼쪽은
 // 지역을 말하는데 오른쪽만 회사를 말하면, 색이 같은 줄이 서로 다른 것을 가리킵니다.
+import Button from '@/components/Button'
 import { useOwnerColor } from '@/shared/ownerColors'
-import { useShowOwner } from '@/shared/scope'
 import { won, wonFull } from '@/utils/format'
 
 import { GROUP_LABEL, type GroupBy, type Range } from '../../periods'
-import { REST_COLOR, toSlices } from '../../slices'
-import { pct, type OwnerShare, type SalesSummary } from '../../useSalesSummary'
+import { REST_COLOR, toSlices, type Slice } from '../../slices'
+import { pct, type OwnerShare, type SalesGroup, type SalesSummary } from '../../useSalesSummary'
 import type { TrendPoint } from '../../useSalesTrend'
 
 import styles from './RevenuePanel.module.scss'
@@ -17,6 +17,8 @@ interface RevenuePanelProps {
   range: Range
   summary: SalesSummary
   by: GroupBy
+  onSelectGroup: (key: string | null) => void
+  selectedGroup: SalesGroup | null
   trend: TrendPoint[]
   trendCaption: string
 }
@@ -71,9 +73,12 @@ function OwnerRank({ share, top, total }: { share: OwnerShare; top: number; tota
   const color = useOwnerColor(share.memberId) ?? REST_COLOR
 
   return (
-    <li>
+    <li className={styles.rankStatic}>
       <i style={{ background: color }} />
-      <span className={styles.rankName}>{share.name}</span>
+      <span className={styles.rankName}>
+        <b>{share.name}</b>
+        <small>계약 {share.count}건</small>
+      </span>
       <span className={styles.rankBar}>
         <b
           style={{ background: color, transform: `scaleX(${top > 0 ? share.actual / top : 0})` }}
@@ -85,11 +90,49 @@ function OwnerRank({ share, top, total }: { share: OwnerShare; top: number; tota
   )
 }
 
+function GroupRank({
+  slice,
+  top,
+  total,
+  selected,
+  onSelect,
+}: {
+  slice: Slice
+  top: number
+  total: number
+  selected: boolean
+  onSelect: (() => void) | undefined
+}) {
+  const selectable = onSelect !== undefined
+
+  return (
+    <li>
+      <button
+        type="button"
+        className={`${styles.rankButton} ${selected ? styles.isSelected : ''}`}
+        aria-pressed={selectable ? selected : undefined}
+        aria-label={
+          selectable
+            ? `${slice.key} 담당자별 매출 보기`
+            : `${slice.key}는 개별 항목으로 나눠 볼 수 없습니다`
+        }
+        disabled={!selectable}
+        onClick={onSelect}
+      >
+        <i style={{ background: slice.color }} />
+        <span className={styles.rankName}>{slice.key}</span>
+        <span className={styles.rankBar}>
+          <b style={{ background: slice.color, transform: `scaleX(${slice.value / top})` }} />
+        </span>
+        <span className={`${styles.rankAmount} tnum`}>{won(slice.value)}</span>
+        <span className={`${styles.rankShare} tnum`}>{pct(slice.value, total).toFixed(1)}%</span>
+      </button>
+    </li>
+  )
+}
+
 /**
- * 이 기간을 누가 얼마나 세웠는지.
- *
- * 위의 리본·순위는 회사·지역·상품을 말하므로 소제목으로 갈라 둡니다. 소제목이 없으면
- * 같은 모양의 목록 두 개가 이어 붙어 아래쪽도 회사 이름인 줄 알고 읽게 됩니다.
+ * 선택한 회사·지역·상품이 어떤 담당자 실적으로 구성됐는지 보여 줍니다.
  */
 function OwnerRanks({ owners, total }: { owners: OwnerShare[]; total: number }) {
   const top = Math.max(...owners.map((share) => share.actual), 0)
@@ -110,11 +153,12 @@ export default function RevenuePanel({
   range,
   summary,
   by,
+  onSelectGroup,
+  selectedGroup,
   trend,
   trendCaption,
 }: RevenuePanelProps) {
   const { totals, delta, prevActual } = summary
-  const showOwner = useShowOwner()
   const slices = toSlices(summary.groups)
   // 순위 막대는 제일 큰 몫을 꽉 채웁니다. 합계 대비로 그리면 상위 몇 곳만 보이고
   // 나머지는 실오라기가 되어, 4등과 5등의 차이를 눈으로 못 잡습니다.
@@ -146,7 +190,9 @@ export default function RevenuePanel({
           <span className="tnum">계약 {totals.count}건</span>
           {/* 목표가 들어오면 달성률이 여기 붙습니다. 아직 아무도 목표를 정하지 않았고,
               정한 적 없는 값의 부재를 화면에서 가장 좋은 자리로 알릴 이유는 없습니다. */}
-          {totals.target > 0 && <span className="tnum">목표 대비 {totals.rate.toFixed(1)}%</span>}
+          {totals.target > 0 && (
+            <span className="tnum">목표 대비 {totals.rate.toFixed(1)}%</span>
+          )}
         </p>
       </header>
 
@@ -157,37 +203,70 @@ export default function RevenuePanel({
         // 추세와 갈라 놓아야, 어느 쪽에 붙은 그림인지 헷갈리지 않습니다.
         <div className={styles.mix}>
           {/* 구성 리본. 이름은 아래 순위 줄이 이미 말하므로 범례를 따로 두지 않습니다. */}
-          <div className={styles.ribbon} aria-hidden>
+          <div
+            className={styles.ribbon}
+            role="group"
+            aria-label={`${GROUP_LABEL[by]}별 매출 구성`}
+          >
             {slices.map((s) => (
-              <span key={s.key} style={{ flexGrow: s.value, background: s.color }} title={s.key} />
+              <button
+                key={s.key}
+                type="button"
+                className={styles.ribbonSlice}
+                aria-label={
+                  s.count === 1
+                    ? `${s.key} 담당자별 매출 보기`
+                    : `${s.key}는 개별 항목으로 나눠 볼 수 없습니다`
+                }
+                disabled={s.count !== 1}
+                style={{ flexGrow: s.value, background: s.color }}
+                onClick={s.count === 1 ? () => onSelectGroup(s.key) : undefined}
+              />
             ))}
           </div>
 
           <ul className={styles.ranks}>
             {slices.map((s) => (
-              <li key={s.key}>
-                <i style={{ background: s.color }} />
-                <span className={styles.rankName}>{s.key}</span>
-                <span className={styles.rankBar}>
-                  <b style={{ background: s.color, transform: `scaleX(${s.value / top})` }} />
-                </span>
-                <span className={`${styles.rankAmount} tnum`}>{won(s.value)}</span>
-                <span className={`${styles.rankShare} tnum`}>
-                  {pct(s.value, totals.actual).toFixed(1)}%
-                </span>
-              </li>
+              <GroupRank
+                key={s.key}
+                slice={s}
+                top={top}
+                total={totals.actual}
+                selected={selectedGroup?.key === s.key}
+                onSelect={s.count === 1 ? () => onSelectGroup(s.key) : undefined}
+              />
             ))}
           </ul>
         </div>
       )}
 
-      {showOwner && totals.actual > 0 && (
-        <OwnerRanks owners={summary.owners} total={totals.actual} />
-      )}
-
       {/* 이 기간을 먼저 읽고, 그 다음에 지난 기간과 견줍니다. 이 기간이 0원이어도
-          막대는 남깁니다. 비어 있다는 사실이야말로 앞뒤와 견줘야 읽히기 때문입니다. */}
+          막대는 남깁니다. 비어 있다는 사실이야말로 앞뒤와 견줘야 읽기 때문입니다. */}
       {trendMax > 0 && <TrendBars points={trend} caption={trendCaption} />}
+
+      {/* 전체 비교를 유지한 채, 고른 항목이 어떤 담당자 실적으로 만들어졌는지 아래에
+          붙입니다. 차트를 갈아 끼우면 비교 기준을 잃으므로 상세는 보완 정보입니다. */}
+      {selectedGroup !== null && (
+        <section className={styles.breakdown} aria-labelledby="selected-group-breakdown">
+          <div className={styles.breakdownHead}>
+            <div>
+              <h3 id="selected-group-breakdown">{selectedGroup.key} 매출 구성</h3>
+              <p>
+                계약 {selectedGroup.contracts.length}건 · 담당자 {selectedGroup.owners.length}명
+              </p>
+            </div>
+            <Button variant="outline" size="sm" onClick={() => onSelectGroup(null)}>
+              상세 닫기
+            </Button>
+          </div>
+
+          {selectedGroup.actual === 0 ? (
+            <p className={styles.empty}>이 항목에는 확정된 매출이 없습니다.</p>
+          ) : (
+            <OwnerRanks owners={selectedGroup.owners} total={selectedGroup.actual} />
+          )}
+        </section>
+      )}
     </section>
   )
 }

--- a/frontend/src/pages/Sales/useSalesSummary.ts
+++ b/frontend/src/pages/Sales/useSalesSummary.ts
@@ -4,7 +4,7 @@ import type { SalesDeal } from '@/pages/Deals/useSalesDeals'
 
 import { prevRange, resolveRange, type GroupBy, type PeriodType } from './periods'
 
-/** 한 사람이 이 묶음에서 세운 매출. 팀장이 여러 명을 함께 볼 때만 화면에 섭니다. */
+/** 한 사람이 이 묶음에서 세운 매출. 선택한 그룹의 담당자 상세가 이 값을 씁니다. */
 export interface OwnerShare {
   memberId: string
   name: string
@@ -80,56 +80,64 @@ export function ownerShares(deals: SalesDeal[]): OwnerShare[] {
   return [...byMember.values()].sort((a, b) => b.actual - a.actual)
 }
 
+/** 기간·그룹 기준에 맞춘 순수 집계. 화면과 검증 코드가 같은 계산을 씁니다. */
+export function salesSummaryOf(
+  deals: SalesDeal[],
+  type: PeriodType,
+  offset: number,
+  by: GroupBy,
+): SalesSummary {
+  const range = resolveRange(type, offset)
+  const list = deals.filter((deal) => {
+    const date = contractDate(deal)
+    return isContract(deal) && date >= range.fromISO && date <= range.toISO
+  })
+  const actual = actualOf(list)
+  const keys = new Set(list.map((deal) => keyOf(deal, by)))
+  const groups = [...keys]
+    .map((key) => {
+      const contracts = list.filter((deal) => keyOf(deal, by) === key)
+      const groupActual = actualOf(contracts)
+      return {
+        key,
+        target: 0,
+        actual: groupActual,
+        share: pct(groupActual, actual),
+        rate: 0,
+        contracts,
+        owners: ownerShares(contracts),
+      }
+    })
+    .sort((a, b) => b.actual - a.actual)
+
+  const previous = prevRange(type, offset)
+  const prevActual = actualOf(
+    deals.filter((deal) => {
+      const date = contractDate(deal)
+      return isContract(deal) && date >= previous.fromISO && date <= previous.toISO
+    }),
+  )
+
+  return {
+    groups,
+    totals: {
+      target: 0,
+      actual,
+      gap: 0,
+      rate: 0,
+      count: list.length,
+    },
+    prevActual,
+    delta: actual - prevActual,
+    owners: ownerShares(list),
+  }
+}
+
 export default function useSalesSummary(
   deals: SalesDeal[],
   type: PeriodType,
   offset: number,
   by: GroupBy,
 ): SalesSummary {
-  return useMemo(() => {
-    const range = resolveRange(type, offset)
-    const list = deals.filter((deal) => {
-      const date = contractDate(deal)
-      return isContract(deal) && date >= range.fromISO && date <= range.toISO
-    })
-    const actual = actualOf(list)
-    const keys = new Set(list.map((deal) => keyOf(deal, by)))
-    const groups = [...keys]
-      .map((key) => {
-        const contracts = list.filter((deal) => keyOf(deal, by) === key)
-        const groupActual = actualOf(contracts)
-        return {
-          key,
-          target: 0,
-          actual: groupActual,
-          share: pct(groupActual, actual),
-          rate: 0,
-          contracts,
-          owners: ownerShares(contracts),
-        }
-      })
-      .sort((a, b) => b.actual - a.actual)
-
-    const previous = prevRange(type, offset)
-    const prevActual = actualOf(
-      deals.filter((deal) => {
-        const date = contractDate(deal)
-        return isContract(deal) && date >= previous.fromISO && date <= previous.toISO
-      }),
-    )
-
-    return {
-      groups,
-      totals: {
-        target: 0,
-        actual,
-        gap: 0,
-        rate: 0,
-        count: list.length,
-      },
-      prevActual,
-      delta: actual - prevActual,
-      owners: ownerShares(list),
-    }
-  }, [by, deals, offset, type])
+  return useMemo(() => salesSummaryOf(deals, type, offset, by), [by, deals, offset, type])
 }

--- a/frontend/tests/salesSummary.test.mjs
+++ b/frontend/tests/salesSummary.test.mjs
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict'
+import { after, test } from 'node:test'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { createServer } from 'vite'
+
+const vite = await createServer({
+  server: { middlewareMode: true, hmr: false },
+  define: { 'import.meta.env.VITE_API_BASE_URL': JSON.stringify('http://synthetic.invalid') },
+})
+after(() => vite.close())
+
+const { salesSummaryOf } = await vite.ssrLoadModule('/src/pages/Sales/useSalesSummary.ts')
+const { TODAY_ISO } = await vite.ssrLoadModule('/src/utils/date.ts')
+const { default: RevenuePanel } = await vite.ssrLoadModule(
+  '/src/pages/Sales/components/RevenuePanel/RevenuePanel.tsx',
+)
+const { client } = await vite.ssrLoadModule('/src/api/client.ts')
+
+client.defaults.adapter = async (config) => ({
+  data: [],
+  status: 200,
+  statusText: 'OK',
+  headers: {},
+  config,
+})
+
+const deals = [
+  {
+    org: '가람병원',
+    region: '서울',
+    product: 'A 제품',
+    owner: '김영업',
+    ownerMemberId: 'kim',
+    status: '확정',
+    amount: 100,
+    contractNo: 'C-1',
+    stagePhase: 'contract',
+    date: TODAY_ISO,
+  },
+  {
+    org: '가람병원',
+    region: '서울',
+    product: 'B 제품',
+    owner: '이영업',
+    ownerMemberId: 'lee',
+    status: '확정',
+    amount: 80,
+    contractNo: 'C-2',
+    stagePhase: 'contract',
+    date: TODAY_ISO,
+  },
+  {
+    org: '누리병원',
+    region: '경기',
+    product: 'A 제품',
+    owner: '김영업',
+    ownerMemberId: 'kim',
+    status: '확정',
+    amount: 40,
+    contractNo: 'C-3',
+    stagePhase: 'contract',
+    date: TODAY_ISO,
+  },
+]
+
+function group(summary, key) {
+  const found = summary.groups.find((item) => item.key === key)
+  assert.ok(found, `${key} 그룹이 있어야 합니다.`)
+  return found
+}
+
+test('회사별 선택 항목은 그 회사의 담당자별 매출·계약 건수만 집계한다', () => {
+  const selected = group(salesSummaryOf(deals, 'month', 0, 'org'), '가람병원')
+
+  assert.equal(selected.actual, 180)
+  assert.equal(selected.contracts.length, 2)
+  assert.deepEqual(selected.owners, [
+    { memberId: 'kim', name: '김영업', actual: 100, count: 1 },
+    { memberId: 'lee', name: '이영업', actual: 80, count: 1 },
+  ])
+})
+
+test('지역별과 상품별도 같은 담당자 분해 규칙을 쓴다', () => {
+  const seoul = group(salesSummaryOf(deals, 'month', 0, 'region'), '서울')
+  const productA = group(salesSummaryOf(deals, 'month', 0, 'product'), 'A 제품')
+
+  assert.deepEqual(seoul.owners.map(({ memberId, actual, count }) => ({ memberId, actual, count })), [
+    { memberId: 'kim', actual: 100, count: 1 },
+    { memberId: 'lee', actual: 80, count: 1 },
+  ])
+  assert.deepEqual(productA.owners.map(({ memberId, actual, count }) => ({ memberId, actual, count })), [
+    { memberId: 'kim', actual: 140, count: 2 },
+  ])
+})
+
+test('전체 차트를 유지한 채 선택한 그룹의 담당자 구성을 아래에 덧붙인다', () => {
+  const summary = salesSummaryOf(deals, 'month', 0, 'org')
+  const selectedGroup = group(summary, '가람병원')
+  const view = renderToStaticMarkup(
+    createElement(RevenuePanel, {
+      range: { label: '이번 달', fromISO: TODAY_ISO, toISO: TODAY_ISO, sub: '' },
+      summary,
+      by: 'org',
+      selectedGroup,
+      onSelectGroup() {},
+      trend: [
+        {
+          offset: 0,
+          label: '이번 달',
+          short: '이번 달',
+          actual: summary.totals.actual,
+          isCurrent: true,
+        },
+      ],
+      trendCaption: '매출 추이',
+    }),
+  )
+
+  assert.match(view, /이번 달 · 회사별/)
+  assert.match(view, /가람병원 매출 구성/)
+  assert.match(view, /상세 닫기/)
+  assert.match(view, /담당자 2명/)
+  assert.match(view, /김영업/)
+  assert.match(view, /계약 1건/)
+  assert.match(view, /매출 추이/)
+})


### PR DESCRIPTION
## 변경 요약

- 문서 업로드·수정 메모를 여러 줄 입력으로 변경
- 매출 그룹 선택, 담당자 상세 패널 및 기간별 선택 상태 처리 추가
- 매출 집계 순수 함수 분리와 테스트 추가

## 검증

- \\
pm run typecheck\\ 통과
- \\
pm test\\ 실행 시 Windows 환경의 spawn EPERM으로 전체 테스트 실패

## 영향 및 주의 사항

- 문서 메모 입력 UI와 매출 분석 화면에 영향
- 별도 수동 적용 작업 없음

## 관련 이슈

- 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 매출 화면에서 그룹 이름을 선택해 담당자별 매출 구성과 계약 건수를 확인할 수 있습니다.
  * 그룹 선택과 계약 목록 펼치기 동작이 পৃথ도로 제공됩니다.
  * 선택한 그룹의 상세 정보를 닫을 수 있습니다.
  * 메모 입력란이 여러 줄을 지원하도록 개선되었습니다.

* **개선 사항**
  * 모바일·태블릿 매출 화면에서 계약 목록이 먼저 표시됩니다.
  * 선택 상태와 키보드 접근성 표시가 강화되었습니다.

* **테스트**
  * 그룹별 매출 및 담당자 상세 표시 검증이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->