### PR TITLE
fix(calendar): 추천 패널 높이와 스크롤 동작을 안정화한다

### DIFF
--- a/frontend/src/pages/Calendar/Calendar.module.scss
+++ b/frontend/src/pages/Calendar/Calendar.module.scss
@@ -1,7 +1,6 @@
 .layout {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 340px;
-  align-items: start;
   gap: var(--s4);
 
   @include lg {
@@ -9,14 +8,10 @@
   }
 }
 
-// 달력이 길어져도 추천은 계속 따라옵니다. 한 컬럼으로 접히면 붙일 곳이 없어 풉니다.
+// 늘어난 컬럼은 sticky가 움직일 자리가 없으므로, 달력 높이는 여기서 받고
+// 붙는 것은 안쪽 패널이 합니다.
 .side {
-  position: sticky;
-  top: calc(var(--topbar-h) + var(--s4));
-
-  @include lg {
-    position: static;
-  }
+  min-height: 0;
 }
 
 // 끄는 동안 손끝을 따라다니는 조각. 자리 찾기(elementFromPoint)를 가리면 안 되므로

--- a/frontend/src/pages/Calendar/components/SuggestionPanel/SuggestionPanel.module.scss
+++ b/frontend/src/pages/Calendar/components/SuggestionPanel/SuggestionPanel.module.scss
@@ -1,10 +1,26 @@
+// 카드가 몇 장이든 달력 옆을 벗어나지 않습니다. 높이는 달력에 맞추고, 창이 그보다
+// 짧으면 화면까지만 쓴 뒤 위에 붙습니다. 넘치는 것은 목록만 스크롤합니다.
 .panel {
   @include card;
 
+  position: sticky;
+  top: calc(var(--topbar-h) + var(--s4));
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  max-height: calc(100dvh - var(--topbar-h) - var(--s6));
   padding: var(--s5);
 
   @include md {
     padding: var(--s4);
+  }
+
+  // 한 컬럼으로 접히면 옆에 맞출 달력이 없어 전부 풉니다.
+  @include lg {
+    position: static;
+    height: auto;
+    max-height: none;
   }
 }
 
@@ -56,9 +72,24 @@
 .list {
   display: flex;
   flex-direction: column;
+  flex: 1;
   gap: var(--s3);
+  min-height: 0;
   margin-top: var(--s4);
+  // 스크롤바가 카드 테두리에 닿지 않게 한 뼘 띄웁니다.
+  padding-right: 2px;
+  overflow-y: auto;
   list-style: none;
+
+  // 스크롤되는 목록이므로 카드는 줄어들지 않고 제 높이를 지킵니다.
+  > * {
+    flex-shrink: 0;
+  }
+
+  @include lg {
+    flex: none;
+    overflow: visible;
+  }
 }
 
 .card {
@@ -183,6 +214,8 @@
 }
 
 .empty {
+  // 달력 높이만큼 늘어난 카드 안에서 위에 붙어 뜨지 않게 가운데로 옮깁니다.
+  margin: auto 0;
   padding: var(--s7) var(--s4);
   text-align: center;
   color: var(--muted);


### PR DESCRIPTION
## 변경 요약

- 캘린더 우측 컬럼이 달력 높이를 이어받도록 하고 sticky 동작을 추천 패널 내부로 이동합니다.
- 추천 패널을 뷰포트 높이에 맞게 제한하고 추천 카드 목록만 내부 스크롤되도록 조정합니다.
- 단일 컬럼 반응형에서는 sticky·높이·overflow 제한을 해제하고 빈 상태를 패널 중앙에 배치합니다.

## 검증

- `npm ci` — 잠금 파일 기준 의존성 설치 성공
- `npm run lint` — 통과
- `npm run format:check` — 통과
- `npm test` — 91개 통과
- `npm run build` — 통과(500 kB 초과 청크 경고 있음)
- `git diff --check` — 통과
- 실제 로그인·데이터를 사용한 브라우저 수동 검증은 실행하지 않았습니다.

## 영향 및 주의 사항

- 프런트엔드 캘린더 추천 패널 레이아웃에만 영향을 줍니다.
- sticky, `100dvh`, 반응형 breakpoint 동작은 리뷰 환경에서 시각 확인이 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 캘린더의 제안 패널이 화면 스크롤 시 적절한 위치에 고정되어 더 쉽게 확인할 수 있습니다.
  - 제안 목록이 패널 내부에서 스크롤되도록 개선되어, 항목이 많아도 캘린더 높이가 불필요하게 늘어나지 않습니다.
  - 제안이 없을 때 안내 내용이 패널 안에서 세로 중앙에 정렬됩니다.
  - 큰 화면과 작은 화면에서 각 레이아웃에 맞게 고정 및 스크롤 동작이 자동으로 조정됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->