### PR TITLE
feat: 고객 상세에 그 회사의 영업 현황을 함께 보여준다

### DIFF
--- a/frontend/src/hooks/useCompanyDeals.ts
+++ b/frontend/src/hooks/useCompanyDeals.ts
@@ -1,8 +1,8 @@
-// 이 미팅의 고객사에 걸린 영업 현황을 받아 옵니다.
+// 한 고객사에 걸린 영업 현황을 받아 옵니다.
 //
-// 보고서 작성 화면에서 "무엇에 대한 미팅이었는지" 를 고르는 목록입니다. 한 회사에
-// 딜이 수십 건씩 쌓이는 곳은 아직 없어 첫 쪽만 받고 더 받지 않습니다. 목록이 길어지면
-// Deals 화면처럼 페이징을 붙일 자리입니다.
+// 보고서 작성의 "무엇에 대한 미팅이었는지" 와 고객 상세의 "이 회사 영업 현황" 이 같은
+// 조회를 봅니다. 한 회사에 딜이 수십 건씩 쌓이는 곳은 아직 없어 첫 쪽만 받고 더 받지
+// 않습니다. 목록이 길어지면 Deals 화면처럼 페이징을 붙일 자리입니다.
 import { useCallback, useEffect, useState } from 'react'
 
 import { client } from '@/api/client'
@@ -11,7 +11,7 @@ import { toSalesDeal, type SalesDeal } from '@/pages/Deals/useSalesDeals'
 import type { PageResponse, SalesDealResponse } from '@/types'
 
 /** 서버가 한 쪽에 주는 최대치입니다. SalesDealPageParams 가 30 을 넘기면 거절합니다. */
-const LIMIT = 30
+export const COMPANY_DEAL_LIMIT = 30
 
 export default function useCompanyDeals(companyId?: string | null) {
   const [deals, setDeals] = useState<SalesDeal[]>([])
@@ -32,7 +32,7 @@ export default function useCompanyDeals(companyId?: string | null) {
     setError(null)
     client
       .get<PageResponse<SalesDealResponse>>('/sales-deals', {
-        params: { customer_company_id: companyId, limit: LIMIT },
+        params: { customer_company_id: companyId, limit: COMPANY_DEAL_LIMIT },
         signal: controller.signal,
       })
       .then(({ data }) => {

--- a/frontend/src/pages/Customers/components/CustomerDrawer/CustomerDeals.tsx
+++ b/frontend/src/pages/Customers/components/CustomerDrawer/CustomerDeals.tsx
@@ -1,0 +1,81 @@
+// 고객 상세 안에서 그 회사에 걸린 영업 현황을 세로로 늘어놓습니다.
+//
+// 딜은 회사에 걸리므로 같은 회사의 다른 담당자를 열어도 같은 목록이 나옵니다. 지금 연
+// 고객이 그 딜의 대표 담당자인 줄만 '담당' 을 달고 맨 위로 올려, 회사 맥락은 남기되
+// 이 사람이 무엇을 들고 있는지가 먼저 보이게 합니다.
+//
+// 줄을 누르면 영업현황으로 넘어가 그 딜 상세가 열립니다. 여기서 딜을 고치지는 않습니다.
+import { Link } from 'react-router'
+
+import Button from '@/components/Button'
+import { SkeletonBlocks } from '@/components/Skeleton'
+import StageChip from '@/components/StageChip'
+import { dealDetailPath } from '@/constants/routes'
+import { COMPANY_DEAL_LIMIT } from '@/hooks/useCompanyDeals'
+import type { SalesDeal } from '@/pages/Deals/useSalesDeals'
+import { fmtDot, parseISO } from '@/utils/date'
+import { wonFull } from '@/utils/format'
+
+import styles from './CustomerDrawer.module.scss'
+
+interface Props {
+  deals: SalesDeal[]
+  loading: boolean
+  error: string | null
+  onRetry: () => void
+  /** 지금 연 고객. 이 사람이 대표 담당자인 딜을 표시하고 위로 올리는 기준입니다. */
+  contactId: string
+}
+
+export default function CustomerDeals({ deals, loading, error, onRetry, contactId }: Props) {
+  if (loading) {
+    return <SkeletonBlocks label="영업 현황을 불러오는 중입니다." count={2} height={58} />
+  }
+
+  if (error) {
+    return (
+      <div className={styles.dealError} role="alert">
+        <p>{error}</p>
+        <Button variant="outline" size="sm" type="button" onClick={onRetry}>
+          다시 시도
+        </Button>
+      </div>
+    )
+  }
+
+  if (deals.length === 0) {
+    return <p className={styles.muted}>이 회사에 연결된 영업 현황이 없습니다.</p>
+  }
+
+  // 서버가 준 순서를 그대로 두고 담당 건만 앞으로 당깁니다. sort 는 제자리에서 바꾸므로
+  // 훅이 들고 있는 배열을 건드리지 않게 복사한 뒤 정렬합니다.
+  const mine = (deal: SalesDeal) => deal.contactId === contactId
+  const ordered = [...deals].sort((a, b) => Number(mine(b)) - Number(mine(a)))
+
+  return (
+    <>
+      <div className={styles.stack}>
+        {ordered.map((deal) => (
+          <Link key={deal.id} className={styles.link} to={dealDetailPath(deal.id)}>
+            <span className={styles.dealBody}>
+              {/* 제목이 비어 있는 딜이 있습니다. 그때는 제품이 그 자리를 대신합니다. */}
+              <strong>{deal.title.trim() || deal.product}</strong>
+              <small className="tnum">
+                {deal.no} · {wonFull(deal.amount)} · {fmtDot(parseISO(deal.date))}
+              </small>
+            </span>
+            <span className={styles.dealSide}>
+              {mine(deal) && <i className={styles.pill}>담당</i>}
+              <StageChip tone={deal.stageTone}>{deal.stageName}</StageChip>
+            </span>
+          </Link>
+        ))}
+      </div>
+      {deals.length === COMPANY_DEAL_LIMIT && (
+        <p className={styles.dealMore}>
+          최근 {COMPANY_DEAL_LIMIT}건까지 보여줍니다. 나머지는 영업현황에서 확인하세요.
+        </p>
+      )}
+    </>
+  )
+}

--- a/frontend/src/pages/Customers/components/CustomerDrawer/CustomerDrawer.module.scss
+++ b/frontend/src/pages/Customers/components/CustomerDrawer/CustomerDrawer.module.scss
@@ -85,16 +85,51 @@
   align-content: start;
 }
 
-.block {
-  h3 {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: var(--s3);
-    margin-bottom: var(--s3);
-    font-size: 13px;
-    font-weight: 700;
-  }
+.block h3,
+.deals h3 {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--s3);
+  margin-bottom: var(--s3);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+// 2열 아래에 전체 폭으로 눕는 회사 단위 섹션입니다. 위 정보와 다른 축의 내용이라
+// 컬럼 안에 끼우지 않고 선 하나로 끊어 세웁니다.
+.deals {
+  margin-top: var(--s6);
+  padding-top: var(--s5);
+  border-top: 1px solid var(--line);
+}
+
+.dealBody {
+  min-width: 0;
+}
+
+// 단계 칩과 '담당' 배지. .tags 와 달리 제목과 같은 줄 오른쪽에 붙습니다.
+.dealSide {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: 5px;
+}
+
+.dealMore {
+  margin-top: var(--s3);
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.dealError {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--s2);
+  color: var(--red);
+  font-size: 12px;
+  line-height: 1.6;
 }
 
 // 회사 단위 섹션임을 밝히거나 합계를 다는 자리입니다.

--- a/frontend/src/pages/Customers/components/CustomerDrawer/CustomerDrawer.tsx
+++ b/frontend/src/pages/Customers/components/CustomerDrawer/CustomerDrawer.tsx
@@ -4,9 +4,11 @@ import { buttonClass } from '@/components/Button'
 import Drawer from '@/components/Drawer'
 import { EditIcon, MoreIcon, TrashIcon } from '@/components/icons'
 import Popover from '@/components/Popover'
+import useCompanyDeals from '@/hooks/useCompanyDeals'
 import type { Customer } from '@/types'
 import { fmtDay, parseISO } from '@/utils/date'
 
+import CustomerDeals from './CustomerDeals'
 import styles from './CustomerDrawer.module.scss'
 
 interface Props {
@@ -36,6 +38,8 @@ const shown = (value: string | null | undefined): string => value || '—'
 
 export default function CustomerDrawer({ customer, canDelete, onEdit, onDelete, onClose }: Props) {
   const [menuOpen, setMenuOpen] = useState(false)
+  // 딜은 사람이 아니라 회사에 걸립니다. 고객을 바꾸면 companyId 가 바뀌어 다시 받아 옵니다.
+  const { deals, loading, error, reload } = useCompanyDeals(customer.companyId)
 
   // 담당자가 여럿이면 상세에서는 전부 보여 줍니다. 좁은 표와 달리 자리가 있습니다.
   const ownerNames =
@@ -190,6 +194,20 @@ export default function CustomerDrawer({ customer, canDelete, onEdit, onDelete, 
           </Block>
         </div>
       </div>
+
+      <section className={styles.deals}>
+        <h3>
+          영업 현황
+          {deals.length > 0 && <span className={styles.blockNote}>{deals.length}건</span>}
+        </h3>
+        <CustomerDeals
+          deals={deals}
+          loading={loading}
+          error={error}
+          onRetry={reload}
+          contactId={customer.id}
+        />
+      </section>
     </Drawer>
   )
 }

--- a/frontend/src/pages/Meetings/Compose.tsx
+++ b/frontend/src/pages/Meetings/Compose.tsx
@@ -7,6 +7,7 @@ import { Link, useNavigate, useSearchParams } from 'react-router'
 import { isAxiosError, isCancel } from 'axios'
 
 import { useCurrentUser } from '@/auth/sessionContext'
+import useCompanyDeals from '@/hooks/useCompanyDeals'
 import { errorMessage, reportGenerationMessage } from '@/api/errorMessage'
 import {
   createReportGeneration,
@@ -41,7 +42,6 @@ import DealReportCard from './components/DealReportCard'
 import MeetingInfoPanel from './components/MeetingInfoPanel'
 import MeetingInputPanel from './components/MeetingInputPanel'
 import MeetingSharedPanel from './components/MeetingSharedPanel'
-import useCompanyDeals from './useCompanyDeals'
 import useMeetingDraft, { hasMeetingDraftContent, isMeetingBodyBlank } from './useMeetingDraft'
 import useMeetingReports, {
   type MeetingDealDraftPayload,


### PR DESCRIPTION
## 변경 요약

고객현황에서 고객을 열면 연락처·회사·고객 정보와 메모만 보여, 이 사람이 속한 회사에 어떤 딜이 어느 단계까지 와 있는지는 영업현황으로 따로 넘어가야 알 수 있었습니다. 상세 드로어 2열 아래에 그 회사의 영업 현황을 전체 폭으로 붙였습니다.

- 딜은 사람이 아니라 회사에 걸리므로 회사 전체를 받아 옵니다. 다만 지금 연 고객이 그 딜의 대표 담당자인 줄에는 `담당` 을 달고 맨 위로 올려, 회사 맥락은 남기되 이 사람이 무엇을 들고 있는지가 먼저 보이게 했습니다.
- 줄마다 단계 칩·딜번호·금액·시작일을 붙이고, 누르면 영업현황(`/deals?deal=<id>`)의 그 딜 상세로 넘어갑니다. 로딩·오류·빈 목록을 각각 나눠 보여 줍니다.
- 회사 딜이 한 쪽 최대치(30건)만큼 꽉 차면 나머지는 영업현황에서 보라고 알립니다. 페이징은 붙이지 않았습니다.
- 회사 id 로 딜을 받아 오는 `useCompanyDeals` 를 `pages/Meetings/` 에서 `hooks/` 로 옮겼습니다. 업무보고서 작성과 고객 상세가 같은 조회를 보게 되어 한 화면 폴더에 둘 수 없습니다. (선행 커밋)

백엔드 변경은 없습니다. 기존 `/api/sales-deals` 의 `customer_company_id` 필터를 그대로 씁니다. 목록 줄 모양도 `CustomerDrawer.module.scss` 에 이미 있던 `.stack`·`.link` 를 그대로 써 새 CSS 를 최소로 두었습니다.

## 검증

- `npm run lint` · `npm run typecheck` · `npm run format:check` 통과
- `npm run test` 91/91 통과
- 로컬 dev 서버 + 팀원 계정으로 화면 확인
  - 모먼트의원(B지점) 정지훈 → 영업 현황 7건, 본인 담당 건이 `담당` 배지를 달고 맨 위. 같은 회사의 이지훈을 열면 같은 7건이되 배지가 옮겨 붙고 순서가 재정렬됩니다.
  - 꿈동물병원 박지유 → `이 회사에 연결된 영업 현황이 없습니다.`
  - 딜 줄 클릭 → `/deals?deal=…` 로 이동하고 해당 딜 상세 드로어가 열립니다.
  - 회귀: `/meetings/new` 로드 시 콘솔 오류 없음 (훅 이동 영향 확인)
- 30건이 꽉 찬 회사는 로컬 자료에 없어 안내 문구는 화면에서 확인하지 못했습니다.

## 영향 및 주의 사항

- 고객 상세를 열 때마다 `/api/sales-deals?customer_company_id=…` 요청이 한 건 더 나갑니다. 목록 조회와 별개이며, 고객을 바꿔야 다시 받아 옵니다.
- `useCompanyDeals` 임포트 경로가 바뀌었습니다. 기존 사용처는 `Meetings/Compose.tsx` 하나뿐이라 함께 고쳤습니다.
- 마이그레이션·수동 작업 없음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 고객 상세 화면에 회사의 영업 현황(딜) 목록을 추가했습니다.
  * 딜별 제목, 번호, 금액, 날짜, 담당자 및 영업 단계를 확인할 수 있습니다.
  * 딜이 없거나 로딩·오류가 발생한 경우 상태별 안내와 재시도 기능을 제공합니다.
  * 표시 한도에 도달하면 추가 딜 안내를 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->