### PR TITLE
docs: 로컬 테스트 DB 시작 실패와 마이그레이션 이어붙이기를 적는다

### DIFF
--- a/docs/technical/local-test-database.md
+++ b/docs/technical/local-test-database.md
@@ -11,8 +11,9 @@
 | PostgreSQL 도구 | `/usr/local/opt/postgresql@17/bin/` |
 | 시작 방식 | 수동 실행. 로그인 시 자동 시작은 설정하지 않음 |
 
-저장소 `backend/sql/*.sql` 38개를 파일명 순서로 적용했다. 적용 파일명과 SHA-256은
-DB의 `test_meta.migrations`에 기록되어 있다. 고객·영업 원본 데이터는 복사하지 않았다.
+저장소 `backend/sql/*.sql`을 파일명 순서로 적용했다(2026-09-07 최초 38개,
+2026-09-09 기준 42개). 적용 파일명과 SHA-256은 DB의 `test_meta.migrations`에
+기록되어 있다. 고객·영업 원본 데이터는 복사하지 않았다.
 Supabase Auth 자체는 설치하지 않고, `member.id` 외래키에 필요한 `auth.users(id uuid)`만 만들었다.
 따라서 Supabase 로그인·토큰 발급·Storage 테스트용 환경은 아니다.
 
@@ -25,7 +26,7 @@ baseline은 RLS를 켜고 클라이언트 정책을 만들지 않으므로, 백�
 저장소 루트에서 시작/상태 확인/중지한다. 데이터 디렉터리는 중지해도 유지된다.
 
 ```sh
-/usr/local/opt/postgresql@17/bin/pg_ctl -D backend/.postgres-test.local/data -l backend/.postgres-test.local/server.log -w start
+LC_ALL=C /usr/local/opt/postgresql@17/bin/pg_ctl -D backend/.postgres-test.local/data -l backend/.postgres-test.local/server.log -w start
 /usr/local/opt/postgresql@17/bin/pg_ctl -D backend/.postgres-test.local/data status
 /usr/local/opt/postgresql@17/bin/pg_ctl -D backend/.postgres-test.local/data -m fast -w stop
 ```
@@ -33,6 +34,26 @@ baseline은 RLS를 켜고 클라이언트 정책을 만들지 않으므로, 백�
 재부팅 등으로 `/tmp/salesluv-test-132-501` 소켓 디렉터리가 없어졌다면 같은 사용자로
 `mkdir -m 700 /tmp/salesluv-test-132-501` 후 시작한다. 이 경로의 501은 이 머신의 사용자 ID다.
 Homebrew의 기본 클러스터와 별도로 만든 인스턴스이므로 `brew services start` 대신 위 명령을 쓴다.
+
+`LC_ALL`이 없으면 시작에 실패한다. 로그에 다음이 남는다.
+
+```text
+FATAL:  postmaster became multithreaded during startup
+HINT:  Set the LC_ALL environment variable to a valid locale.
+```
+
+PostgreSQL은 시작 시 단일 스레드여야 하는데, macOS에서 로케일이 비어 있으면 시스템이
+로케일을 찾느라 스레드를 만든다. postmaster가 그것을 감지하고 시작을 멈춘다. `LC_ALL=C`는
+찾을 것을 없애 스레드가 생기지 않게 한다. DB에 저장된 정렬·인코딩 설정은 바뀌지 않고,
+시작 시점의 프로세스 환경에만 영향을 준다.
+
+브랜치를 옮겨 새 마이그레이션이 생겼다면 `backend`에서 bootstrap을 다시 실행한다.
+이미 적용한 파일은 SHA-256을 대조해 건너뛰고 새 파일만 적용하므로 반복 실행해도 안전하다.
+기존 파일이 수정됐다면 그 자리에서 멈춘다.
+
+```sh
+uv run --no-sync python .postgres-test.local/bootstrap.py
+```
 
 `backend`에서 명시적으로 테스트 설정을 읽는다. 앱의 일반 `.env`는 생성하거나 덮어쓰지 않았다.
 


### PR DESCRIPTION
## 변경 요약

`docs/technical/local-test-database.md`의 시작 명령이 그대로는 동작하지 않아 고칩니다.

- **시작 명령에 `LC_ALL=C`를 붙입니다.** 없으면 `postmaster became multithreaded during startup`으로 시작이 실패합니다. macOS 에서 로케일이 비어 있으면 로케일 조회가 스레드를 만들고, postmaster 가 이를 감지해 멈추기 때문입니다. 로그에 실제로 남는 문구와 이유를 함께 적었습니다. 상태 확인·중지에는 필요 없어 그대로 두었습니다.
- **새 마이그레이션을 이어서 적용하는 방법을 적습니다.** 브랜치를 옮겨 SQL 이 늘었을 때 어떻게 하는지가 문서에 없었습니다. `backend`에서 bootstrap 을 다시 실행하면 되고, 이미 적용한 파일은 SHA-256 대조로 건너뛰므로 반복 실행해도 안전하다는 점을 적었습니다.
- **적용 개수 표기를 시점이 드러나게 바꿉니다.** "38개"만 적혀 있어 새 마이그레이션이 생기면 바로 낡습니다. 최초 시점과 현재 시점을 함께 남겼습니다.

DB 구성이나 접속 설정은 바꾸지 않았습니다. 문서만 고칩니다.

## 검증

문서에 적은 명령을 이 머신에서 실제로 실행해 확인했습니다.

| 명령 | 결과 |
|---|---|
| `-m fast -w stop` | 서버 멈추었음 |
| `LC_ALL=C ... -w start` | server started |
| `status` | 서버가 실행 중임 |
| `backend`에서 `bootstrap.py` 재실행 | `READY`, 이미 적용한 파일은 재적용하지 않음 |
| `--env-file .env.test`, `RUN_INTEGRATION_TESTS=true`로 `test_local_database.py`, `test_health.py` | 3 passed |

`LC_ALL` 없이 시작하면 실패하는 것도 확인했고, 그때 로그에 남은 문구를 문서에 그대로 옮겼습니다.

`git diff --check` 통과. 코드 변경이 없어 lint·빌드는 해당하지 않습니다.

## 영향 및 주의 사항

- 문서만 바뀝니다. 코드·설정·DB 변경 없음.
- 이 문서의 환경은 이 작업 머신 기준입니다. 다른 머신에서 같은 증상이 나는지는 확인하지 않았습니다.
- CI 가 실패로 보인다면 현재 `develop` 자체가 빨간불인 영향입니다. 이 PR 은 문서만 바꿉니다.

## 관련 이슈

- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 로컬 테스트 데이터베이스 설정 문서를 최신 적용 SQL 파일 수와 기준일에 맞게 업데이트했습니다.
  * macOS에서 데이터베이스 시작이 실패하는 경우와 `LC_ALL=C` 설정을 통한 해결 방법을 설명했습니다.
  * 새 마이그레이션을 적용하고 기존 파일의 무결성을 확인하는 절차와 명령 예시를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->