### PR TITLE
feat: 사업자등록증 원본을 보관하고 전화번호 저장 형식을 통일한다

### DIFF
--- a/backend/app/api/business_licenses.py
+++ b/backend/app/api/business_licenses.py
@@ -1,17 +1,35 @@
-"""사업자등록증 PDF·이미지 OCR API."""
+"""사업자등록증 PDF·이미지 OCR 및 원본 보관 API."""
 
+from datetime import datetime
 from pathlib import Path
 from typing import Annotated
-from uuid import UUID
+from uuid import UUID, uuid4
 
-from fastapi import APIRouter, BackgroundTasks, File, HTTPException, UploadFile, status
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    File,
+    Form,
+    HTTPException,
+    Response,
+    UploadFile,
+    status,
+)
+from sqlalchemy import select
 
-from app.api.deps import CurrentMember
+from app.api.deps import CurrentMember, DbSession
 from app.core.config import settings
+from app.models.content import Document
+from app.models.content import File as FileRow
+from app.models.crm import CustomerCompany
 from app.schemas.business_licenses import BusinessLicenseScanAccepted, BusinessLicenseScanStatus
-from app.services import business_license_scans
+from app.schemas.documents import DocumentRead
+from app.services import business_license_scans, storage
 from app.services.agent_logging import log_agent_event
+from app.services.storage import StorageError
 from app.services.upload_guard import (
+    AllowedMediaType,
+    AllowedType,
     UploadRejected,
     check_image_upload,
     check_size,
@@ -19,6 +37,30 @@ from app.services.upload_guard import (
 )
 
 router = APIRouter(tags=["business-licenses"])
+
+
+def _check_license_upload(
+    *,
+    file_name: str,
+    declared_media_type: str | None,
+    content: bytes,
+) -> AllowedType | AllowedMediaType:
+    """등록증은 PDF 와 사진을 함께 받는다. 인식과 보관이 같은 기준으로 막는다."""
+    check_size(len(content), settings.business_card_max_bytes)
+    extension = Path(file_name).suffix.lower()
+    if extension == ".pdf":
+        return check_upload(
+            file_name=file_name,
+            declared_media_type=declared_media_type,
+            content=content,
+        )
+    if extension in {".png", ".jpg", ".jpeg", ".webp"}:
+        return check_image_upload(
+            file_name=file_name,
+            declared_media_type=declared_media_type,
+            content=content,
+        )
+    raise UploadRejected("business_license_unsupported_file", 415)
 
 
 @router.post(
@@ -34,24 +76,13 @@ async def scan_business_license(
     """사업자등록증 인식을 접수하고 결과 조회용 scan_id를 돌려준다."""
 
     file_name = file.filename or "business-license"
-    extension = Path(file_name).suffix.lower()
     content = await file.read(settings.business_card_max_bytes + 1)
     try:
-        check_size(len(content), settings.business_card_max_bytes)
-        if extension == ".pdf":
-            allowed = check_upload(
-                file_name=file_name,
-                declared_media_type=file.content_type,
-                content=content,
-            )
-        elif extension in {".png", ".jpg", ".jpeg", ".webp"}:
-            allowed = check_image_upload(
-                file_name=file_name,
-                declared_media_type=file.content_type,
-                content=content,
-            )
-        else:
-            raise UploadRejected("business_license_unsupported_file", 415)
+        allowed = _check_license_upload(
+            file_name=file_name,
+            declared_media_type=file.content_type,
+            content=content,
+        )
     except UploadRejected as rejected:
         raise HTTPException(status_code=rejected.status_code, detail=rejected.detail) from rejected
 
@@ -103,3 +134,110 @@ async def get_business_license_scan(
             draft.ready_for_company_registration if draft is not None else False
         ),
     )
+
+
+@router.post(
+    "/business-licenses/archive",
+    response_model=DocumentRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def archive_business_license(
+    response: Response,
+    company_id: Annotated[UUID, Form()],
+    file: Annotated[UploadFile, File()],
+    member: CurrentMember,
+    db: DbSession,
+) -> DocumentRead:
+    """등록된 고객사에 사업자등록증 원본을 연결해 보관한다.
+
+    등록증은 사람이 아니라 회사의 문서다. 담당자가 아니라 회사에 묶어 두면 같은 회사의
+    담당자 상세가 모두 같은 원본을 보고, 담당자마다 같은 파일이 쌓이지 않는다.
+    """
+    if not settings.storage_configured:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="storage_not_configured",
+        )
+
+    file_name = file.filename or "business-license"
+    content = await file.read(settings.business_card_max_bytes + 1)
+    try:
+        allowed = _check_license_upload(
+            file_name=file_name,
+            declared_media_type=file.content_type,
+            content=content,
+        )
+    except UploadRejected as rejected:
+        raise HTTPException(status_code=rejected.status_code, detail=rejected.detail) from rejected
+
+    company = (
+        await db.execute(
+            select(CustomerCompany).where(
+                CustomerCompany.id == company_id,
+                CustomerCompany.team_id == member.team_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if company is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="customer_company_not_found",
+        )
+
+    storage_key = storage.build_storage_key(member.team_id, allowed.extension)
+    try:
+        await storage.upload(
+            storage_key=storage_key,
+            content=content,
+            media_type=allowed.media_type,
+        )
+    except StorageError as error:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(error),
+        ) from error
+
+    document_id = uuid4()
+    try:
+        # 문서번호 생성은 기존 자료실 규칙을 재사용하고, 여기서는 고객사 연결만 추가한다.
+        from app.api.documents import _detail, _next_document_no
+
+        db.add(
+            Document(
+                id=document_id,
+                team_id=member.team_id,
+                created_by_member_id=member.id,
+                document_no=await _next_document_no(db, member, datetime.now().year),
+                category_code="business_license",
+                title=f"{company.name} 사업자등록증",
+                description="사업자등록증 등록 시 보관된 원본",
+                customer_company_id=company.id,
+                tags=["business_license", "archive"],
+            )
+        )
+        db.add(
+            FileRow(
+                id=uuid4(),
+                report_id=None,
+                document_id=document_id,
+                # 명함 보관본과 같다. 버전은 관리하지 않지만 DB 검사가 1 이상을 요구한다.
+                version_no=1,
+                file_name=file_name.strip(),
+                storage_key=storage_key,
+                media_type=allowed.media_type,
+                byte_size=len(content),
+                processing_status="uploaded",
+                extracted_text=None,
+                uploaded_by_member_id=member.id,
+                note="사업자등록증 원본",
+            )
+        )
+        await db.commit()
+        read = await _detail(db, member, document_id)
+    except Exception:
+        await db.rollback()
+        await storage.remove(storage_key=storage_key)
+        raise
+
+    response.headers["Location"] = f"/api/documents/{document_id}"
+    return read

--- a/backend/app/api/customers.py
+++ b/backend/app/api/customers.py
@@ -11,11 +11,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
 from app.api.deps import CurrentMember, DbSession, owner_scope
+from app.core.config import settings
 from app.models.configuration import CustomerContactStatus
+from app.models.content import Document
+from app.models.content import File as FileRow
 from app.models.crm import CustomerCompany, CustomerContact, CustomerContactAssignee
 from app.models.workspace import Member
 from app.schemas.customers import (
     ContactAssigneeRead,
+    CustomerAttachmentRead,
     CustomerCompanyCreate,
     CustomerCompanyPage,
     CustomerCompanyPatch,
@@ -35,10 +39,15 @@ from app.schemas.customers import (
     CustomerPageParams,
     digits_only,
 )
-from app.services import customer_duplicates
+from app.services import customer_duplicates, storage
 from app.services.customer_duplicates import DuplicateProbe
+from app.services.storage import StorageError
 
 router = APIRouter(tags=["customers"])
+
+# 상세 드로어는 한동안 열어 두는 화면이다. 자료실 내려받기(60초)보다 넉넉히 두어야
+# 열어 둔 사이에 명함 사진이 빈칸이 되지 않는다.
+ATTACHMENT_EXPIRES_IN = 300
 
 
 def _contains(value: str) -> str:
@@ -519,6 +528,68 @@ async def get_customer_contact(
     db: DbSession,
 ) -> CustomerContactRead:
     return _contact_read(*await _get_contact_row(db, member, contact_id))
+
+
+@router.get(
+    "/customer-contacts/{contact_id}/attachments",
+    response_model=list[CustomerAttachmentRead],
+)
+async def list_customer_contact_attachments(
+    contact_id: UUID,
+    member: CurrentMember,
+    db: DbSession,
+) -> list[CustomerAttachmentRead]:
+    """등록에 쓴 원본. 명함은 그 담당자의 것이고, 사업자등록증은 회사의 것이다."""
+    contact = (await _get_contact_row(db, member, contact_id))[0]
+    if not settings.storage_configured:
+        # 첨부는 상세의 곁가지다. 저장소가 없다고 상세가 실패하면 안 된다.
+        return []
+
+    rows = (
+        await db.execute(
+            select(Document, FileRow)
+            .join(FileRow, FileRow.document_id == Document.id)
+            .where(
+                Document.team_id == member.team_id,
+                Document.deleted_at.is_(None),
+                or_(
+                    and_(
+                        Document.category_code == "business_card",
+                        Document.customer_contact_id == contact.id,
+                    ),
+                    and_(
+                        Document.category_code == "business_license",
+                        Document.customer_company_id == contact.company_id,
+                    ),
+                ),
+            )
+            .order_by(FileRow.uploaded_at.desc())
+        )
+    ).all()
+
+    attachments: list[CustomerAttachmentRead] = []
+    for document, file_row in rows:
+        try:
+            url = await storage.signed_url(
+                storage_key=file_row.storage_key,
+                expires_in=ATTACHMENT_EXPIRES_IN,
+            )
+        except StorageError:
+            # 한 건을 못 받았다고 나머지 첨부까지 감추지 않는다.
+            continue
+        attachments.append(
+            CustomerAttachmentRead(
+                kind=document.category_code,
+                document_id=document.id,
+                file_id=file_row.id,
+                file_name=file_row.file_name,
+                media_type=file_row.media_type,
+                byte_size=file_row.byte_size,
+                url=url,
+                expires_in=ATTACHMENT_EXPIRES_IN,
+            )
+        )
+    return attachments
 
 
 @router.post(

--- a/backend/app/api/customers.py
+++ b/backend/app/api/customers.py
@@ -33,6 +33,7 @@ from app.schemas.customers import (
     CustomerDuplicateProbe,
     CustomerDuplicateRead,
     CustomerPageParams,
+    digits_only,
 )
 from app.services import customer_duplicates
 from app.services.customer_duplicates import DuplicateProbe
@@ -43,6 +44,19 @@ router = APIRouter(tags=["customers"])
 def _contains(value: str) -> str:
     escaped = value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
     return f"%{escaped}%"
+
+
+def _phone_search(q: str):
+    """전화번호는 숫자만 남겨 견준다.
+
+    저장 형식이 숫자로 바뀌기 전에 들어온 값에는 하이픈이 남아 있다. 양쪽을 숫자로
+    맞춰야 010-1234 로 찾든 0101234 로 찾든 같은 사람이 나온다.
+    """
+    digits = digits_only(q)
+    if not digits:
+        return CustomerContact.phone.ilike(_contains(q), escape="\\")
+    stored = func.regexp_replace(CustomerContact.phone, r"[^0-9]", "", "g")
+    return stored.like(_contains(digits), escape="\\")
 
 
 async def _get_company(
@@ -450,7 +464,7 @@ async def list_customer_contacts(
                 CustomerContact.department.ilike(pattern, escape="\\"),
                 CustomerContact.job_title.ilike(pattern, escape="\\"),
                 CustomerContact.email.ilike(pattern, escape="\\"),
-                CustomerContact.phone.ilike(pattern, escape="\\"),
+                _phone_search(page.q),
             )
         )
     total_result = await db.execute(
@@ -598,14 +612,14 @@ async def check_customer_contact_duplicates(
 # 고객 등록 폼과 같은 규칙이다. 여기서 걸러야 한 줄의 오타가 나머지 줄까지 막지 않는다.
 _EMAIL = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
 
-# 각 칸이 담을 수 있는 길이. 단건 등록 스키마(Text·Phone·Memo)와 같은 값이다.
+# 각 칸이 담을 수 있는 길이. 단건 등록 스키마(Text·Memo)와 같은 값이다.
+# 전화번호는 숫자만 남긴 길이로 재므로 여기 두지 않는다.
 _BULK_LIMITS: tuple[tuple[str, str, int], ...] = (
     ("company_name", "company_too_long", 254),
     ("name", "name_too_long", 254),
     ("department", "department_too_long", 254),
     ("job_title", "job_title_too_long", 254),
     ("email", "email_too_long", 254),
-    ("phone", "phone_too_long", 50),
     ("memo", "memo_too_long", 5_000),
 )
 
@@ -616,13 +630,17 @@ def _bulk_problem(item: CustomerContactBulkItem) -> str | None:
         return "name_required"
     if not item.company_name.strip():
         return "company_required"
-    if not item.phone.strip():
+    phone = digits_only(item.phone)
+    if not phone:
         return "phone_required"
+    # 단건 등록 스키마의 Phone 과 같은 자릿수만 받는다.
+    if len(phone) > 20:
+        return "phone_too_long"
     email = item.email.strip()
     if email and not _EMAIL.match(email):
         return "email_invalid"
     business_no = item.business_no.strip()
-    if business_no and len(re.sub(r"[^0-9]", "", business_no)) != 10:
+    if business_no and len(digits_only(business_no)) != 10:
         return "business_no_invalid"
     for field_name, code, limit in _BULK_LIMITS:
         if len(getattr(item, field_name).strip()) > limit:
@@ -655,7 +673,7 @@ async def _bulk_company(
     )
     company = result.scalar_one_or_none()
     if company is None:
-        digits = re.sub(r"[^0-9]", "", business_no)
+        digits = digits_only(business_no)
         company = CustomerCompany(
             id=uuid4(),
             team_id=member.team_id,
@@ -762,7 +780,7 @@ async def create_customer_contacts_bulk(
                 department=item.department.strip() or None,
                 job_title=item.job_title.strip() or None,
                 email=item.email.strip() or None,
-                phone=item.phone.strip(),
+                phone=digits_only(item.phone),
                 customer_contact_status_id=None if contact_status is None else contact_status.id,
                 source_code=None,
                 memo=item.memo.strip() or None,

--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -76,9 +76,9 @@ _READ_COLUMNS = (
     _contact_owner.display_name,
 )
 
-# 자료실 목록에서 빼는 분류. 명함 보관본은 고객 명함을 등록할 때 원본 이미지를 붙여 두는
+# 자료실 목록에서 빼는 분류. 명함·사업자등록증 보관본은 고객을 등록할 때 원본을 붙여 두는
 # 것이라 자료실이 다루는 영업 문서가 아니다. 문서 하나를 여는 길(_detail)은 막지 않는다.
-_HIDDEN_CATEGORY_CODES = ("business_card",)
+_HIDDEN_CATEGORY_CODES = ("business_card", "business_license")
 
 DOWNLOAD_EXPIRES_IN = 60
 

--- a/backend/app/schemas/business_cards.py
+++ b/backend/app/schemas/business_cards.py
@@ -1,9 +1,11 @@
 """명함 OCR 결과와 고객 담당자 등록 초안 스키마."""
 
-from typing import Any
+from typing import Annotated, Any
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
+
+from app.schemas.customers import to_digits
 
 
 class BusinessCardFields(BaseModel):
@@ -17,7 +19,8 @@ class BusinessCardFields(BaseModel):
     department: str = Field(default="", max_length=254)
     job_title: str = Field(default="", max_length=254)
     email: str = Field(default="", max_length=254)
-    phone: str = Field(default="", max_length=50)
+    # 저장 형식과 같게 숫자만 남긴다. 화면에 보일 하이픈은 프론트가 붙인다.
+    phone: Annotated[str, BeforeValidator(to_digits)] = Field(default="", max_length=50)
     website: str = Field(default="", max_length=254)
     address: str = Field(default="", max_length=500)
     memo: str = Field(default="", max_length=5_000)

--- a/backend/app/schemas/business_licenses.py
+++ b/backend/app/schemas/business_licenses.py
@@ -1,9 +1,11 @@
 """사업자등록증 OCR 결과와 고객사 등록 초안 스키마."""
 
-from typing import Any
+from typing import Annotated, Any
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
+
+from app.schemas.customers import to_digits
 
 
 class BusinessLicenseFields(BaseModel):
@@ -12,7 +14,8 @@ class BusinessLicenseFields(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     company: str = Field(default="", max_length=254)
-    business_no: str = Field(default="", max_length=30)
+    # 저장 형식과 같게 숫자 10자리만 남긴다. 화면에 보일 하이픈은 프론트가 붙인다.
+    business_no: Annotated[str, BeforeValidator(to_digits)] = Field(default="", max_length=30)
     address: str = Field(default="", max_length=500)
     representative: str = Field(default="", max_length=100)
     confidence: float | None = Field(default=None, ge=0, le=1)

--- a/backend/app/schemas/customers.py
+++ b/backend/app/schemas/customers.py
@@ -321,3 +321,16 @@ class CustomerContactBulkResult(BaseModel):
     invalid: int
     failed: int
     results: list[CustomerContactBulkRowResult]
+
+
+class CustomerAttachmentRead(BaseModel):
+    """고객 상세에 붙는 원본 한 건. 저장소 키는 내보내지 않고 짧게 사는 주소만 준다."""
+
+    kind: Literal["business_card", "business_license"]
+    document_id: UUID
+    file_id: UUID
+    file_name: str
+    media_type: str | None
+    byte_size: int
+    url: str
+    expires_in: int

--- a/backend/app/schemas/customers.py
+++ b/backend/app/schemas/customers.py
@@ -1,8 +1,27 @@
+import re
 from datetime import datetime
-from typing import Annotated, Literal, Self
+from typing import Annotated, Any, Literal, Self
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    model_validator,
+)
+
+
+def digits_only(value: str | None) -> str:
+    """숫자만 남긴다. 전화번호·사업자등록번호는 이 형태로만 저장한다."""
+    return re.sub(r"[^0-9]", "", value or "")
+
+
+def to_digits(value: Any) -> Any:
+    """저장 전에 하이픈·공백을 걷어낸다. 문자열이 아니면 그대로 두어 타입 오류를 남긴다."""
+    return digits_only(value) if isinstance(value, str) else value
+
 
 Text = Annotated[
     str,
@@ -12,9 +31,11 @@ RegionCode = Annotated[
     str,
     StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=64),
 ]
+# 어떤 등록 경로로 들어와도 숫자만 저장한다. 화면에 보일 하이픈은 프론트가 붙인다.
 Phone = Annotated[
     str,
-    StringConstraints(strip_whitespace=True, strict=True, min_length=1, max_length=50),
+    BeforeValidator(to_digits),
+    StringConstraints(strict=True, pattern=r"^[0-9]{1,20}$"),
 ]
 Email = Annotated[
     str,
@@ -36,7 +57,8 @@ SearchQuery = Annotated[
 ]
 BusinessNo = Annotated[
     str,
-    StringConstraints(strip_whitespace=True, strict=True, pattern=r"^[0-9]{10}$"),
+    BeforeValidator(to_digits),
+    StringConstraints(strict=True, pattern=r"^[0-9]{10}$"),
 ]
 Postcode = Annotated[
     str,

--- a/backend/app/services/business_cards.py
+++ b/backend/app/services/business_cards.py
@@ -67,11 +67,6 @@ def contact_memo(fields: BusinessCardFields) -> str | None:
     return "\n".join(values) or None
 
 
-def normalize_phone(value: str) -> str:
-    """전화번호의 공백만 정리한다. 숫자 추정이나 국가번호 변환은 하지 않는다."""
-    return re.sub(r"[ \t]+", " ", value).strip()
-
-
 def normalize_ocr_contact_text(value: str) -> str:
     """명함 필드 분석 전에 연락처 기호 주변의 OCR 공백만 정리한다."""
     normalized = value.replace("＠", "@").replace("ⓐ", "@").replace("。", ".")

--- a/backend/app/services/business_licenses.py
+++ b/backend/app/services/business_licenses.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 
 from app.schemas.business_licenses import BusinessLicenseDraft, BusinessLicenseFields
+from app.schemas.customers import digits_only
 from app.services.llm import generate_structured
 
 SYSTEM_PROMPT = """너는 SalesLuv 사업자등록증 구조화 에이전트다.
@@ -191,7 +192,7 @@ def _labeled_value(text: str, labels: tuple[str, ...]) -> str:
 
 
 def _business_no_value(text: str) -> str:
-    """OCR 원문에 표시된 3-2-5 형식의 번호만 보완한다."""
+    """OCR 원문에 표시된 3-2-5 형식의 번호를 숫자만 남겨 돌려준다."""
 
     match = re.search(r"(?<!\d)\d{3}[-\s]?\d{2}[-\s]?\d{5}(?!\d)", text)
-    return match.group(0).strip() if match else ""
+    return digits_only(match.group(0)) if match else ""

--- a/backend/app/services/customer_duplicates.py
+++ b/backend/app/services/customer_duplicates.py
@@ -15,7 +15,6 @@
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from uuid import UUID
 
@@ -24,6 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.crm import CustomerCompany, CustomerContact
 from app.models.workspace import Member
+from app.schemas.customers import digits_only
 
 
 @dataclass(frozen=True)
@@ -54,8 +54,11 @@ class DuplicateMatch:
 
 
 def phone_digits(value: str | None) -> str:
-    """전화번호에서 숫자만 남긴다. 010-1234-5678 과 01012345678 은 같은 번호다."""
-    return re.sub(r"[^0-9]", "", value or "")
+    """전화번호에서 숫자만 남긴다. 010-1234-5678 과 01012345678 은 같은 번호다.
+
+    저장할 때 쓰는 규칙과 같아야 하므로 스키마의 정규화를 그대로 부른다.
+    """
+    return digits_only(value)
 
 
 def normalized_email(value: str | None) -> str:

--- a/backend/tests/test_business_card_api.py
+++ b/backend/tests/test_business_card_api.py
@@ -195,7 +195,7 @@ def test_business_card_matches_route_returns_confirmation_candidates(monkeypatch
 
     async def _matches(_db, **kwargs):
         assert kwargs["member"] is member
-        assert kwargs["fields"].phone == "010-0000-0000"
+        assert kwargs["fields"].phone == "01000000000"
         return [candidate]
 
     async def _db():

--- a/backend/tests/test_business_cards.py
+++ b/backend/tests/test_business_cards.py
@@ -57,8 +57,8 @@ async def test_extract_does_not_mark_incomplete_ocr_as_ready(monkeypatch):
     assert draft.missing_required_fields == ["company_name", "phone"]
 
 
-def test_normalize_phone_only_removes_redundant_spaces():
-    assert business_cards.normalize_phone("010-0000-0000  ") == "010-0000-0000"
+def test_card_fields_keep_only_digits_in_the_phone():
+    assert BusinessCardFields(phone="010-0000-0000  ").phone == "01000000000"
 
 
 def test_match_labels_reports_normalized_phone_email_and_name_company():

--- a/backend/tests/test_business_license_api.py
+++ b/backend/tests/test_business_license_api.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 import pytest
 from fastapi.testclient import TestClient
 
-from app.api.deps import get_current_member
+from app.api.deps import get_current_member, get_db
 from app.core.config import settings
 from app.main import app
 from app.models.workspace import Member
@@ -85,7 +85,7 @@ def test_business_license_scan_accepts_pdf_and_returns_draft(monkeypatch):
 
     assert result.status_code == 200
     assert result.json()["processing_status"] == "completed"
-    assert result.json()["fields"]["business_no"] == "123-45-67890"
+    assert result.json()["fields"]["business_no"] == "1234567890"
     assert result.json()["ready_for_company_registration"] is True
 
 
@@ -256,7 +256,7 @@ async def test_first_draft_is_kept_when_the_image_retry_fails(monkeypatch):
     # 재시도가 안 되더라도 1차 결과는 살아 있어야 한다.
     assert state.processing_status == "completed"
     assert state.draft is not None
-    assert state.draft.fields.business_no == "123-45-67890"
+    assert state.draft.fields.business_no == "1234567890"
 
 
 @pytest.mark.anyio
@@ -278,3 +278,179 @@ async def test_text_pdf_is_not_retried_when_the_company_is_read(monkeypatch):
     )
 
     assert seen == ["application/pdf"]
+
+
+def _archive_member() -> Member:
+    return _scan_member()
+
+
+def _pdf(size: int = 64) -> bytes:
+    return b"%PDF-1.7\n" + b"0" * size
+
+
+def test_business_license_archive_links_original_to_company(monkeypatch):
+    from app.models.content import Document
+    from app.models.crm import CustomerCompany
+    from app.schemas.documents import DocumentRead
+    from app.services import storage
+
+    member = _archive_member()
+    company = CustomerCompany(id=uuid4(), team_id=member.team_id, name="합성 회사")
+
+    class _Result:
+        def scalar_one_or_none(self):
+            return company
+
+    class _Db:
+        def __init__(self):
+            self.added = []
+            self.committed = False
+
+        async def execute(self, _statement):
+            return _Result()
+
+        def add(self, value):
+            self.added.append(value)
+
+        async def commit(self):
+            self.committed = True
+
+        async def rollback(self):
+            raise AssertionError("rollback should not run")
+
+    db = _Db()
+    uploaded = []
+
+    async def _upload(**kwargs):
+        uploaded.append(kwargs)
+
+    async def _detail(_db, _member, document_id):
+        return DocumentRead(
+            id=document_id,
+            document_no="SL-DC-2026-0002",
+            category_code="business_license",
+            title="합성 회사 사업자등록증",
+            description="사업자등록증 등록 시 보관된 원본",
+            customer_company_id=company.id,
+            customer_company_name=company.name,
+            customer_contact_id=None,
+            sales_deal_id=None,
+            sales_deal_no=None,
+            purchase_order_id=None,
+            product_id=None,
+            product_name=None,
+            tags=["business_license", "archive"],
+            created_by_member_id=member.id,
+            created_by_display_name=member.display_name,
+            owner_member_id=member.id,
+            owner_display_name=member.display_name,
+            created_at="2026-09-09T00:00:00Z",
+            file=None,
+        )
+
+    async def _next_document_no(*_args):
+        return "SL-DC-2026-0002"
+
+    monkeypatch.setattr(type(settings), "storage_configured", property(lambda self: True))
+    monkeypatch.setattr(storage, "upload", _upload)
+    monkeypatch.setattr(storage, "build_storage_key", lambda *_args: "team/license.pdf")
+    monkeypatch.setattr("app.api.documents._detail", _detail)
+    monkeypatch.setattr("app.api.documents._next_document_no", _next_document_no)
+    app.dependency_overrides[get_current_member] = lambda: member
+
+    async def _db():
+        yield db
+
+    app.dependency_overrides[get_db] = _db
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/business-licenses/archive",
+                headers={"Origin": settings.cors_origin_list[0]},
+                data={"company_id": str(company.id)},
+                files={"file": ("license.pdf", _pdf(), "application/pdf")},
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 201
+    assert db.committed
+    assert uploaded[0]["content"].startswith(b"%PDF-")
+    archived = next(value for value in db.added if isinstance(value, Document))
+    # 등록증은 사람이 아니라 회사의 문서다.
+    assert archived.customer_company_id == company.id
+    assert archived.customer_contact_id is None
+    assert archived.category_code == "business_license"
+
+
+def test_business_license_archive_rejects_other_team_company(monkeypatch):
+    from app.services import storage
+
+    member = _archive_member()
+
+    class _Result:
+        def scalar_one_or_none(self):
+            return None
+
+    class _Db:
+        async def execute(self, _statement):
+            return _Result()
+
+        def add(self, value):
+            raise AssertionError("add should not run")
+
+        async def commit(self):
+            raise AssertionError("commit should not run")
+
+    removed = []
+
+    async def _upload(**_kwargs):
+        return None
+
+    async def _remove(**kwargs):
+        removed.append(kwargs)
+
+    monkeypatch.setattr(type(settings), "storage_configured", property(lambda self: True))
+    monkeypatch.setattr(storage, "upload", _upload)
+    monkeypatch.setattr(storage, "remove", _remove)
+    app.dependency_overrides[get_current_member] = lambda: member
+
+    async def _db():
+        yield _Db()
+
+    app.dependency_overrides[get_db] = _db
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/business-licenses/archive",
+                headers={"Origin": settings.cors_origin_list[0]},
+                data={"company_id": str(uuid4())},
+                files={"file": ("license.pdf", _pdf(), "application/pdf")},
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "customer_company_not_found"
+    # 회사를 확인하기 전에 올리지 않으므로 지울 것도 없다.
+    assert removed == []
+
+
+def test_business_license_archive_rejects_unsupported_file(monkeypatch):
+    member = _archive_member()
+
+    monkeypatch.setattr(type(settings), "storage_configured", property(lambda self: True))
+    app.dependency_overrides[get_current_member] = lambda: member
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/business-licenses/archive",
+                headers={"Origin": settings.cors_origin_list[0]},
+                data={"company_id": str(uuid4())},
+                files={"file": ("license.exe", b"MZ\x00\x00", "application/octet-stream")},
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 415
+    assert response.json()["detail"] == "business_license_unsupported_file"

--- a/backend/tests/test_customers.py
+++ b/backend/tests/test_customers.py
@@ -251,7 +251,8 @@ def test_customer_request_sales_deal_trims_and_rejects_invalid_values():
     }
     assert contact.name == "합성 고객"
     assert contact.email == "customer@demo.test"
-    assert contact.phone == "02-000-0000"
+    # 전화번호는 어떤 모양으로 적어도 숫자만 남겨 저장한다.
+    assert contact.phone == "020000000"
     assert (
         CustomerContactCreate(
             company_id=uuid4(),
@@ -837,15 +838,24 @@ def test_company_write_round_trips_business_no_and_rejects_other_shapes():
             headers={"Origin": ORIGIN},
             json={"name": "합성 고객사", "region_code": None, "business_no": " 1234567890 "},
         )
-        rejected = client.post(
+        hyphenated = client.post(
             "/api/customer-companies",
             headers={"Origin": ORIGIN},
             json={"name": "합성 고객사", "business_no": "123-45-67890"},
+        )
+        rejected = client.post(
+            "/api/customer-companies",
+            headers={"Origin": ORIGIN},
+            json={"name": "합성 고객사", "business_no": "123-45-678"},
         )
 
     assert created.status_code == 201
     assert created.json()["business_no"] == "1234567890"
     assert db.added[0].business_no == "1234567890"
+    # 화면에서 하이픈을 넣어 보내도 숫자만 남겨 받는다.
+    assert hyphenated.status_code == 201
+    assert hyphenated.json()["business_no"] == "1234567890"
+    # 숫자가 10자리가 아니면 여전히 거절한다.
     assert rejected.status_code == 422
 
 
@@ -1213,6 +1223,28 @@ def test_bulk_creates_a_missing_company_and_keeps_the_existing_business_no():
     assert created[0].name == "새 고객사"
     assert created[0].business_no == "1234567890"
     assert existing.business_no == "1234567890"
+
+
+def test_bulk_keeps_only_digits_in_the_phone():
+    """엑셀은 하이픈·공백이 섞여 들어온다. 저장 형식은 한 가지여야 한다."""
+    member = _member()
+    company = _company(member.team_id)
+    contact_status = _contact_status(member.team_id, code="new")
+    db = _Db(
+        _Result(scalar=contact_status),
+        _Result(rows=[]),
+        _Result(scalar=company),
+    )
+
+    response = _bulk_post(
+        db,
+        member,
+        [_bulk_item(2, company_name=company.name, phone="010 1111-2222")],
+    )
+
+    assert response.status_code == 200
+    contacts = [row for row in db.added if isinstance(row, CustomerContact)]
+    assert [contact.phone for contact in contacts] == ["01011112222"]
 
 
 def test_bulk_skips_customers_that_already_exist():

--- a/backend/tests/test_customers.py
+++ b/backend/tests/test_customers.py
@@ -1493,3 +1493,125 @@ def test_duplicate_check_with_nothing_to_compare_asks_the_database_nothing():
     assert response.status_code == 200
     assert response.json() == []
     assert db.statements == []
+
+
+def _attachment_rows(contact: CustomerContact, company: CustomerCompany, member: Member):
+    """상세 첨부 조회가 읽는 (문서, 파일) 행. 명함은 사람에, 등록증은 회사에 붙는다."""
+    from app.models.content import Document
+    from app.models.content import File as FileRow
+
+    card = Document(
+        id=uuid4(),
+        team_id=member.team_id,
+        created_by_member_id=member.id,
+        document_no="SL-DC-2026-0001",
+        category_code="business_card",
+        title="합성 고객 명함",
+        customer_company_id=company.id,
+        customer_contact_id=contact.id,
+    )
+    card_file = FileRow(
+        id=uuid4(),
+        document_id=card.id,
+        version_no=1,
+        file_name="card.jpg",
+        storage_key="team/card.jpg",
+        media_type="image/jpeg",
+        byte_size=1234,
+        processing_status="uploaded",
+        uploaded_by_member_id=member.id,
+    )
+    license_document = Document(
+        id=uuid4(),
+        team_id=member.team_id,
+        created_by_member_id=member.id,
+        document_no="SL-DC-2026-0002",
+        category_code="business_license",
+        title="합성 고객사 사업자등록증",
+        customer_company_id=company.id,
+    )
+    license_file = FileRow(
+        id=uuid4(),
+        document_id=license_document.id,
+        version_no=1,
+        file_name="license.pdf",
+        storage_key="team/license.pdf",
+        media_type="application/pdf",
+        byte_size=5678,
+        processing_status="uploaded",
+        uploaded_by_member_id=member.id,
+    )
+    return [(card, card_file), (license_document, license_file)]
+
+
+def test_customer_attachments_return_signed_urls_for_card_and_license(monkeypatch):
+    from app.services import storage
+
+    member = _member()
+    company = _company(member.team_id)
+    contact = _contact(company.id, member.id)
+    contact_status = _contact_status(member.team_id, status_id=contact.customer_contact_status_id)
+    db = _Db(
+        _Result(rows=[_contact_row(contact, company, member, contact_status)]),
+        _assignee_result((contact, member)),
+        _Result(rows=_attachment_rows(contact, company, member)),
+    )
+
+    signed = []
+
+    async def _signed_url(*, storage_key, expires_in):
+        signed.append((storage_key, expires_in))
+        return f"https://storage.test/{storage_key}?token=x"
+
+    monkeypatch.setattr(type(settings), "storage_configured", property(lambda self: True))
+    monkeypatch.setattr(storage, "signed_url", _signed_url)
+
+    with _client(db, member) as client:
+        response = client.get(f"/api/customer-contacts/{contact.id}/attachments")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [item["kind"] for item in body] == ["business_card", "business_license"]
+    assert body[0]["media_type"] == "image/jpeg"
+    assert body[1]["file_name"] == "license.pdf"
+    assert all(item["url"].startswith("https://storage.test/") for item in body)
+    # 저장소 키 자체는 절대 내보내지 않는다.
+    assert all("storage_key" not in item for item in body)
+    assert [key for key, _expires in signed] == ["team/card.jpg", "team/license.pdf"]
+
+    attachment_sql = str(db.statements[2])
+    assert "business_card" in str(db.statements[2].compile().params.values())
+    assert "document.deleted_at IS NULL" in attachment_sql
+
+
+def test_customer_attachments_are_empty_without_storage(monkeypatch):
+    member = _member()
+    company = _company(member.team_id)
+    contact = _contact(company.id, member.id)
+    contact_status = _contact_status(member.team_id, status_id=contact.customer_contact_status_id)
+    db = _Db(
+        _Result(rows=[_contact_row(contact, company, member, contact_status)]),
+        _assignee_result((contact, member)),
+    )
+
+    monkeypatch.setattr(type(settings), "storage_configured", property(lambda self: False))
+
+    with _client(db, member) as client:
+        response = client.get(f"/api/customer-contacts/{contact.id}/attachments")
+
+    # 첨부는 상세의 곁가지다. 저장소가 없어도 상세가 실패하면 안 된다.
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_customer_attachments_hide_other_team_contact(monkeypatch):
+    member = _member()
+    db = _Db(_Result(rows=[]))
+
+    monkeypatch.setattr(type(settings), "storage_configured", property(lambda self: True))
+
+    with _client(db, member) as client:
+        response = client.get(f"/api/customer-contacts/{uuid4()}/attachments")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "customer_contact_not_found"

--- a/frontend/src/pages/Customers/Customers.tsx
+++ b/frontend/src/pages/Customers/Customers.tsx
@@ -361,6 +361,7 @@ export default function Customers() {
           onCreated={onCustomerCreated}
           duplicateMatches={cardDraft?.matches}
           archiveImage={cardDraft?.sourceImage}
+          archiveLicense={licenseDraft?.sourceFile}
           // 등록증에 있는 사람은 대표자뿐입니다. 이름만 채우고 나머지 사람 칸은
           // 명함일 때만 채웁니다. 대표자가 담당자가 아니면 폼에서 고칩니다.
           initial={

--- a/frontend/src/pages/Customers/businessLicense.ts
+++ b/frontend/src/pages/Customers/businessLicense.ts
@@ -11,6 +11,8 @@ export interface BusinessLicenseDraft {
   address: string
   /** 등록증의 대표자. 담당자 이름 칸의 첫 값으로 씁니다. */
   representative: string
+  /** 인식에 쓴 원본. 고객 등록 뒤 그 회사에 보관합니다. */
+  sourceFile: File
 }
 
 interface BusinessLicenseScanAccepted {
@@ -106,6 +108,7 @@ export async function extractBusinessLicense(file: File): Promise<BusinessLicens
       businessNo: scan.fields.business_no,
       address: scan.fields.address,
       representative: scan.fields.representative,
+      sourceFile: file,
     }
   } catch (error: unknown) {
     if (isAxiosError(error) && [502, 503].includes(error.response?.status ?? 0)) {
@@ -126,4 +129,12 @@ export async function extractBusinessLicense(file: File): Promise<BusinessLicens
     }
     throw error
   }
+}
+
+/** 등록증 원본을 그 회사에 보관합니다. 등록증은 사람이 아니라 회사의 문서입니다. */
+export async function archiveBusinessLicense(companyId: string, file: File): Promise<void> {
+  const form = new FormData()
+  form.append('company_id', companyId)
+  form.append('file', file)
+  await client.post('/business-licenses/archive', form)
 }

--- a/frontend/src/pages/Customers/columns.ts
+++ b/frontend/src/pages/Customers/columns.ts
@@ -4,6 +4,7 @@ import { createElement, type ReactNode } from 'react'
 
 import type { Customer, CustomerOwner } from '@/types'
 import { fmtDotShort, parseISO } from '@/utils/date'
+import { formatPhone } from '@/utils/format'
 
 import { EmailCell, OwnerCell, PlainNumber, VisitCell } from './cells'
 
@@ -82,8 +83,8 @@ export const ALL_COLUMNS: ColumnDef[] = [
     width: 128,
     minWidth: 120,
     sortable: false,
-    value: (c) => c.phone,
-    render: (c) => createElement(PlainNumber, { value: c.phone }),
+    value: (c) => formatPhone(c.phone),
+    render: (c) => createElement(PlainNumber, { value: formatPhone(c.phone) }),
   },
   {
     id: 'owner',

--- a/frontend/src/pages/Customers/columns.ts
+++ b/frontend/src/pages/Customers/columns.ts
@@ -2,6 +2,7 @@
 // 셋을 따로 두면 컬럼을 하나 늘릴 때 세 군데를 고쳐야 하고 결국 어긋납니다.
 import { createElement, type ReactNode } from 'react'
 
+import { regionLabel } from '@/shared/regionCodes'
 import type { Customer, CustomerOwner } from '@/types'
 import { fmtDotShort, parseISO } from '@/utils/date'
 import { formatPhone } from '@/utils/format'
@@ -53,6 +54,15 @@ export const ALL_COLUMNS: ColumnDef[] = [
     value: (c) => c.name,
   },
   {
+    id: 'region',
+    header: '지역',
+    width: 88,
+    minWidth: 72,
+    sortable: true,
+    // 고객사의 지역 코드입니다. 코드는 사람이 읽는 말이 아니라 한글 이름으로 바꿉니다.
+    value: (c) => regionLabel(c.regionCode ?? null, '미지정'),
+  },
+  {
     id: 'dept',
     header: '부서',
     width: 140,
@@ -97,12 +107,21 @@ export const ALL_COLUMNS: ColumnDef[] = [
     render: (c) => createElement(OwnerCell, { owners: ownersOf(c) }),
   },
   {
+    id: 'source',
+    header: '유입경로',
+    width: 110,
+    minWidth: 90,
+    sortable: true,
+    // 라벨을 그대로 씁니다. 코드(referral 등)는 사람이 읽는 말이 아닙니다.
+    value: (c) => c.source,
+  },
+  {
     id: 'visited',
     header: '방문여부',
     width: 96,
     minWidth: 82,
     sortable: false,
-    // CSV 도 같은 말을 씁니다. 내보낸 파일을 그대로 다시 가져올 수 있어야 합니다.
+    // 기본으로 켜지 않습니다. 등록 폼에서 받는 항목이라 켤 수 있게만 남깁니다.
     value: (c) => (c.visited ? '방문' : '미방문'),
     render: (c) => createElement(VisitCell, { visited: c.visited }),
   },
@@ -135,7 +154,7 @@ export const DEFAULT_VISIBLE = [
   'email',
   'phone',
   'owner',
-  'visited',
+  'source',
   'memo',
 ]
 

--- a/frontend/src/pages/Customers/components/BusinessCardModal/BusinessCardModal.tsx
+++ b/frontend/src/pages/Customers/components/BusinessCardModal/BusinessCardModal.tsx
@@ -103,6 +103,19 @@ export default function BusinessCardModal({
     if (!reading) onClose()
   }
 
+  // 읽는 동안에는 사용자가 손댈 것이 없습니다. 미리보기와 눌리지 않는 버튼까지
+  // 함께 두면 화면만 길어지므로, 어디까지 왔는지 하나만 남깁니다.
+  if (reading && progress) {
+    return (
+      <Modal title="명함으로 고객 등록" description="" onClose={close}>
+        <RecognitionLoading
+          description={progressLabel(progress)}
+          progress={progress.phase === 'uploading' ? progress.percent : undefined}
+        />
+      </Modal>
+    )
+  }
+
   return (
     <Modal
       title="명함으로 고객 등록"
@@ -110,11 +123,11 @@ export default function BusinessCardModal({
       onClose={close}
       footer={
         <>
-          <Button type="button" variant="outline" disabled={reading} onClick={close}>
+          <Button type="button" variant="outline" onClick={close}>
             취소
           </Button>
-          <Button type="button" disabled={image === null || reading} onClick={read}>
-            {reading ? '읽는 중…' : '명함 읽기'}
+          <Button type="button" disabled={image === null} onClick={read}>
+            명함 읽기
           </Button>
         </>
       }
@@ -133,12 +146,7 @@ export default function BusinessCardModal({
       />
 
       {/* 명함 비율(91×55) 그대로입니다. 무엇을 넣는 자리인지 글자보다 먼저 보입니다. */}
-      <button
-        type="button"
-        className={styles.drop}
-        disabled={reading}
-        onClick={() => fileRef.current?.click()}
-      >
+      <button type="button" className={styles.drop} onClick={() => fileRef.current?.click()}>
         {preview === null ? (
           <span className={styles.empty}>
             <CardIcon width={30} height={30} strokeWidth={1.4} />
@@ -159,13 +167,6 @@ export default function BusinessCardModal({
           {image.name} · <span className="tnum">{sizeLabel(image.size)}</span> · 다시 고르려면
           사진을 누르세요.
         </p>
-      )}
-
-      {reading && progress && (
-        <RecognitionLoading
-          description={progressLabel(progress)}
-          progress={progress.phase === 'uploading' ? progress.percent : undefined}
-        />
       )}
 
       {error && (

--- a/frontend/src/pages/Customers/components/BusinessLicenseModal/BusinessLicenseModal.tsx
+++ b/frontend/src/pages/Customers/components/BusinessLicenseModal/BusinessLicenseModal.tsx
@@ -88,6 +88,16 @@ export default function BusinessLicenseModal({ onClose, onDrafted }: Props) {
     if (!reading) onClose()
   }
 
+  // 읽는 동안에는 사용자가 손댈 것이 없습니다. 파일 줄과 미리보기, 눌리지 않는 버튼까지
+  // 함께 두면 화면만 길어지므로, 어디까지 왔는지 하나만 남깁니다.
+  if (reading) {
+    return (
+      <Modal title="사업자 등록증으로 고객 등록" description="" onClose={close}>
+        <RecognitionLoading description="사업자등록증에서 고객사 정보를 확인하고 있습니다." />
+      </Modal>
+    )
+  }
+
   return (
     <Modal
       title="사업자 등록증으로 고객 등록"
@@ -95,11 +105,11 @@ export default function BusinessLicenseModal({ onClose, onDrafted }: Props) {
       onClose={close}
       footer={
         <>
-          <Button type="button" variant="outline" disabled={reading} onClick={close}>
+          <Button type="button" variant="outline" onClick={close}>
             취소
           </Button>
-          <Button type="button" disabled={file === null || reading} onClick={read}>
-            {reading ? '읽는 중…' : '다음'}
+          <Button type="button" disabled={file === null} onClick={read}>
+            다음
           </Button>
         </>
       }
@@ -168,7 +178,6 @@ export default function BusinessLicenseModal({ onClose, onDrafted }: Props) {
               type="button"
               variant="outline"
               size="sm"
-              disabled={reading}
               onClick={() => fileRef.current?.click()}
             >
               파일 변경
@@ -177,7 +186,6 @@ export default function BusinessLicenseModal({ onClose, onDrafted }: Props) {
               type="button"
               className={styles.remove}
               aria-label={`${file.name} 삭제`}
-              disabled={reading}
               onClick={clear}
             >
               <TrashIcon />
@@ -190,10 +198,6 @@ export default function BusinessLicenseModal({ onClose, onDrafted }: Props) {
               src={preview}
               alt={`선택한 사업자등록증 ${file.name}`}
             />
-          )}
-
-          {reading && (
-            <RecognitionLoading description="사업자등록증에서 고객사 정보를 확인하고 있습니다." />
           )}
 
           {error && (

--- a/frontend/src/pages/Customers/components/CustomerDrawer/CustomerDrawer.module.scss
+++ b/frontend/src/pages/Customers/components/CustomerDrawer/CustomerDrawer.module.scss
@@ -86,6 +86,7 @@
 }
 
 .block h3,
+.attach h3,
 .deals h3 {
   display: flex;
   align-items: baseline;
@@ -98,10 +99,63 @@
 
 // 2열 아래에 전체 폭으로 눕는 회사 단위 섹션입니다. 위 정보와 다른 축의 내용이라
 // 컬럼 안에 끼우지 않고 선 하나로 끊어 세웁니다.
+.attach,
 .deals {
   margin-top: var(--s6);
   padding-top: var(--s5);
   border-top: 1px solid var(--line);
+}
+
+/* ---- 첨부 원본 ---- */
+
+// 종류가 달라도 자리는 같습니다. 첨부가 늘면 세로로 쌓이지 않고 옆으로 붙습니다.
+.shots {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s4);
+}
+
+.shot {
+  margin: 0;
+  width: 168px;
+}
+
+.tile {
+  display: grid;
+  place-items: center;
+  height: 104px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+  overflow: hidden;
+  transition: border-color var(--t-fast);
+
+  &:hover {
+    border-color: rgba(0, 122, 255, 0.3);
+  }
+
+  // 책상 위에서 찍은 사진은 여백이 제각각입니다. 잘라 내지 않고 통째로 넣습니다.
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
+}
+
+// 미리 보여 줄 수 없는 파일. 사진이 있을 자리에 받는 길을 둡니다.
+.doc {
+  display: grid;
+  justify-items: center;
+  gap: 6px;
+  color: var(--blue);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.shotNote {
+  margin-top: 6px;
+  color: var(--muted);
+  font-size: 12px;
 }
 
 .dealBody {

--- a/frontend/src/pages/Customers/components/CustomerDrawer/CustomerDrawer.tsx
+++ b/frontend/src/pages/Customers/components/CustomerDrawer/CustomerDrawer.tsx
@@ -1,11 +1,12 @@
 import { useState, type ReactNode } from 'react'
 
-import { buttonClass } from '@/components/Button'
 import Drawer from '@/components/Drawer'
-import { EditIcon, MoreIcon, TrashIcon } from '@/components/icons'
+import { DocumentsIcon, EditIcon, MoreIcon, TrashIcon } from '@/components/icons'
 import Popover from '@/components/Popover'
 import useCompanyDeals from '@/hooks/useCompanyDeals'
-import type { Customer } from '@/types'
+import useCustomerAttachments from '@/pages/Customers/useCustomerAttachments'
+import type { Customer, CustomerAttachment } from '@/types'
+import { sizeLabel } from '@/utils/attachment'
 import { fmtDay, parseISO } from '@/utils/date'
 import { formatPhone } from '@/utils/format'
 
@@ -37,10 +38,51 @@ function Block({ title, children }: BlockProps) {
 
 const shown = (value: string | null | undefined): string => value || '—'
 
+const KIND_LABEL: Record<CustomerAttachment['kind'], string> = {
+  business_card: '명함',
+  business_license: '사업자등록증',
+}
+
+/**
+ * 등록에 쓴 원본 한 건. 사진은 어느 명함인지 알아볼 만큼만 줄여 놓고, 크게 볼 일은
+ * 눌러서 원본을 엽니다. PDF 는 미리 보여 줄 수 없어 같은 크기의 자리에 받는 길만 둡니다.
+ * 둘을 같은 타일로 맞춰 두면 첨부가 늘어도 세로로 길어지지 않고 옆으로 늡니다.
+ */
+function Attachment({ attachment }: { attachment: CustomerAttachment }) {
+  const label = KIND_LABEL[attachment.kind]
+  const image = attachment.media_type?.startsWith('image/') === true
+
+  return (
+    <figure className={styles.shot}>
+      <a
+        className={styles.tile}
+        href={attachment.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={image ? `${label} 원본 열기` : `${label} 원본 받기`}
+      >
+        {image ? (
+          <img src={attachment.url} alt={`${label} 원본`} />
+        ) : (
+          <span className={styles.doc}>
+            <DocumentsIcon width={20} height={20} />
+            원본 받기
+          </span>
+        )}
+      </a>
+      <figcaption className={styles.shotNote}>
+        {label} · {sizeLabel(attachment.byte_size)}
+      </figcaption>
+    </figure>
+  )
+}
+
 export default function CustomerDrawer({ customer, canDelete, onEdit, onDelete, onClose }: Props) {
   const [menuOpen, setMenuOpen] = useState(false)
   // 딜은 사람이 아니라 회사에 걸립니다. 고객을 바꾸면 companyId 가 바뀌어 다시 받아 옵니다.
   const { deals, loading, error, reload } = useCompanyDeals(customer.companyId)
+  // 명함은 이 사람의 것이고, 사업자등록증은 이 회사의 것입니다. 서버가 함께 줍니다.
+  const attachments = useCustomerAttachments(customer.id)
 
   // 담당자가 여럿이면 상세에서는 전부 보여 줍니다. 좁은 표와 달리 자리가 있습니다.
   const ownerNames =
@@ -126,13 +168,6 @@ export default function CustomerDrawer({ customer, canDelete, onEdit, onDelete, 
           <i className={styles.pill}>유입 {customer.source}</i>
           <span className={styles.when}>담당 {customer.owner}</span>
         </>
-      footer={
-        customer.email ? (
-          <a className={buttonClass()} href={`mailto:${customer.email}`}>
-            이메일 보내기
-          </a>
-        ) : undefined
-      }
       }
     >
       <div className={styles.grid}>
@@ -209,6 +244,21 @@ export default function CustomerDrawer({ customer, canDelete, onEdit, onDelete, 
           contactId={customer.id}
         />
       </section>
+
+      {/* 직접 등록한 고객에는 원본이 없습니다. 빈 자리를 남기지 않고 통째로 뺍니다. */}
+      {attachments.length > 0 && (
+        <section className={styles.attach}>
+          <h3>
+            첨부 자료
+            <span className={styles.blockNote}>{attachments.length}건</span>
+          </h3>
+          <div className={styles.shots}>
+            {attachments.map((attachment) => (
+              <Attachment key={attachment.file_id} attachment={attachment} />
+            ))}
+          </div>
+        </section>
+      )}
     </Drawer>
   )
 }

--- a/frontend/src/pages/Customers/components/CustomerDrawer/CustomerDrawer.tsx
+++ b/frontend/src/pages/Customers/components/CustomerDrawer/CustomerDrawer.tsx
@@ -7,6 +7,7 @@ import Popover from '@/components/Popover'
 import useCompanyDeals from '@/hooks/useCompanyDeals'
 import type { Customer } from '@/types'
 import { fmtDay, parseISO } from '@/utils/date'
+import { formatPhone } from '@/utils/format'
 
 import CustomerDeals from './CustomerDeals'
 import styles from './CustomerDrawer.module.scss'
@@ -125,13 +126,13 @@ export default function CustomerDrawer({ customer, canDelete, onEdit, onDelete, 
           <i className={styles.pill}>유입 {customer.source}</i>
           <span className={styles.when}>담당 {customer.owner}</span>
         </>
-      }
       footer={
         customer.email ? (
           <a className={buttonClass()} href={`mailto:${customer.email}`}>
             이메일 보내기
           </a>
         ) : undefined
+      }
       }
     >
       <div className={styles.grid}>
@@ -154,7 +155,7 @@ export default function CustomerDrawer({ customer, canDelete, onEdit, onDelete, 
                 <dt>전화</dt>
                 <dd>
                   <a className={`${styles.mail} tnum`} href={`tel:${customer.phone}`}>
-                    {customer.phone}
+                    {formatPhone(customer.phone)}
                   </a>
                 </dd>
               </div>

--- a/frontend/src/pages/Customers/components/CustomerFormModal/CustomerFormModal.tsx
+++ b/frontend/src/pages/Customers/components/CustomerFormModal/CustomerFormModal.tsx
@@ -23,6 +23,7 @@ import type {
 import { businessNoDigits, formatPhone, maskBusinessNo, phoneDigits } from '@/utils/format'
 
 import type { BusinessCardMatch } from '../../businessCard'
+import { archiveBusinessLicense } from '../../businessLicense'
 import { type DuplicateDraft } from '../../duplicate'
 import DuplicateConfirmModal from '../DuplicateConfirmModal'
 import styles from './CustomerFormModal.module.scss'
@@ -56,6 +57,8 @@ interface CustomerFormModalProps {
   duplicateMatches?: BusinessCardMatch[]
   /** 명함 OCR에 사용한 원본. 고객 등록 뒤 자료실에 보관합니다. */
   archiveImage?: File
+  /** 사업자등록증 OCR에 사용한 원본. 고객 등록 뒤 그 회사에 보관합니다. */
+  archiveLicense?: File
 }
 
 const EMPTY = {
@@ -183,6 +186,7 @@ export default function CustomerFormModal({
   initialAddress,
   duplicateMatches = [],
   archiveImage,
+  archiveLicense,
 }: CustomerFormModalProps) {
   const { isManager, memberId } = useCurrentUser()
   const editing = customer !== undefined
@@ -345,6 +349,14 @@ export default function CustomerFormModal({
           // 고객 등록은 완료됐으므로 원본 보관 실패가 등록 자체를 되돌리지는 않습니다.
           warning =
             '고객은 등록됐지만 명함 원본 보관에 실패했습니다. 자료실에 다시 업로드해 주세요.'
+        }
+      }
+      // 등록증은 사람이 아니라 회사에 붙습니다. 회사는 위에서 이미 확정됐습니다.
+      if (archiveLicense) {
+        try {
+          await archiveBusinessLicense(fields.company_id, archiveLicense)
+        } catch {
+          warning = '고객은 등록됐지만 사업자등록증 원본 보관에 실패했습니다.'
         }
       }
       setSubmitting(false)

--- a/frontend/src/pages/Customers/components/CustomerFormModal/CustomerFormModal.tsx
+++ b/frontend/src/pages/Customers/components/CustomerFormModal/CustomerFormModal.tsx
@@ -20,7 +20,7 @@ import type {
   CustomerDuplicateResponse,
   CustomerSourceCode,
 } from '@/types'
-import { businessNoDigits, formatBusinessNo } from '@/utils/format'
+import { businessNoDigits, formatPhone, maskBusinessNo, phoneDigits } from '@/utils/format'
 
 import type { BusinessCardMatch } from '../../businessCard'
 import { type DuplicateDraft } from '../../duplicate'
@@ -82,7 +82,7 @@ function validate({ draft, company, businessNo, assigneeIds }: Form): Errors {
   const errors: Errors = {}
   if (company === null) errors.company = '회사를 검색해서 고르거나 직접 등록해 주세요.'
   if (draft.name.trim() === '') errors.name = '이름을 입력하세요.'
-  if (draft.phone.trim() === '') errors.phone = '전화번호를 입력하세요.'
+  if (phoneDigits(draft.phone) === '') errors.phone = '전화번호를 입력하세요.'
   if (draft.email.trim() !== '' && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(draft.email.trim())) {
     errors.email = '이메일 형식이 맞지 않습니다. 예: name@company.com'
   }
@@ -195,10 +195,13 @@ export default function CustomerFormModal({
   // 유입경로. 빈 문자열은 미지정입니다.
   const [sourceCode, setSourceCode] = useState<CustomerSourceCode | ''>(customer?.sourceCode ?? '')
   const [company, setCompany] = useState<CompanySelection | null>(initialCompany ?? null)
+  // 입력칸은 하이픈을 붙여 보여 주지만 상태에는 저장 형식대로 숫자만 담습니다.
   const [businessNo, setBusinessNo] = useState(() =>
-    initialCompany?.kind === 'existing'
-      ? (formatBusinessNo(initialCompany.company.business_no) ?? '')
-      : (initialBusinessNo ?? ''),
+    businessNoDigits(
+      (initialCompany?.kind === 'existing'
+        ? initialCompany.company.business_no
+        : initialBusinessNo) ?? '',
+    ),
   )
   const [address, setAddress] = useState<AddressValue>(() =>
     initialCompany?.kind === 'existing'
@@ -239,7 +242,7 @@ export default function CustomerFormModal({
       .then(({ data }) => {
         if (controller.signal.aborted) return
         setCompany({ kind: 'existing', company: data })
-        setBusinessNo(formatBusinessNo(data.business_no) ?? '')
+        setBusinessNo(businessNoDigits(data.business_no ?? ''))
         setAddress(companyAddress(data))
       })
       .catch((error: unknown) => {
@@ -271,7 +274,7 @@ export default function CustomerFormModal({
     setCompany(selection)
     if (selection?.kind === 'existing') {
       // 이미 있는 회사의 사업자번호와 주소는 그 회사의 것입니다. 여기서 고치지 않습니다.
-      setBusinessNo(formatBusinessNo(selection.company.business_no) ?? '')
+      setBusinessNo(businessNoDigits(selection.company.business_no ?? ''))
       setAddress(companyAddress(selection.company))
     } else if (leavingExistingCompany) {
       setBusinessNo('')
@@ -301,7 +304,7 @@ export default function CustomerFormModal({
         department: optional(draft.dept),
         job_title: optional(draft.title),
         email: optional(draft.email),
-        phone: draft.phone.trim(),
+        phone: phoneDigits(draft.phone),
         source_code: sourceCode === '' ? null : sourceCode,
         memo: optional(draft.memo),
         visited,
@@ -413,7 +416,7 @@ export default function CustomerFormModal({
           <ul>
             {duplicateMatches.map((match) => (
               <li key={match.contact_id}>
-                {match.company_name} · {match.name} · {match.phone}
+                {match.company_name} · {match.name} · {formatPhone(match.phone)}
               </li>
             ))}
           </ul>
@@ -433,7 +436,7 @@ export default function CustomerFormModal({
 
         <Field label="사업자 등록번호" error={errors.businessNo}>
           <input
-            value={businessNo}
+            value={maskBusinessNo(businessNo)}
             placeholder="123-45-67890"
             maxLength={12}
             // 이미 있는 회사는 그 회사의 값을 보여 주기만 합니다.
@@ -441,7 +444,7 @@ export default function CustomerFormModal({
             // 회사를 고르기 전이라도, 등록증에서 읽어 온 값은 고칠 수 있어야 합니다.
             disabled={submitting || (company === null && businessNo === '')}
             onChange={(event) => {
-              setBusinessNo(event.target.value)
+              setBusinessNo(businessNoDigits(event.target.value))
               clearError('businessNo')
             }}
           />
@@ -470,11 +473,11 @@ export default function CustomerFormModal({
         <Field label="전화" required error={errors.phone}>
           <input
             type="tel"
-            value={draft.phone}
+            value={formatPhone(draft.phone)}
             placeholder="02-000-0000"
             maxLength={50}
             disabled={submitting}
-            onChange={(event) => set('phone', event.target.value)}
+            onChange={(event) => set('phone', phoneDigits(event.target.value))}
           />
         </Field>
 

--- a/frontend/src/pages/Customers/components/DuplicateConfirmModal/DuplicateConfirmModal.tsx
+++ b/frontend/src/pages/Customers/components/DuplicateConfirmModal/DuplicateConfirmModal.tsx
@@ -11,6 +11,7 @@ import { Fragment } from 'react'
 import Button from '@/components/Button'
 import Modal from '@/components/Modal'
 import type { CustomerDuplicateResponse } from '@/types'
+import { formatPhone } from '@/utils/format'
 
 import { isSameCustomer, type DuplicateDraft } from '../../duplicate'
 
@@ -41,7 +42,7 @@ export default function DuplicateConfirmModal({
     ['고객명', draft.name],
     ['부서', draft.department],
     ['직책', draft.jobTitle],
-    ['전화번호', draft.phone],
+    ['전화번호', formatPhone(draft.phone)],
     ['이메일', draft.email],
   ].filter((row): row is [string, string] => row[1].trim() !== '')
 

--- a/frontend/src/pages/Customers/duplicate.ts
+++ b/frontend/src/pages/Customers/duplicate.ts
@@ -1,4 +1,5 @@
 import type { CustomerDuplicateResponse } from '@/types'
+import { phoneDigits } from '@/utils/format'
 
 /** 지금 등록하려던 값. 폼과 명함·등록증 흐름이 모두 이 모양으로 넘깁니다. */
 export interface DuplicateDraft {
@@ -27,7 +28,7 @@ export function isSameCustomer(draft: DuplicateDraft, match: CustomerDuplicateRe
     draft.department.trim() === text(match.department) &&
     draft.jobTitle.trim() === text(match.job_title) &&
     draft.email.trim() === text(match.email) &&
-    draft.phone.trim() === match.phone.trim() &&
+    phoneDigits(draft.phone) === phoneDigits(match.phone) &&
     draft.memo.trim() === text(match.memo) &&
     draft.visited === match.visited
   )

--- a/frontend/src/pages/Customers/useColumnPrefs.ts
+++ b/frontend/src/pages/Customers/useColumnPrefs.ts
@@ -4,7 +4,7 @@ import { useCallback, useState } from 'react'
 
 import { ALL_COLUMNS, COLUMN_BY_ID, DEFAULT_VISIBLE } from './columns'
 
-const KEY = 'salesluv.customers.columns.v5'
+const KEY = 'salesluv.customers.columns.v6'
 
 export interface ColumnPrefs {
   order: string[]

--- a/frontend/src/pages/Customers/useCustomerAttachments.ts
+++ b/frontend/src/pages/Customers/useCustomerAttachments.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+
+import { client } from '@/api/client'
+import type { CustomerAttachment } from '@/types'
+
+/**
+ * 고객 등록에 쓴 명함·사업자등록증 원본. 저장소 주소는 서버가 내보내지 않으므로
+ * 서명 주소를 건별로 받아 옵니다.
+ *
+ * 주소는 5분이면 만료합니다. 상세를 오래 열어 두면 사진 자리가 비고,
+ * 그때는 다시 열면 됩니다.
+ */
+export default function useCustomerAttachments(contactId: string): CustomerAttachment[] {
+  const [attachments, setAttachments] = useState<CustomerAttachment[]>([])
+
+  useEffect(() => {
+    setAttachments([])
+    const controller = new AbortController()
+    void client
+      .get<CustomerAttachment[]>(`/customer-contacts/${contactId}/attachments`, {
+        signal: controller.signal,
+      })
+      .then(({ data }) => {
+        if (!controller.signal.aborted) setAttachments(data)
+      })
+      .catch(() => {
+        // 첨부를 못 받았다고 상세 전체가 실패하지는 않습니다. 없는 것으로 둡니다.
+      })
+
+    return () => controller.abort()
+  }, [contactId])
+
+  return attachments
+}

--- a/frontend/src/types/customers.ts
+++ b/frontend/src/types/customers.ts
@@ -207,3 +207,17 @@ export interface CustomerContactBulkResult {
   failed: number
   results: CustomerContactBulkRowResult[]
 }
+
+export type CustomerAttachmentKind = 'business_card' | 'business_license'
+
+/** 고객 등록에 쓴 원본 한 건. 주소는 짧게 살아 있어 화면을 오래 두면 만료됩니다. */
+export interface CustomerAttachment {
+  kind: CustomerAttachmentKind
+  document_id: string
+  file_id: string
+  file_name: string
+  media_type: string | null
+  byte_size: number
+  url: string
+  expires_in: number
+}

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -24,3 +24,46 @@ export function formatBusinessNo(value: string | null | undefined): string | nul
 export function businessNoDigits(value: string): string {
   return value.replaceAll(/\D/g, '')
 }
+
+/** 전화번호를 저장 형식(숫자만)으로 되돌립니다. 하이픈·공백·국가번호 기호를 걷어냅니다. */
+export function phoneDigits(value: string): string {
+  return value.replaceAll(/\D/g, '')
+}
+
+/**
+ * 01012345678 → 010-1234-5678. 저장은 숫자만 하고 하이픈은 화면에서만 붙입니다.
+ *
+ * 입력 중인 짧은 값도 그대로 다루므로 입력칸의 자동 하이픈에 함께 씁니다.
+ * 국내 번호 모양이 아니면 숫자를 그대로 돌려줍니다. 해외 번호가 화면에서 사라지면 안 됩니다.
+ */
+export function formatPhone(value: string | null | undefined): string {
+  const d = phoneDigits(value ?? '')
+  if (d.length <= 3) return d
+  // 서울 지역번호만 두 자리입니다.
+  if (d.startsWith('02')) {
+    if (d.length <= 5) return `${d.slice(0, 2)}-${d.slice(2)}`
+    if (d.length <= 9) return `${d.slice(0, 2)}-${d.slice(2, 5)}-${d.slice(5)}`
+    if (d.length === 10) return `${d.slice(0, 2)}-${d.slice(2, 6)}-${d.slice(6)}`
+    return d
+  }
+  // 1588 같은 대표번호는 지역번호가 없습니다.
+  if (/^1[0-9]{3}/.test(d) && d.length <= 8) {
+    return d.length <= 4 ? d : `${d.slice(0, 4)}-${d.slice(4)}`
+  }
+  if (d.length <= 7) return `${d.slice(0, 3)}-${d.slice(3)}`
+  if (d.length <= 10) return `${d.slice(0, 3)}-${d.slice(3, 6)}-${d.slice(6)}`
+  if (d.length === 11) return `${d.slice(0, 3)}-${d.slice(3, 7)}-${d.slice(7)}`
+  return d
+}
+
+/**
+ * 입력 중인 사업자 등록번호에 하이픈을 붙입니다.
+ *
+ * 다 적기 전에도 보정해야 하므로, 10자리가 아니면 null 을 주는 formatBusinessNo 와 나눠 둡니다.
+ */
+export function maskBusinessNo(value: string): string {
+  const d = businessNoDigits(value).slice(0, 10)
+  if (d.length <= 3) return d
+  if (d.length <= 5) return `${d.slice(0, 3)}-${d.slice(3)}`
+  return `${d.slice(0, 3)}-${d.slice(3, 5)}-${d.slice(5)}`
+}


### PR DESCRIPTION
## 변경 요약

- **전화번호·사업자등록번호를 숫자만 남겨 저장한다.** 폼·명함 OCR·등록증 OCR·엑셀 일괄 등록이 저마다 다른 모양으로 넣던 값을 스키마에서 한 형태로 모았다. 하이픈은 목록·상세·폼·중복 확인 화면에서만 붙인다. 이미 하이픈이 섞여 저장된 값이 있으므로 담당자 검색은 양쪽을 숫자로 맞춰 견준다.
- **사업자등록증 원본을 보관한다.** 등록증은 사람이 아니라 회사의 문서이므로 담당자가 아니라 고객사에 묶는다. 인식과 보관이 같은 기준으로 파일을 검사한다. 등록증 보관본은 명함 보관본처럼 자료실 목록에서 뺀다.
- **고객 상세에 첨부 자료를 보여 준다.** 명함은 그 담당자의 것, 등록증은 그 회사의 것을 함께 보여 준다. 저장소 키는 내보내지 않고 5분짜리 서명 주소만 준다. 저장소가 없거나 한 건을 못 받아도 상세는 실패하지 않는다. 자리를 내주기 위해 아래쪽 '이메일 보내기' 버튼은 뺐다(이메일 칸을 눌러도 같은 곳으로 간다).
- **명함·등록증을 읽는 동안에는 진행 화면만 남긴다.** 그 사이 손댈 것이 없는 미리보기와 눌리지 않는 버튼을 함께 두지 않는다.
- **고객 목록에 지역·유입경로 컬럼을 더한다.** 기본 컬럼에서 방문여부를 빼고 유입경로를 넣었다(방문여부는 켤 수 있게 남김). 기본값이 바뀌어 저장된 컬럼 설정 키를 v6 으로 올렸다.

## 검증

- `uv run pytest` — 1405 passed, 8 skipped, 6 failed. 실패한 6건은 `tests/test_ocr.py` 5건과 `tests/test_models.py` 1건으로, 로컬 `.env` 값이 `Settings` 에 섞여 드는 환경 문제다. 이 PR 이 건드리지 않은 파일이고, `.env` 가 없는 워크트리에서는 수집 단계에서 같은 이유로 실패한다.
- `uv run ruff check .` / `uv run ruff format --check .` — 통과
- `npm run typecheck` / `npm run lint` — 통과
- 브라우저로 화면을 열어 본 수동 확인은 하지 않았다.

## 영향 및 주의 사항

- **기존 데이터는 그대로 둔다.** 이미 하이픈이 섞여 저장된 전화번호를 옮기는 마이그레이션은 넣지 않았다. 검색은 양쪽을 숫자로 맞춰 견디지만, 저장 형식을 완전히 정리하려면 별도 작업이 필요하다.
- 담당자 검색이 `regexp_replace` 로 저장값을 정규화해 견주므로 전화번호 검색은 인덱스를 타지 못한다. 지금 규모에서는 문제되지 않지만 목록이 커지면 다시 볼 지점이다.
- `_phone_search` 자체에 대한 테스트는 넣지 않았다. 일괄 등록·스키마 쪽 정규화만 테스트로 덮었다.
- 컬럼 설정 키가 올라가 사용자가 맞춰 둔 컬럼 구성이 한 번 초기화된다.
- `/business-licenses/archive` 는 저장소가 설정돼 있어야 동작한다. 설정되지 않은 환경에서는 503 을 주고, 고객 등록 자체는 성공한 뒤 보관 실패만 안내한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 사업자등록증 원본을 회사에 보관하고 고객 정보와 연결할 수 있습니다.
  - 고객 상세 화면에서 명함 및 사업자등록증 첨부 파일을 확인하고 열거나 다운로드할 수 있습니다.
  - 고객 목록에 지역과 등록 출처 열이 추가되었습니다.
- **개선**
  - 전화번호와 사업자등록번호가 숫자만 저장되며, 화면에서는 읽기 쉬운 형식으로 표시됩니다.
  - 명함·사업자등록증 인식 중 전용 진행 화면이 표시됩니다.
  - 첨부 파일이 없는 고객과 이미지가 아닌 파일도 명확하게 안내됩니다.
- **버그 수정**
  - 고객 중복 확인과 검색에서 전화번호 형식 차이로 인한 불일치를 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->