### PR TITLE
추천 카드에 이 회사의 딜 없는 예정 방문을 알린다

### DIFF
--- a/backend/app/api/contract_suggestions.py
+++ b/backend/app/api/contract_suggestions.py
@@ -6,10 +6,13 @@ from sqlalchemy import select
 
 from app.api.deps import CurrentMember, DbSession
 from app.models.agent import AgentRun, ContractNextMeetingSuggestion
-from app.models.crm import CustomerCompany, CustomerContact
+from app.models.crm import Activity, CustomerCompany, CustomerContact
 from app.models.sales import SalesDeal
 from app.models.workspace import Member
-from app.schemas.contract_suggestions import ContractNextMeetingSuggestionRead
+from app.schemas.contract_suggestions import (
+    ContractNextMeetingSuggestionRead,
+    ScheduledCompanyVisit,
+)
 
 router = APIRouter(tags=["contract-suggestions"])
 
@@ -22,6 +25,7 @@ def _read(
     owner_name: str,
     schedule_run: AgentRun,
     next_meeting_run: AgentRun | None,
+    scheduled_visit: ScheduledCompanyVisit | None,
 ) -> ContractNextMeetingSuggestionRead:
     next_meeting_output = (next_meeting_run.output_snapshot if next_meeting_run else None) or {}
     suggestion_detail = next_meeting_output.get("next_meeting_suggestion") or {}
@@ -39,6 +43,7 @@ def _read(
         risks=next_meeting_output.get("risks") or [],
         schedule_management_run_id=suggestion.schedule_management_run_id,
         schedule_candidates=(schedule_run.output_snapshot or {}).get("schedule_candidates") or [],
+        scheduled_company_visit=scheduled_visit,
         status_code=suggestion.status_code,
         created_at=suggestion.created_at,
         updated_at=suggestion.updated_at,
@@ -91,6 +96,30 @@ async def list_contract_next_meeting_suggestions(
             ).all()
         )
 
+    # 이 회사에 딜 없이 잡아 둔 방문. 추천을 막지는 않고 카드에 알리기만 한다 — 회사 단위로
+    # 막아 버리면 그 회사의 다른 딜까지 추천이 끊겨 놓치는 건이 생긴다. 딜이 붙은 일정은
+    # 이미 추천 계산이 보고 있으므로(_deal_ids_with_upcoming_activity) 여기서 세지 않는다.
+    company_ids = {deal.customer_company_id for _s, deal, _c, _o in rows}
+    visit_rows = (
+        await db.execute(
+            select(Activity.customer_company_id, Activity.starts_at, Activity.title)
+            .where(
+                Activity.team_id == member.team_id,
+                Activity.customer_company_id.in_(company_ids),
+                Activity.sales_deal_id.is_(None),
+                Activity.deleted_at.is_(None),
+                Activity.starts_at > datetime.now(UTC),
+            )
+            .order_by(Activity.customer_company_id, Activity.starts_at)
+        )
+    ).all()
+    # 가장 이른 것 하나만 보여 준다. 정렬해 두었으니 처음 만난 것이 그것이다.
+    scheduled_visits: dict[UUID, ScheduledCompanyVisit] = {}
+    for company_id, starts_at, title in visit_rows:
+        scheduled_visits.setdefault(
+            company_id, ScheduledCompanyVisit(starts_at=starts_at, title=title)
+        )
+
     schedule_run_ids = {suggestion.schedule_management_run_id for suggestion, _d, _c, _o in rows}
     schedule_runs = {
         run.id: run
@@ -132,6 +161,7 @@ async def list_contract_next_meeting_suggestions(
                 owner_name,
                 schedule_run,
                 next_meeting_run,
+                scheduled_visits.get(deal.customer_company_id),
             )
         )
     return results

--- a/backend/app/schemas/contract_suggestions.py
+++ b/backend/app/schemas/contract_suggestions.py
@@ -5,6 +5,17 @@ from uuid import UUID
 from pydantic import BaseModel
 
 
+class ScheduledCompanyVisit(BaseModel):
+    """이 회사에 딜 없이 잡아 둔 가장 이른 방문.
+
+    딜이 붙은 일정은 추천 계산이 이미 보고 있어 추천 자체가 올라오지 않는다. 딜이 없는
+    일정은 그 계산에 잡히지 않으므로, 막는 대신 카드에 알려 사람이 판단하게 한다.
+    """
+
+    starts_at: datetime
+    title: str
+
+
 class ContractNextMeetingSuggestionRead(BaseModel):
     """캘린더 "AI 추천 일정" 패널이 그대로 그리는 값. LLM을 다시 부르지 않고 저장된 값만 담는다."""
 
@@ -21,6 +32,8 @@ class ContractNextMeetingSuggestionRead(BaseModel):
     risks: list[dict[str, Any]]
     schedule_management_run_id: UUID
     schedule_candidates: list[dict[str, Any]]
+    # 이 회사에 딜 없이 잡아 둔 방문이 있으면 그 한 건. 추천을 막지는 않는다.
+    scheduled_company_visit: ScheduledCompanyVisit | None
     status_code: str
     created_at: datetime
     updated_at: datetime

--- a/backend/tests/test_contract_suggestions.py
+++ b/backend/tests/test_contract_suggestions.py
@@ -197,6 +197,7 @@ def test_list_returns_stored_candidates_without_calling_the_llm():
     suggestion = _suggestion(deal, schedule_run.id)
     db = _Db(
         _Result(rows=[(suggestion, deal, company.name, member.display_name)]),
+        _Result(rows=[]),  # 이 회사에 딜 없이 잡아 둔 방문 없음
         _Result(scalar_values=[schedule_run]),
         _Result(scalar_values=[next_meeting_run]),
     )
@@ -215,6 +216,66 @@ def test_list_returns_stored_candidates_without_calling_the_llm():
     assert member.id in db.statements[0].compile().params.values()
 
 
+def test_list_reports_a_scheduled_visit_without_suppressing_the_suggestion():
+    """이 회사에 딜 없이 잡아 둔 방문이 있으면 알리되, 추천은 그대로 올린다.
+
+    딜이 붙은 일정은 추천 계산이 이미 보고 있어 추천 자체가 올라오지 않는다. 딜이 없는
+    일정은 그 계산에 잡히지 않는데, 회사 단위로 막아 버리면 그 회사의 다른 딜까지 알림이
+    끊겨 놓치는 건이 생긴다. 그래서 막지 않고 알리기만 한다.
+    """
+    member = _member()
+    company = _company(member.team_id)
+    deal = _deal(member, company)
+    next_meeting_run = _run(
+        member.team_id,
+        agent_code="contract_management_next_meeting",
+        output={
+            "risks": [],
+            "next_meeting_suggestion": {"sales_deal_id": str(deal.id), "reason": "후속 확인"},
+        },
+    )
+    schedule_run = _run(
+        member.team_id,
+        agent_code="schedule_management",
+        parent_run_id=next_meeting_run.id,
+        output={
+            "schedule_candidates": [
+                {
+                    "candidate_id": "candidate-1",
+                    "title": "후속 미팅",
+                    "starts_at": "2026-09-01T10:00:00+09:00",
+                    "ends_at": "2026-09-01T11:00:00+09:00",
+                    "priority": 1,
+                    "reason": "가장 이른 빈 시간",
+                }
+            ]
+        },
+    )
+    suggestion = _suggestion(deal, schedule_run.id)
+    visit_at = datetime(2026, 8, 25, 1, tzinfo=UTC)
+    db = _Db(
+        _Result(rows=[(suggestion, deal, company.name, member.display_name)]),
+        _Result(rows=[(company.id, visit_at, "인사차 방문")]),
+        _Result(scalar_values=[schedule_run]),
+        _Result(scalar_values=[next_meeting_run]),
+    )
+
+    with _client(db, member) as client:
+        response = client.get("/api/contract-next-meeting-suggestions", headers={"Origin": ORIGIN})
+
+    assert response.status_code == 200
+    [item] = response.json()
+    assert item["scheduled_company_visit"]["title"] == "인사차 방문"
+    # 알리기만 한다 — 추천은 목록에 그대로 남는다.
+    assert item["sales_deal_id"] == str(deal.id)
+
+    sql = str(db.statements[1])
+    # 딜이 붙은 일정은 추천 계산이 이미 보고 있어 여기서 세지 않는다.
+    assert "activity.sales_deal_id IS NULL" in sql
+    assert "activity.deleted_at IS NULL" in sql
+    assert "activity.starts_at >" in sql
+
+
 def test_list_skips_suggestions_whose_run_has_not_finished():
     """아직 돌고 있거나 실패한 실행은 보여줄 내용이 없다 — 다음 트리거가 다시 채운다."""
     member = _member()
@@ -224,6 +285,7 @@ def test_list_skips_suggestions_whose_run_has_not_finished():
     suggestion = _suggestion(deal, running_run.id)
     db = _Db(
         _Result(rows=[(suggestion, deal, company.name, member.display_name)]),
+        _Result(rows=[]),  # 이 회사에 딜 없이 잡아 둔 방문 없음
         _Result(scalar_values=[running_run]),
     )
 

--- a/frontend/src/pages/Calendar/components/SuggestionPanel/SuggestionPanel.module.scss
+++ b/frontend/src/pages/Calendar/components/SuggestionPanel/SuggestionPanel.module.scss
@@ -229,3 +229,16 @@
   color: var(--blue);
   font-weight: 600;
 }
+
+// 이 회사에 딜 없이 잡아 둔 방문. 추천을 막지 않고 알리기만 하므로, 근거 배지보다
+// 조용하게 두되 눈에는 걸리도록 왼쪽에 선을 세운다.
+.scheduledVisit {
+  margin: 0;
+  padding: 7px 10px;
+  border-left: 2px solid var(--orange);
+  border-radius: 0 6px 6px 0;
+  background: var(--orange-tint);
+  color: var(--orange-ink);
+  font-size: 12px;
+  line-height: 1.5;
+}

--- a/frontend/src/pages/Calendar/components/SuggestionPanel/SuggestionPanel.tsx
+++ b/frontend/src/pages/Calendar/components/SuggestionPanel/SuggestionPanel.tsx
@@ -170,6 +170,10 @@ export default function SuggestionPanel({
                 </div>
               )}
 
+              {s.scheduledVisitNote && (
+                <p className={styles.scheduledVisit}>{s.scheduledVisitNote}</p>
+              )}
+
               <div className={styles.basis}>
                 <i className={styles.kind}>{KIND_LABEL[s.kind]}</i>
                 {s.basis.map((b) => (

--- a/frontend/src/pages/Calendar/useAiSuggestions.ts
+++ b/frontend/src/pages/Calendar/useAiSuggestions.ts
@@ -10,7 +10,9 @@ import type {
   AiSuggestionOption,
   CalendarEvent,
   ContractNextMeetingSuggestion,
+  ScheduledCompanyVisit,
 } from '@/types'
+import { fmtDay } from '@/utils/date'
 
 type NewEvent = Partial<Omit<CalendarEvent, 'id'>> & { date: string; title: string }
 type AddEvent = (draft: NewEvent) => Promise<AgendaItem>
@@ -32,6 +34,21 @@ function toOptions(item: ContractNextMeetingSuggestion): AiSuggestionOption[] {
         priority: candidate.priority,
       }
     })
+}
+
+/**
+ * 이 회사에 딜 없이 잡아 둔 방문을 한 줄로 적는다.
+ *
+ * 딜이 붙은 일정은 추천 계산이 이미 보고 있어 그 딜의 추천이 아예 올라오지 않는다. 딜이
+ * 없는 일정은 그 계산에 잡히지 않아, 이미 잡아 둔 방문이 있어도 추천이 계속 올라온다.
+ * 막지 않고 알리기만 하는 이유는 회사 단위로 막으면 그 회사의 다른 딜까지 알림이 끊겨
+ * 놓치는 건이 생기기 때문이다.
+ */
+function toScheduledVisitNote(visit: ScheduledCompanyVisit | null): string | null {
+  if (visit === null) return null
+  const at = new Date(visit.starts_at)
+  if (Number.isNaN(at.getTime())) return null
+  return `이 회사에 ${fmtDay(at)} 방문이 이미 잡혀 있습니다 (건 미지정)`
 }
 
 function toAiSuggestion(
@@ -61,6 +78,7 @@ function toAiSuggestion(
     activityTitle: chosen.title,
     proposalReason: item.reason,
     basis: [...new Set(item.risks.map((risk) => RISK_LABEL[risk.code]))],
+    scheduledVisitNote: toScheduledVisitNote(item.scheduled_company_visit),
     scheduleRunId: item.schedule_management_run_id,
     options,
     selectedCandidateId: chosen.candidateId,

--- a/frontend/src/types/contractAgent.ts
+++ b/frontend/src/types/contractAgent.ts
@@ -51,6 +51,15 @@ export interface ContractBriefingOutput {
  * 결과다 — 캘린더가 이 값을 읽을 때는 LLM을 부르지 않는다.
  * backend/app/schemas/contract_suggestions.py 의 ContractNextMeetingSuggestionRead 를 옮긴다.
  */
+/**
+ * 딜이 붙지 않은 예정 방문. 딜이 붙은 일정은 추천 계산이 이미 보고 있어 추천 자체가
+ * 올라오지 않지만, 딜이 없는 일정은 그 계산에 잡히지 않는다.
+ */
+export interface ScheduledCompanyVisit {
+  starts_at: string
+  title: string
+}
+
 export interface ContractNextMeetingSuggestion {
   id: string
   sales_deal_id: string
@@ -65,6 +74,8 @@ export interface ContractNextMeetingSuggestion {
   risks: ContractRisk[]
   schedule_management_run_id: string
   schedule_candidates: ScheduleCandidate[]
+  /** 이 회사에 딜 없이 잡아 둔 가장 이른 방문. 추천을 막지는 않고 카드에 알리기만 한다. */
+  scheduled_company_visit: ScheduledCompanyVisit | null
   status_code: 'pending' | 'dismissed' | 'accepted'
   created_at: string
   updated_at: string

--- a/frontend/src/types/suggestions.ts
+++ b/frontend/src/types/suggestions.ts
@@ -45,6 +45,11 @@ export interface AiSuggestion {
   proposalReason: string
   /** 추천 근거 배지. 예: ['계약 만료 임박', '재방문 필요'] */
   basis: string[]
+  /**
+   * 이 회사에 딜 없이 잡아 둔 방문이 있으면 그 안내. 추천을 막지는 않는다 — 회사 단위로
+   * 막으면 그 회사의 다른 딜까지 알림이 끊겨 놓치는 건이 생긴다.
+   */
+  scheduledVisitNote: string | null
   /** 승인 시 브리핑 실행을 이어붙이는 데 쓰는 일정관리 실행 id */
   scheduleRunId: string
   /** 고를 수 있는 시간 후보 전체. 위의 date/time/dur 은 이 중 선택된 것의 값이다 */


### PR DESCRIPTION
## 변경 요약

이미 방문을 잡아 두었는데도 같은 회사의 추천이 계속 올라오는 문제를 고칩니다.

딜이 붙은 일정은 추천 계산이 이미 보고 있어(`_deal_ids_with_upcoming_activity`) 그 딜의
추천이 아예 올라오지 않습니다. 그런데 **딜이 없는 일정은 그 계산에 잡히지 않아** 방문을
잡아 둔 뒤에도 추천이 그대로 남습니다.

- `GET /contract-next-meeting-suggestions` 응답에 `scheduled_company_visit` 을 더합니다.
  그 회사에 딜 없이 잡아 둔 **가장 이른 예정 방문 한 건**(`starts_at`, `title`)이고,
  없으면 `null` 입니다.
- 캘린더 "AI 추천 일정" 카드에 한 줄로 표시합니다 —
  `이 회사에 9월 12일 (토) 방문이 이미 잡혀 있습니다 (건 미지정)`

**막지 않고 알리기만 합니다.** 회사 단위로 억제하면 한 번 방문한 것으로 그 회사의 다른
딜까지 추천이 끊겨 놓치는 건이 생깁니다. 알림이 더 오는 것보다 안 오는 편이 나쁩니다.

**조회 시점에 계산합니다.** 제안을 만든 뒤에 잡은 방문도 바로 보이고, 저장할 컬럼이
늘지 않습니다.

---

## 이 브랜치가 왜 따로 떨어져 있나 (`Refs #114`)

**이 PR 은 새로 시작한 작업이 아니라, #117 에서 의도적으로 떼어 둔 나머지입니다.**
커밋 날짜가 9/4 로 오래돼 보이는 이유이기도 하니 배경을 남깁니다.

### #114 아래 있던 작업 묶음

이슈 #114 는 제목이 "목업 데이터의 고객 담당자 비어 있는 행 정리 (딜 19건 · 일정 33건)"
라 데이터 정리처럼 보이지만, 실제로는 **담당자를 필수로 만들기 위해 필요했던 기능 변경
전체**가 이 이슈 아래 달려 있었습니다. `Refs #114` 를 단 커밋이 9/3~9/4 에 걸쳐 16개
있습니다.

```
#114  목업 데이터의 고객 담당자 비어 있는 행 정리
  │
  ├─ 일정에 고객사를 두고 담당자가 빈 딜·일정을 정리한다      → #115 머지
  ├─ 딜·일정의 담당자를 필수로 받는다                        → #117 머지
  ├─ 딜을 고르지 않은 미팅도 보고서를 쓸 수 있게 한다          → #117 머지
  ├─ 손으로 만든 일정에도 AI 브리핑을 붙인다                  → #117 머지
  └─ 추천 카드에 이 회사의 딜 없는 예정 방문을 알린다          ← 이 PR (미머지)
```

### 왜 빠졌나

원래 `jiyu-park/activity-sales-deal-required`(#117) 안에 커밋 `9c4a06f` 로 함께
있었습니다. 리뷰에서 "딜을 정하는 시점은 일정이 아니라 보고서다 — 일정 등록에서 딜을
앞당겨 받지 말자"는 지적이 나왔고, 이를 반영한 커밋 `08aa295` 가 일정 등록 영역을
걷어내면서 이 표시도 함께 빠졌습니다. 그 커밋 메시지에 그대로 적혀 있습니다.

> 추천 카드의 '이 회사에 이미 잡힌 방문' 표시는 일정 등록 영역이 아니라
> `jiyu-park/suggestion-scheduled-visit` 로 옮겨 두고 여기서는 뺀다

즉 **버린 것이 아니라 옮겨 둔 것**이고, 옮긴 뒤 PR 을 올리지 않은 채 남았습니다.
`Refs #114` 는 그 계보를 가리키는 표시이므로 유지합니다.

### 지금 develop 과의 관계

- 분기점 `15f440a`(9/4). 이후 develop 이 이 PR 이 건드리는 8개 파일을 **하나도 건드리지
  않았습니다.** `git merge-tree` 로 확인했고 충돌 없습니다.
- develop 에는 이 기능이 **없습니다.** `contract_suggestions.py` 에 방문 관련 코드가
  전혀 없어 중복 구현이 아닙니다.

---

## 검증

`develop`(`7130980`)에 머지한 상태로 전체 백엔드 스위트를 돌렸습니다. 브랜치 단독으로
돌리면 9/4 기준이라 테스트가 177개 적어 비교가 되지 않습니다.

| | develop 기준선 | 머지 후 |
|---|---|---|
| passed | 1145 | **1146** (+1) |
| failed | 1 | 1 |
| skipped | 7 | 7 |
| errors | 20 | 20 |

늘어난 1건이 이 PR 의 신규 테스트
`test_list_reports_a_scheduled_visit_without_suppressing_the_suggestion` 입니다
(방문이 있어도 추천이 목록에 남는 것, 딜이 붙은 일정은 세지 않는 것).
**실패·에러는 하나도 늘지 않았습니다.**

- `pytest tests/test_contract_suggestions.py` — **7 passed** (기존 6 + 신규 1).
  쿼리가 하나 늘어난 것에 맞춰 기존 테스트 2건의 `_Db` 결과 순서도 함께 고쳤습니다.
- `ruff check` — All checks passed · `ruff format --check` — 203 files already formatted
- 프론트 `tsc -b --noEmit` 통과 · `oxlint` 통과 · `node --test` **91 passed**
- 기존 실패 1건(`test_models.py::test_all_database_tables_are_mapped`, 컬럼 수 458≠446)과
  에러 20건(`test_deal_baseline.py` 18 · `test_ocr.py` 2, 로컬 ML 아티팩트 없음)은
  **`develop` 에서도 동일하게 재현**됩니다. 이 변경과 무관합니다.
- `prettier --check` 가 `RevenuePanel.tsx` 를 지적하지만 이 PR 이 건드리지 않은 파일이고
  `develop` 에서도 같습니다.

---

## 아직 확인하지 않은 것 — 이어서 할 일

단위 테스트의 `_Db` 는 결과를 미리 먹여 주는 가짜라 **SQL 을 문자열로만** 검사합니다.
쿼리가 실제로 옳은 행을 돌려주는지는 확인하지 않았습니다. 아래는 실제 화면·DB 로
확인해야 하는 항목입니다.

- [ ] **방문이 2건 이상일 때 가장 이른 것만 실리는가** — 가장 중요합니다.
      `scheduled_visits.setdefault()` 가 DB 정렬(`ORDER BY customer_company_id,
      starts_at`)에 기대는데, 가짜 DB 는 정렬을 재현하지 않아 자동 검증 밖에 있습니다.
- [ ] 방문이 없을 때 응답이 `null` 인가 (기존 테스트가 빈 결과를 먹이긴 하나 필드 단언 없음)
- [ ] 다른 회사의 방문이 섞이지 않는가 (`IN` 절 그룹핑)
- [ ] 다른 팀의 방문이 보이지 않는가 (`team_id` 필터)
- [ ] 삭제한 일정이 빠지는가 (`deleted_at IS NULL`)
- [ ] 지난 방문이 빠지는가 (`starts_at > now()`)
- [ ] `EXPLAIN ANALYZE` — `activity` 에 `customer_company_id` 인덱스가 **없습니다.**
      기존 `activity_team_starts_idx (team_id, starts_at) WHERE deleted_at IS NULL` 로
      `team_id` + `starts_at` 까지는 타고 나머지는 필터로 걸립니다. 현재 데이터 규모면
      문제없을 것으로 보이나 확인하지 않았습니다.

### 수동 확인 순서

1. 회사 A 에 추천 카드가 뜨는 상태를 만든다
2. **딜 연결 없이** A 에 미래 일정을 등록 → 카드에 줄이 뜨고 **추천은 그대로 남는지**
3. A 에 미래 방문을 하나 더 등록 → **이른 쪽만** 뜨는지 (위 첫 항목)
4. 그 일정을 삭제 → 줄이 사라지는지
5. 지난 날짜로 등록 → 뜨지 않는지
6. 다른 팀 계정으로 조회 → 보이지 않는지

앞의 3개(방문 없음 / 여러 건 / 다른 회사)는 `_Db` 에 rows 를 여러 개 먹이는 단위
테스트로도 덮을 수 있습니다. 다만 "가장 이른 것 하나"는 정렬 의존이라 실제 DB 가
필요합니다.

---

## 영향 및 주의 사항

- **스키마 변경 없음.** 마이그레이션 불필요합니다.
- 목록 조회에 쿼리가 **한 번 늘어납니다.** 회사 id 를 모아 `IN` 으로 한 번에 읽고,
  `(customer_company_id, starts_at)` 순으로 정렬해 회사마다 첫 행만 씁니다.
  제안이 없으면 `if not rows: return []` 로 조기 반환하므로 빈 목록에는 쿼리가 늘지
  않습니다.
- `deleted_at IS NULL` 과 `team_id` 를 함께 걸어, 지워진 일정과 다른 팀 일정은 세지 않습니다.
- 응답 필드가 하나 늘어나므로 이 API 를 쓰는 다른 클라이언트가 있다면 무시해도 안전합니다
  (`null` 허용).
- 기준 시각은 조회 시점의 서버 시각입니다. 방금 지난 방문은 다음 조회부터 사라집니다.

## 리뷰 포인트

- **막지 않고 알리기만 하는 선택.** 회사 단위 억제와 저울질한 결과이며, 근거는 커밋
  메시지와 [contract_suggestions.py](backend/app/api/contract_suggestions.py) 주석에
  남겼습니다. 이 판단에 이견이 있으면 여기가 논점입니다.
- **조회 시점 계산.** 저장 컬럼을 늘리지 않는 대신 조회마다 쿼리가 하나 붙습니다.

Refs #114
