### PR TITLE
feat: 팀 관리를 요약·개입·구성원 세 단으로 다시 세운다

### DIFF
--- a/frontend/src/pages/Team/Team.module.scss
+++ b/frontend/src/pages/Team/Team.module.scss
@@ -1,92 +1,20 @@
 .page {
   display: flex;
   flex-direction: column;
-  gap: var(--s3);
-}
-
-/* 팀 목표 카드. 대시보드 매출 목표 타일과 같은 어휘를 한 단계 크게 씁니다. */
-.goal {
-  @include card;
-  display: flex;
-  flex-direction: column;
-  gap: var(--s3);
-  padding: var(--s4);
-}
-
-.goalHead {
-  display: flex;
-  align-items: baseline;
-  gap: var(--s2);
-}
-
-.goalTitle {
-  margin: 0;
-  color: var(--ink);
-  font-size: 14px;
-  font-weight: 700;
-}
-
-.goalMonth {
-  color: var(--muted);
-  font-size: 12px;
-}
-
-.goalStats {
-  display: flex;
-  align-items: center;
-  gap: var(--s6);
-  flex-wrap: wrap;
-}
-
-.stat {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  margin: 0;
-  color: var(--muted);
-  font-size: 12px;
-
-  strong {
-    color: var(--ink);
-    font-size: 18px;
-    font-weight: 700;
-  }
-}
-
-.goalTrack {
-  position: relative;
-  height: 6px;
-  border-radius: var(--r-pill);
-  background: var(--fill);
-  overflow: hidden;
-
-  i {
-    display: block;
-    height: 100%;
-    width: var(--p, 0%);
-    border-radius: inherit;
-    background: linear-gradient(90deg, var(--blue), #4da3ff);
-    transition: width var(--t-slow) var(--ease-spring);
-  }
-}
-
-// 목표를 넘어선 막대. 길이로는 더 보일 자리가 없어 색으로 알립니다.
-.isOver i {
-  background: linear-gradient(90deg, var(--green), var(--green-ink));
-}
-
-.goalFoot {
-  display: flex;
-  justify-content: space-between;
-  gap: var(--s2);
-  margin: 0;
-  color: var(--muted);
-  font-size: 11px;
+  gap: var(--s4);
 }
 
 .card {
   @include card;
   overflow: hidden; // 둥근 모서리 밖으로 표가 새어 나오지 않게
+}
+
+.cardHead {
+  margin: 0;
+  padding: var(--s4) var(--s4) var(--s3);
+  color: var(--ink);
+  font-size: 14px;
+  font-weight: 700;
 }
 
 /* 가로 스크롤은 카드 안에서만 일어납니다. 페이지 본문은 절대 옆으로 밀리지 않습니다. */
@@ -102,8 +30,7 @@
 
   th,
   td {
-    height: 52px;
-    padding: var(--s2) var(--s3);
+    padding: var(--s3) var(--s4);
     text-align: left;
     vertical-align: middle;
     white-space: nowrap;
@@ -113,8 +40,10 @@
     position: sticky;
     top: 0;
     z-index: 2;
-    height: 40px;
+    padding-top: var(--s2);
+    padding-bottom: var(--s2);
     background: var(--surface-2);
+    border-top: 1px solid var(--line);
     border-bottom: 1px solid var(--line);
     color: var(--ink-2);
     font-size: 12px;

--- a/frontend/src/pages/Team/Team.tsx
+++ b/frontend/src/pages/Team/Team.tsx
@@ -1,8 +1,11 @@
 // 팀 관리. 구성원의 역할·재직 상태와 매출 목표를 다룹니다.
 //
-// 화면 하나에 "팀이 이번 달 얼마를 목표하고 지금 얼마까지 왔는가" 와 "누가 어디까지 왔는가"
-// 를 함께 둡니다. 목표를 고치면 대시보드의 매출 목표 타일도 같은 값을 보게 됩니다. 달성률은
-// 서버가 셈해 준 것을 그대로 씁니다. 화면에서 다시 계산하면 두 화면의 숫자가 갈라집니다.
+// 화면을 세 단으로 세웁니다. 이번 달 팀의 숫자(GoalBand), 지금 손봐야 할 사람
+// (AttentionCard), 그리고 구성원별 진척(표)입니다. 팀장이 위에서 아래로 한 번 훑으면
+// 무엇부터 할지가 정해지도록 둔 순서입니다.
+//
+// 목표를 고치면 대시보드의 매출 목표 타일도 같은 값을 보게 됩니다. 달성률은 서버가 셈해
+// 준 것을 그대로 씁니다. 화면에서 다시 계산하면 두 화면의 숫자가 갈라집니다.
 //
 // 고치는 일은 줄 안에서 하지 않고 상세 드로어에서 합니다. 목표·역할·재직 상태를 한 줄에
 // 늘어놓으면 표가 입력 폼이 되어 읽기가 어려워집니다. 드로어는 줄 아무 곳이나 눌러 엽니다.
@@ -11,10 +14,12 @@ import { useMemo, useState } from 'react'
 import { useCurrentUser } from '@/auth/sessionContext'
 import ErrorToast from '@/components/ErrorToast'
 import { ListPageSkeleton, TableSkeleton } from '@/components/Skeleton'
+import type { SelectOption } from '@/components/Select'
 import StatusBadge from '@/components/StatusBadge'
 import type { TeamMemberRow } from '@/types'
-import { wonFull } from '@/utils/format'
 
+import AttentionCard from './components/AttentionCard'
+import GoalBand from './components/GoalBand'
 import MemberDrawer from './components/MemberDrawer'
 import MemberRow from './components/MemberRow'
 import useTeamOverview from './useTeamOverview'
@@ -27,14 +32,34 @@ function thisMonth(): string {
   return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-01`
 }
 
+/** 이번 달부터 거슬러 열두 달. 목표는 지난달 것도 들여다봐야 할 때가 있습니다. */
+function monthOptions(): SelectOption[] {
+  const now = new Date()
+  return Array.from({ length: 12 }, (_, back) => {
+    const date = new Date(now.getFullYear(), now.getMonth() - back, 1)
+    const year = date.getFullYear()
+    const month = date.getMonth() + 1
+    return {
+      value: `${year}-${String(month).padStart(2, '0')}-01`,
+      label: `${year}년 ${month}월`,
+    }
+  })
+}
+
 export default function Team() {
   const { memberId } = useCurrentUser()
-  const [targetMonth] = useState(thisMonth)
+  const [targetMonth, setTargetMonth] = useState(thisMonth)
   const [openId, setOpenId] = useState<string | null>(null)
 
   const { data, loading, error, reload, saveMember } = useTeamOverview(targetMonth)
 
-  const members = useMemo<TeamMemberRow[]>(() => data?.members ?? [], [data])
+  const months = useMemo(monthOptions, [])
+  const members = useMemo<TeamMemberRow[]>(() => {
+    // 자리를 비운 사람이 가운데 끼면 읽는 흐름이 끊깁니다. 순서는 그대로 두고 뒤로만 보냅니다.
+    const rows = data?.members ?? []
+    return [...rows].sort((a, b) => Number(b.active) - Number(a.active))
+  }, [data])
+
   const open = members.find((member) => member.id === openId) ?? null
   const activeCount = members.filter((member) => member.active).length
 
@@ -56,52 +81,23 @@ export default function Team() {
       <ErrorToast message={error} onRetry={reload} />
 
       {data !== null && (
-        <div className={styles.goal}>
-          <div className={styles.goalHead}>
-            <h2 className={styles.goalTitle}>팀 목표 매출</h2>
-            <span className={styles.goalMonth}>{data.target_month}</span>
-          </div>
-
-          <div className={styles.goalStats}>
-            <p className={styles.stat}>
-              <span>월 목표 매출</span>
-              <strong className="tnum">{wonFull(data.team_target)}</strong>
-            </p>
-            <p className={styles.stat}>
-              <span>현재 매출</span>
-              <strong className="tnum">{wonFull(data.team_confirmed)}</strong>
-            </p>
-            <p className={styles.stat}>
-              <span>달성률</span>
-              <strong className="tnum">
-                {/* 목표를 세우지 않은 것과 아직 못 채운 것은 다릅니다. */}
-                {data.team_rate === null ? '목표 미설정' : `${data.team_rate}%`}
-              </strong>
-            </p>
-          </div>
-
-          {/* 대시보드 매출 목표 타일과 같은 막대입니다. 목표를 넘어선 만큼은 막대 밖으로
-              나갈 자리가 없으므로 막대를 채우고 색으로 알립니다. */}
-          <div
-            className={`${styles.goalTrack} ${(data.team_rate ?? 0) > 100 ? styles.isOver : ''}`}
-            style={{ '--p': `${Math.min(100, data.team_rate ?? 0)}%` } as React.CSSProperties}
-          >
-            <i />
-          </div>
-
-          <p className={styles.goalFoot}>
-            <span>재직 중인 구성원 {activeCount}명</span>
-            {/* 지금은 팀 목표를 따로 세우지 않고 팀원 목표를 더해 씁니다. 두 값을 나눠
-                보여 주어야 나중에 팀 목표를 따로 넣게 되어도 화면이 그대로입니다. */}
-            <span className="tnum">팀원 목표 합계 {wonFull(data.member_target_sum)}</span>
-          </p>
-        </div>
+        <GoalBand
+          data={data}
+          activeCount={activeCount}
+          month={targetMonth}
+          monthOptions={months}
+          onMonthChange={setTargetMonth}
+        />
       )}
+
+      <AttentionCard members={members} onOpen={setOpenId} />
 
       {!error && loading ? (
         <TableSkeleton label="팀 정보를 새로고침하는 중입니다." rows={members.length} />
       ) : (
         <div className={styles.card}>
+          <h2 className={styles.cardHead}>구성원별 현황</h2>
+
           <div className={styles.scroller}>
             <table className={styles.table}>
               <caption className="sr-only">
@@ -110,16 +106,11 @@ export default function Team() {
               <thead>
                 <tr>
                   <th scope="col">팀원</th>
-                  <th scope="col">직책</th>
-                  <th scope="col">역할</th>
-                  <th scope="col">담당지역</th>
+                  <th scope="col">역할·담당지역</th>
+                  <th scope="col">현재 매출 / 목표 매출</th>
                   <th scope="col" className={styles.right}>
-                    목표 매출
+                    달성률
                   </th>
-                  <th scope="col" className={styles.right}>
-                    현재 매출
-                  </th>
-                  <th scope="col">달성률</th>
                   <th scope="col">상태</th>
                 </tr>
               </thead>

--- a/frontend/src/pages/Team/components/AttentionCard/AttentionCard.module.scss
+++ b/frontend/src/pages/Team/components/AttentionCard/AttentionCard.module.scss
@@ -1,0 +1,113 @@
+.card {
+  @include card;
+  padding: var(--s4);
+}
+
+.head {
+  display: flex;
+  align-items: center;
+  gap: var(--s2);
+  margin: 0 0 var(--s2);
+  color: var(--ink);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.count {
+  @include tag-pill;
+  padding: 1px 8px;
+  background: var(--orange-tint);
+  color: var(--orange-ink);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+
+  li + li {
+    border-top: 1px solid var(--line);
+  }
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: var(--s3);
+  width: 100%;
+  padding: var(--s3) var(--s2);
+  border: 0;
+  border-radius: var(--r-xs);
+  background: none;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--t-fast);
+
+  &:hover {
+    background: var(--fill-2);
+  }
+}
+
+// 갈래를 알리는 한 글자. 색은 이 카드에서만 쓰는 강조이고 나머지 화면은 조용히 둡니다.
+.mark {
+  flex: none;
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  border-radius: var(--r-xs);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.warn {
+  background: var(--orange-tint);
+  color: var(--orange-ink);
+}
+
+.bad {
+  background: var(--red-tint);
+  color: var(--red-ink);
+}
+
+.quiet {
+  background: var(--fill);
+  color: var(--muted);
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.title {
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.names {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.action {
+  flex: none;
+  margin-left: auto;
+  color: var(--blue);
+  font-size: 12px;
+  font-weight: 600;
+
+  // 좁은 화면에서는 이름이 먼저 읽혀야 합니다. 손잡이 전체가 눌리므로 문구는 접습니다.
+  @include sm {
+    display: none;
+  }
+}

--- a/frontend/src/pages/Team/components/AttentionCard/AttentionCard.tsx
+++ b/frontend/src/pages/Team/components/AttentionCard/AttentionCard.tsx
@@ -1,0 +1,102 @@
+// 지금 팀장이 손봐야 할 사람만 모아 두는 카드입니다.
+//
+// 목록은 여덟 명이 다 같은 무게로 서 있어서, 훑지 않으면 누구부터 볼지 알 수 없습니다.
+// 여기서는 갈래마다 한 줄만 두고 이름을 앞에서 셋까지 보여 준 뒤 첫 사람의 상세를 엽니다.
+//
+// 새로 받아 오는 값은 없습니다. 이미 화면에 있는 구성원 목록에서 추려낼 뿐입니다.
+// 볼 것이 하나도 없으면 이 카드는 아예 서지 않습니다.
+import type { TeamMemberRow } from '@/types'
+
+import { WATCH } from '../../health'
+
+import styles from './AttentionCard.module.scss'
+
+interface Props {
+  members: readonly TeamMemberRow[]
+  onOpen: (memberId: string) => void
+}
+
+type Tone = 'warn' | 'bad' | 'quiet'
+
+interface Group {
+  key: string
+  tone: Tone
+  mark: string
+  title: string
+  people: readonly TeamMemberRow[]
+}
+
+/** 이름을 셋까지 늘어놓고 나머지는 수로 접습니다. */
+function names(people: readonly TeamMemberRow[]): string {
+  const shown = people.slice(0, 3).map((member) => member.display_name)
+  const rest = people.length - shown.length
+  return rest > 0 ? `${shown.join(' · ')} 외 ${rest}명` : shown.join(' · ')
+}
+
+export default function AttentionCard({ members, onOpen }: Props) {
+  const active = members.filter((member) => member.active)
+
+  const all: Group[] = [
+    {
+      key: 'unset',
+      tone: 'warn',
+      mark: '!',
+      title: '목표 미설정',
+      people: active.filter((member) => member.target_amount === 0),
+    },
+    {
+      key: 'behind',
+      tone: 'bad',
+      mark: '↘',
+      title: `달성률 ${WATCH}% 미만`,
+      // 목표가 없는 사람은 위 갈래에서 이미 셉니다. 한 사람이 두 줄에 서지 않게 합니다.
+      people: active.filter(
+        (member) => member.achievement_rate !== null && member.achievement_rate < WATCH,
+      ),
+    },
+    {
+      key: 'inactive',
+      tone: 'quiet',
+      mark: '—',
+      title: '비활성 구성원',
+      people: members.filter((member) => !member.active),
+    },
+  ]
+
+  const groups = all.filter((group) => group.people.length > 0)
+
+  if (groups.length === 0) return null
+
+  return (
+    <section className={styles.card} aria-labelledby="team-attention-heading">
+      <h2 id="team-attention-heading" className={styles.head}>
+        확인이 필요한 구성원
+        <span className={styles.count}>{groups.reduce((sum, g) => sum + g.people.length, 0)}</span>
+      </h2>
+
+      <ul className={styles.list}>
+        {groups.map((group) => (
+          <li key={group.key}>
+            <button
+              type="button"
+              className={styles.row}
+              // 여는 것은 첫 사람 하나입니다. 무엇이 열리는지 손잡이 이름으로 밝혀 둡니다.
+              onClick={() => onOpen(group.people[0].id)}
+            >
+              <span className={`${styles.mark} ${styles[group.tone]}`} aria-hidden="true">
+                {group.mark}
+              </span>
+              <span className={styles.body}>
+                <span className={styles.title}>
+                  {group.title} {group.people.length}명
+                </span>
+                <span className={styles.names}>{names(group.people)}</span>
+              </span>
+              <span className={styles.action}>{group.people[0].display_name} 열기</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/frontend/src/pages/Team/components/AttentionCard/index.ts
+++ b/frontend/src/pages/Team/components/AttentionCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AttentionCard'

--- a/frontend/src/pages/Team/components/GoalBand/GoalBand.module.scss
+++ b/frontend/src/pages/Team/components/GoalBand/GoalBand.module.scss
@@ -1,0 +1,143 @@
+.band {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s3);
+}
+
+.head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s3);
+}
+
+.title {
+  margin: 0;
+  color: var(--ink);
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.month {
+  flex: none;
+}
+
+.tiles {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--s3);
+
+  // 넷이 한 줄에 서면 금액이 두 줄로 접힙니다. 접히기 전에 둘씩 내립니다.
+  @include lg {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  @include sm {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+// 누르는 곳이 아니므로 hover·그림자 변화를 넣지 않습니다.
+.tile {
+  @include card;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: var(--s4);
+
+  strong {
+    font-size: 24px;
+    font-weight: 700;
+    letter-spacing: -0.022em;
+    color: var(--ink);
+  }
+
+  // 숫자가 없는 자리. 사정을 적을 뿐이므로 금액만 한 목소리를 내지 않습니다.
+  .soft {
+    font-size: 18px;
+    color: var(--muted);
+  }
+
+  // 보조 줄은 타일 바닥에 붙여 옆 타일과 높이를 맞춥니다.
+  small {
+    margin-top: auto;
+    padding-top: var(--s2);
+    color: var(--muted);
+    font-size: 11px;
+  }
+}
+
+.label {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+// 목표 대비 어디쯤인지 알리는 칩. 색은 목록의 상태 배지와 같은 눈금(70/40)을 씁니다.
+.chip {
+  @include tag-pill;
+  padding: 2px 7px;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.good {
+  background: var(--green-tint);
+  color: var(--green-ink);
+}
+
+.warn {
+  background: var(--orange-tint);
+  color: var(--orange-ink);
+}
+
+.bad {
+  background: var(--red-tint);
+  color: var(--red-ink);
+}
+
+.track {
+  position: relative;
+  height: 6px;
+  margin-top: var(--s2);
+  border-radius: var(--r-pill);
+  background: var(--fill);
+  overflow: hidden;
+
+  i {
+    display: block;
+    height: 100%;
+    width: var(--p, 0%);
+    border-radius: inherit;
+    background: linear-gradient(90deg, var(--blue), #4da3ff);
+    transition: width var(--t-slow) var(--ease-spring);
+  }
+}
+
+// 목표 초과. 달성률 숫자는 자르지 않으므로 116% 같은 값이 그대로 섭니다.
+.isOver {
+  strong {
+    color: var(--green-ink);
+  }
+
+  .track i {
+    background: linear-gradient(
+      90deg,
+      var(--green) 0 var(--split),
+      var(--green-ink) var(--split) 100%
+    );
+  }
+
+  // 100% 눈금. 막대 위에 얇게 파인 자국으로 넘어선 구간을 갈라 놓습니다.
+  .track::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: var(--mark);
+    width: 2px;
+    margin-left: -1px;
+    background: var(--surface);
+    opacity: 0.75;
+  }
+}

--- a/frontend/src/pages/Team/components/GoalBand/GoalBand.tsx
+++ b/frontend/src/pages/Team/components/GoalBand/GoalBand.tsx
@@ -1,0 +1,135 @@
+// 팀 관리 첫 단. 이번 달 팀의 숫자를 네 조각으로 세웁니다.
+//
+// 대시보드 매출 목표 타일과 같은 막대(--p/--mark/--split)를 씁니다. 같은 값을 두 화면이
+// 다른 모양으로 그리면 팀장이 둘을 견주지 못합니다. 달성률은 언제나 서버가 셈해 준 값입니다.
+//
+// 타일은 누르는 곳이 아닙니다. 이 화면에서 실제로 열리는 것은 아래 구성원 줄뿐이라
+// 대시보드와 달리 button 이 아닌 글상자로 두고 hover 도 넣지 않습니다.
+import Select, { type SelectOption } from '@/components/Select'
+import type { StatusTone } from '@/components/StatusBadge'
+import type { TeamOverviewResponse } from '@/types'
+import { wonFull } from '@/utils/format'
+
+import { health } from '../../health'
+
+import styles from './GoalBand.module.scss'
+
+// 칩 색은 목록의 상태 배지와 같은 눈금(health)을 씁니다. 위 카드는 주황인데 아래 배지는
+// 초록이면, 한 화면이 같은 숫자를 두고 서로 다른 말을 하게 됩니다.
+const CHIP: Partial<Record<StatusTone, string>> = {
+  green: styles.good,
+  orange: styles.warn,
+  red: styles.bad,
+}
+
+interface Props {
+  data: TeamOverviewResponse
+  /** 재직 중인 구성원 수. 목록에서 세어 넘깁니다. */
+  activeCount: number
+  /** 'YYYY-MM-01' */
+  month: string
+  monthOptions: readonly SelectOption[]
+  onMonthChange: (month: string) => void
+}
+
+/** 이 달 말일까지 남은 일수. 지난달을 보고 있으면 셈하지 않습니다. */
+function daysLeftIn(month: string): number | null {
+  const now = new Date()
+  const current = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-01`
+  if (month !== current) return null
+  const last = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate()
+  return last - now.getDate()
+}
+
+export default function GoalBand({ data, activeCount, month, monthOptions, onMonthChange }: Props) {
+  const target = data.team_target
+  const confirmed = data.team_confirmed
+  // 목표가 없으면 0% 가 아니라 '미설정' 입니다. 서버가 달성률을 null 로 갈라 줍니다.
+  const hasTarget = data.team_rate !== null
+  const percent = data.team_rate ?? 0
+  const remaining = Math.max(0, target - confirmed)
+  const surplus = confirmed - target
+  const daysLeft = daysLeftIn(month)
+
+  // 목표를 넘기면 트랙이 100% 가 아니라 달성률 전체를 담습니다. 그래야 막대가 잘리지 않고
+  // 100% 눈금이 트랙 안에 남아 얼마나 넘었는지가 길이로 읽힙니다.
+  const trackMax = Math.max(percent, 100)
+  const over = hasTarget && surplus > 0
+  const tone = health(data.team_rate).tone
+
+  return (
+    <section className={styles.band} aria-labelledby="team-goal-heading">
+      <div className={styles.head}>
+        <h2 id="team-goal-heading" className={styles.title}>
+          팀 목표 매출
+        </h2>
+        <Select
+          label="기준 월"
+          size="sm"
+          value={month}
+          options={monthOptions}
+          onChange={onMonthChange}
+          className={styles.month}
+        />
+      </div>
+
+      <div className={styles.tiles}>
+        <div className={styles.tile}>
+          <span className={styles.label}>팀 목표</span>
+          <strong className="tnum">{wonFull(target)}</strong>
+          {/* 지금은 팀 목표를 따로 세우지 않고 팀원 목표를 더해 씁니다. 두 값을 나눠 두면
+              나중에 팀 목표를 따로 넣게 되어도 이 자리가 그대로 남습니다. */}
+          <small className="tnum">팀원 목표 합계 {wonFull(data.member_target_sum)}</small>
+        </div>
+
+        <div className={styles.tile}>
+          <span className={styles.label}>현재 매출</span>
+          <strong className="tnum">{wonFull(confirmed)}</strong>
+          <small>
+            {hasTarget ? (
+              <i className={`${styles.chip} ${CHIP[tone] ?? ''}`}>목표의 {percent}%</i>
+            ) : (
+              '이번 달 확정된 계약 금액'
+            )}
+          </small>
+        </div>
+
+        <div className={styles.tile}>
+          <span className={styles.label}>{over ? '목표 초과' : '목표까지'}</span>
+          <strong className="tnum">{hasTarget ? wonFull(over ? surplus : remaining) : '—'}</strong>
+          <small>
+            {!hasTarget
+              ? '목표를 정하면 남은 금액이 나옵니다'
+              : daysLeft === null
+                ? `${data.target_month} 기준`
+                : daysLeft === 0
+                  ? '오늘이 이달 마지막 날입니다'
+                  : `이번 달 ${daysLeft}일 남음`}
+          </small>
+        </div>
+
+        <div className={`${styles.tile} ${over ? styles.isOver : ''}`}>
+          <span className={styles.label}>달성률</span>
+          <strong className={hasTarget ? 'tnum' : styles.soft}>
+            {hasTarget ? `${percent}%` : '목표 미설정'}
+          </strong>
+          {hasTarget && (
+            <div
+              className={styles.track}
+              style={
+                {
+                  '--p': `${(percent / trackMax) * 100}%`,
+                  '--mark': `${(100 / trackMax) * 100}%`,
+                  '--split': percent > 0 ? `${(100 / percent) * 100}%` : '100%',
+                } as React.CSSProperties
+              }
+            >
+              <i />
+            </div>
+          )}
+          <small>재직 중인 구성원 {activeCount}명</small>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/pages/Team/components/GoalBand/index.ts
+++ b/frontend/src/pages/Team/components/GoalBand/index.ts
@@ -1,0 +1,1 @@
+export { default } from './GoalBand'

--- a/frontend/src/pages/Team/components/MemberRow/MemberRow.module.scss
+++ b/frontend/src/pages/Team/components/MemberRow/MemberRow.module.scss
@@ -8,8 +8,42 @@
   cursor: pointer;
 }
 
+.person {
+  display: flex;
+  align-items: center;
+  gap: var(--s3);
+}
+
+// 담당자 색을 알아보는 자리입니다. 이름표(OwnerName)와 같은 색을 원으로만 씁니다.
+.avatar {
+  flex: none;
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border-radius: var(--r-pill);
+  background: var(--fill);
+  color: var(--ink-2);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.identity {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1px;
+  // 직책이 있는 줄만 키가 커지면 표가 들쭉날쭉해집니다. 두 줄 자리를 늘 잡아 둡니다.
+  min-height: 32px;
+  min-width: 0;
+}
+
+.nameLine {
+  display: flex;
+  align-items: center;
+}
+
 // 이름 칸의 키보드용 손잡이입니다. 누를 곳은 줄 전체이므로 밑줄은 긋지 않습니다.
-// '나' 이름표가 옆에 서므로 블록이 아니라 글줄 안에 둡니다.
 .openButton {
   padding: 0;
   border: 0;
@@ -32,22 +66,45 @@
   font-weight: 700;
 }
 
-.right {
-  text-align: right !important;
+.job {
+  color: var(--muted);
+  font-size: 12px;
 }
 
-.rate {
-  display: inline-flex;
+.role {
+  display: flex;
   align-items: center;
   gap: var(--s2);
-  min-width: 108px;
+}
+
+.region {
+  color: var(--ink-2);
+  font-size: 12px;
+}
+
+.progressCell {
+  // 남는 폭을 이 칸이 다 가져갑니다. 표를 훑을 때 먼저 잡히는 것이 막대 길이이므로,
+  // 오른쪽에 빈 자리를 남기고 막대를 짧게 두지 않습니다.
+  width: 100%;
+  min-width: 220px;
+}
+
+.amounts {
+  display: block;
+  color: var(--ink);
+  font-size: 13px;
+
+  em {
+    color: var(--muted);
+    font-style: normal;
+  }
 }
 
 // 대시보드 매출 목표 막대와 같은 모양을 한 단계 얇게 씁니다.
 .track {
-  flex: 1;
+  display: block;
   height: 4px;
-  min-width: 48px;
+  margin-top: 6px;
   border-radius: var(--r-pill);
   background: var(--fill);
   overflow: hidden;
@@ -60,4 +117,13 @@
     background: var(--blue);
     transition: width var(--t-slow) var(--ease-spring);
   }
+}
+
+.right {
+  text-align: right !important;
+}
+
+// 달성률이 없는 자리. 상태 칸이 '미설정' 을 말하므로 여기서는 조용히 비웁니다.
+.blank {
+  color: var(--muted-2);
 }

--- a/frontend/src/pages/Team/components/MemberRow/MemberRow.tsx
+++ b/frontend/src/pages/Team/components/MemberRow/MemberRow.tsx
@@ -2,10 +2,17 @@
 //
 // 다른 목록(고객·자료실·고객불만)과 같이 줄 아무 곳이나 눌러 상세를 엽니다. 줄은 초점을
 // 받지 못하므로 이름 칸에 키보드용 손잡이를 하나 둡니다.
-import StatusBadge, { type StatusTone } from '@/components/StatusBadge'
+//
+// 한 사람에 대한 여덟 칸을 다섯으로 묶었습니다. 직책·지역처럼 자주 비는 값은 제 칸을
+// 가지면 표가 '—' 로 덮이므로, 있을 때만 이름·역할 옆에 붙는 곁줄로 둡니다.
+import StatusBadge from '@/components/StatusBadge'
+import { useOwnerColor } from '@/shared/ownerColors'
 import { regionLabel } from '@/shared/regionCodes'
 import type { Role, TeamMemberRow } from '@/types'
+import { readableInk } from '@/utils/color'
 import { wonFull } from '@/utils/format'
+
+import { health } from '../../health'
 
 import styles from './MemberRow.module.scss'
 
@@ -18,21 +25,12 @@ interface MemberRowProps {
 
 const ROLE_LABEL: Record<Role, string> = { manager: '팀장', member: '팀원' }
 
-// 달성률로 가르는 눈금. 팀장이 먼저 봐야 할 사람을 색으로 띄웁니다.
-const HEALTHY = 70
-const WATCH = 40
-
-function health(rate: number | null): { label: string; tone: StatusTone } {
-  // 목표를 세우지 않았으면 잘하고 못하고를 말할 수 없습니다.
-  if (rate === null) return { label: '미설정', tone: 'neutral' }
-  if (rate >= HEALTHY) return { label: '정상', tone: 'green' }
-  if (rate >= WATCH) return { label: '주의', tone: 'orange' }
-  return { label: '위험', tone: 'red' }
-}
-
 export default function MemberRow({ member, isSelf, onOpen }: MemberRowProps) {
+  // 색의 주인은 언제나 DB 입니다. 이름에서 색을 지어내지 않습니다.
+  const color = useOwnerColor(member.id)
   const state = health(member.achievement_rate)
   const rate = member.achievement_rate
+  const region = member.region_code === null ? null : regionLabel(member.region_code)
 
   return (
     <tr
@@ -40,45 +38,73 @@ export default function MemberRow({ member, isSelf, onOpen }: MemberRowProps) {
       onClick={onOpen}
     >
       <td>
-        <button
-          type="button"
-          className={styles.openButton}
-          onClick={(event) => {
-            event.stopPropagation()
-            onOpen()
-          }}
-        >
-          {member.display_name}
-        </button>
-        {isSelf && <span className={styles.self}>나</span>}
-      </td>
-
-      <td>{member.job_title ?? '—'}</td>
-
-      <td>
-        <StatusBadge
-          label={ROLE_LABEL[member.role_code]}
-          tone={member.role_code === 'manager' ? 'blue' : 'neutral'}
-        />
-      </td>
-
-      <td>{regionLabel(member.region_code)}</td>
-
-      <td className={`${styles.right} tnum`}>{wonFull(member.target_amount)}</td>
-      <td className={`${styles.right} tnum`}>{wonFull(member.confirmed_amount)}</td>
-
-      <td>
-        <span className={styles.rate}>
-          <span className="tnum">{rate === null ? '—' : `${rate}%`}</span>
-          {/* 숫자 옆의 얇은 막대. 표를 훑을 때 눈으로 먼저 잡히는 것은 길이입니다. */}
+        <span className={styles.person}>
+          {/* 색을 정해 두지 않았으면 회색 그대로 섭니다. */}
           <span
-            className={styles.track}
-            style={{ '--p': `${Math.min(100, rate ?? 0)}%` } as React.CSSProperties}
+            className={styles.avatar}
+            style={color === null ? undefined : { background: color, color: readableInk(color) }}
             aria-hidden="true"
           >
-            <i />
+            {member.display_name.trim().slice(0, 1)}
+          </span>
+          <span className={styles.identity}>
+            <span className={styles.nameLine}>
+              <button
+                type="button"
+                className={styles.openButton}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  onOpen()
+                }}
+              >
+                {member.display_name}
+              </button>
+              {isSelf && <span className={styles.self}>나</span>}
+            </span>
+            {member.job_title !== null && <span className={styles.job}>{member.job_title}</span>}
           </span>
         </span>
+      </td>
+
+      <td>
+        <span className={styles.role}>
+          <StatusBadge
+            label={ROLE_LABEL[member.role_code]}
+            tone={member.role_code === 'manager' ? 'blue' : 'neutral'}
+          />
+          {region !== null && <span className={styles.region}>{region}</span>}
+        </span>
+      </td>
+
+      <td className={styles.progressCell}>
+        {member.target_amount === 0 ? (
+          // 목표가 없는 사람에게 '₩0 / ₩0' 은 아무것도 알려 주지 않습니다.
+          <span className={`${styles.amounts} tnum`}>{wonFull(member.confirmed_amount)}</span>
+        ) : (
+          <>
+            <span className={`${styles.amounts} tnum`}>
+              {wonFull(member.confirmed_amount)} <em>/ {wonFull(member.target_amount)}</em>
+            </span>
+            {/* 표를 훑을 때 눈으로 먼저 잡히는 것은 숫자가 아니라 길이입니다. */}
+            <span
+              className={styles.track}
+              style={{ '--p': `${Math.min(100, rate ?? 0)}%` } as React.CSSProperties}
+              aria-hidden="true"
+            >
+              <i />
+            </span>
+          </>
+        )}
+      </td>
+
+      <td className={styles.right}>
+        {/* 목표가 없으면 달성률도 없습니다. 무엇을 해야 하는지는 위 카드가 한 번만 말합니다.
+            여기까지 파란 손잡이를 두면 여덟 줄이 전부 손잡이가 되어 진짜 할 일이 묻힙니다. */}
+        {rate === null ? (
+          <span className={styles.blank}>—</span>
+        ) : (
+          <span className="tnum">{rate}%</span>
+        )}
       </td>
 
       <td>

--- a/frontend/src/pages/Team/health.ts
+++ b/frontend/src/pages/Team/health.ts
@@ -1,0 +1,18 @@
+// 달성률로 사람을 가르는 눈금입니다.
+//
+// 목록의 상태 배지와 '확인이 필요한 구성원' 카드가 같은 기준을 봐야 합니다. 한쪽만
+// 눈금을 옮기면 목록에서는 '주의'인 사람이 위쪽 카드에는 안 뜨는 일이 생깁니다.
+import type { StatusTone } from '@/components/StatusBadge'
+
+/** 이만큼 왔으면 팀장이 따로 볼 일이 없습니다. */
+export const HEALTHY = 70
+/** 이 아래는 이달 안에 따라잡기 어렵습니다. */
+export const WATCH = 40
+
+export function health(rate: number | null): { label: string; tone: StatusTone } {
+  // 목표를 세우지 않았으면 잘하고 못하고를 말할 수 없습니다.
+  if (rate === null) return { label: '미설정', tone: 'neutral' }
+  if (rate >= HEALTHY) return { label: '정상', tone: 'green' }
+  if (rate >= WATCH) return { label: '주의', tone: 'orange' }
+  return { label: '위험', tone: 'red' }
+}


### PR DESCRIPTION
## 변경 요약

팀 관리는 목표 카드 한 장과 여덟 열짜리 표 하나였습니다. 목표를 세우지 않은 달에는 화면 전체가 `₩0` 과 `—` 로 덮여, 팀장이 무엇을 먼저 해야 하는지 읽어낼 수 없었습니다. 이번 달 숫자 요약 → 지금 확인할 사람 → 구성원별 진척 순으로 세워, 위에서 아래로 한 번 훑으면 다음 할 일이 정해지도록 했습니다.

**백엔드 변경 없음.** `GET /api/team/members` 가 이미 주는 값만 씁니다. 새 엔드포인트·새 요청·새 의존성이 없어 호출 수와 페이로드는 이전과 같습니다.

- `GoalBand` (신규): 팀 목표 / 현재 매출 / 목표까지 / 달성률 네 타일. 대시보드 매출 목표 타일과 같은 막대(`--p`/`--mark`/`--split`)를 써서 초과분이 눈금과 색으로 읽힙니다. 누르는 곳이 아니므로 `button` 이 아닌 글상자로 두었습니다. 기준 월 선택을 붙여 지난달도 볼 수 있습니다(훅이 이미 `target_month` 를 받고 있었습니다).
- `AttentionCard` (신규): 목표 미설정 · 달성률 40% 미만 · 비활성을 이미 받은 목록에서 추려 갈래마다 한 줄만 세우고, 누르면 첫 사람의 상세가 열립니다. 볼 것이 없으면 카드 자체가 서지 않습니다.
- `MemberRow`: 여덟 열을 다섯으로 묶어 자주 비는 직책·담당지역이 `—` 로 남지 않게 했습니다. 담당자 색을 원형 이니셜로 쓰고(`ownerColors`·`readableInk` 재사용), 달성률 막대가 남는 폭을 다 가져갑니다.
- `health.ts` (신규): 상태 배지의 눈금(70/40)을 꺼내 요약 칩·개입 카드·목록이 같은 기준을 보게 했습니다.
- `Team.tsx`: 비활성 구성원을 목록 맨 아래로 내립니다.

기존 여덟 열이 담던 정보는 하나도 빠지지 않았습니다. 편집도 손대지 않아 줄을 누르면 같은 `MemberDrawer` 가 열리고 PATCH 계약·본인 역할 변경 잠금·저장 후 `refreshOwnerColors()` 가 그대로입니다. 달성률은 지금까지처럼 서버가 셈해 준 값을 씁니다.

## 검증

- `npm run lint` / `npm run typecheck` / `npm run format:check` 통과
- `npm test` 91개 전부 통과
- 브라우저(로그인 상태)로 `/team` 확인
  - 목표 미설정 달(2026-09)과 목표가 있는 달(2026-07) 양쪽의 표시 확인 — 정상/주의/미설정 배지, 105% 초과 행, 달성률 막대
  - 기준 월 전환 시 `target_month=2026-07-01` 로 재요청되고 숫자가 갈아 끼워짐
  - 행 클릭 및 키보드(Enter 로 드로어 열림, Esc 로 이름 손잡이에 초점 복귀)
  - 1440 / 1024 / 520px 에서 페이지 본문 가로 스크롤 없음(표는 카드 안에서만 가로 스크롤)
- 저장(PATCH) 흐름은 실제 운영 데이터를 건드리게 되어 실행하지 않았습니다. 해당 코드 경로는 이번 변경에서 수정하지 않았습니다.

## 영향 및 주의 사항

- 영향 범위는 `/team` 화면뿐입니다. 백엔드·API 계약·다른 화면 변경 없음.
- 참고 화면에 있던 파이프라인 단계별 금액, 예상 실적, 구성원 최근 활동, 코칭 과제는 현재 API 에 근거가 없어 만들지 않았습니다. 필요하다면 집계 엔드포인트 신설이 선행되어야 합니다.
- 마이그레이션·수동 작업 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 팀 목표 화면을 개편해 월별 목표, 현재 매출, 달성률을 한눈에 확인할 수 있습니다.
  * 월을 선택해 기간별 목표 현황을 조회할 수 있습니다.
  * 목표 미설정, 낮은 달성률, 비활성 구성원을 별도 카드에서 확인할 수 있습니다.
  * 구성원 목록에 아바타, 직책·지역, 매출 진행률이 표시됩니다.
  * 구성원 달성률을 정상·주의·위험 상태로 구분해 표시합니다.

* **스타일 개선**
  * 카드, 목표 요약 영역, 표 헤더와 진행률 표시의 시각적 구성이 개선되었습니다.
  * 좁은 화면에서도 팀 현황을 더 쉽게 확인할 수 있도록 반응형 레이아웃을 적용했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->