### PR TITLE
feat(meetings): 보고서에서 일반 딜 생성과 자동 연결을 지원한다

### DIFF
--- a/frontend/src/hooks/useCompanyDeals.ts
+++ b/frontend/src/hooks/useCompanyDeals.ts
@@ -48,6 +48,14 @@ export default function useCompanyDeals(companyId?: string | null) {
   }, [companyId, reloadKey])
 
   const reload = useCallback(() => setReloadKey((key) => key + 1), [])
+  const addDeal = useCallback(
+    (deal: SalesDeal) => {
+      if (!companyId || deal.customerCompanyId !== companyId) return
+      setDeals((current) => [deal, ...current.filter((item) => item.id !== deal.id)])
+      setError(null)
+    },
+    [companyId],
+  )
 
-  return { deals, loading, error, reload }
+  return { deals, loading, error, reload, addDeal }
 }

--- a/frontend/src/pages/Customers/duplicate.ts
+++ b/frontend/src/pages/Customers/duplicate.ts
@@ -1,5 +1,5 @@
 import type { CustomerDuplicateResponse } from '@/types'
-import { phoneDigits } from '@/utils/format'
+import { phoneDigits } from '../../utils/format.ts'
 
 /** 지금 등록하려던 값. 폼과 명함·등록증 흐름이 모두 이 모양으로 넘깁니다. */
 export interface DuplicateDraft {

--- a/frontend/src/pages/Deals/useSalesDeals.ts
+++ b/frontend/src/pages/Deals/useSalesDeals.ts
@@ -138,7 +138,7 @@ function requestErrorMessage(error: unknown, target: '목록' | '상세'): strin
   return transportMessage(error) ?? fallback
 }
 
-function mutationErrorMessage(error: unknown, action: string): string {
+export function mutationErrorMessage(error: unknown, action: string): string {
   const fallback = action + '하지 못했습니다.'
   if (!isAxiosError(error)) return fallback
   if (error.response?.status === 401) return '로그인이 만료되었습니다. 다시 로그인해 주세요.'
@@ -335,6 +335,17 @@ export function toCreateRequest(
     ...(input.title === null ? {} : { title: input.title }),
     participant_contact_ids: input.participantContactIds,
   }
+}
+
+export async function createSalesDealRecord(
+  input: SalesDealSaveInput,
+  pipelineId: string,
+): Promise<SalesDeal> {
+  const { data } = await client.post<SalesDealResponse>(
+    '/sales-deals',
+    toCreateRequest(input, pipelineId),
+  )
+  return toSalesDeal(data)
 }
 
 function toPatchRequest(
@@ -613,11 +624,7 @@ export default function useSalesDeals(
     (input: SalesDealSaveInput) =>
       runMutation('create', '영업 딜을 등록', async () => {
         if (stagePipelineId === null) throw new Error('사용할 영업 파이프라인이 없습니다.')
-        const { data } = await client.post<SalesDealResponse>(
-          '/sales-deals',
-          toCreateRequest(input, stagePipelineId),
-        )
-        const created = toSalesDeal(data)
+        const created = await createSalesDealRecord(input, stagePipelineId)
         setCards((previous) => [created, ...previous])
         await syncSalesDeals()
         return created

--- a/frontend/src/pages/Meetings/Compose.tsx
+++ b/frontend/src/pages/Meetings/Compose.tsx
@@ -40,6 +40,7 @@ import { attachmentPayloadsOf, meetingAttachmentPurposeOf } from '@/utils/attach
 
 import DealReportCard from './components/DealReportCard'
 import MeetingInfoPanel from './components/MeetingInfoPanel'
+import MeetingDealForm from './components/MeetingDealForm'
 import MeetingInputPanel from './components/MeetingInputPanel'
 import MeetingSharedPanel from './components/MeetingSharedPanel'
 import useMeetingDraft, { hasMeetingDraftContent, isMeetingBodyBlank } from './useMeetingDraft'
@@ -248,6 +249,12 @@ export default function Compose() {
     return () => controller.abort()
   }, [agendaId, draftReady, memberId, savedReport, resumeGeneration])
   const deals = useCompanyDeals(item?.customerCompanyId)
+  const [createDealOpen, setCreateDealOpen] = useState(false)
+  const createDealKey = useRef('')
+  useEffect(() => {
+    setCreateDealOpen(false)
+    createDealKey.current = ''
+  }, [agendaId, item?.customerCompanyId])
   const [confirm, setConfirm] = useState<Confirm>(null)
 
   if (agendaLoading || loading) {
@@ -303,7 +310,7 @@ export default function Compose() {
   const fixedDealIds = draft.salesDealIds.filter(
     (dealId) => draft.draftsByDeal[dealId]?.reportId !== undefined,
   )
-  const busy = pending || generating || recovering || submitting
+  const busy = pending || generating || recovering || submitting || createDealOpen
   const meetingDate = savedReport?.date ?? draft.reportDate ?? item.date
   const meetingTime = savedReport?.time ?? item.time
   const when = `미팅일 ${fmtDot(parseISO(meetingDate))} ${meetingTime}`
@@ -583,6 +590,11 @@ export default function Compose() {
                 selectedDealIds={draft.salesDealIds}
                 fixedDealIds={fixedDealIds}
                 onToggleDeal={draft.toggleSalesDeal}
+                onCreateDeal={() => {
+                  if (busy || !canEdit || !item.customerCompanyId || deals.loading) return
+                  createDealKey.current = `${item.id}:${item.customerCompanyId}`
+                  setCreateDealOpen(true)
+                }}
                 disabled={busy || !canEdit}
               />
             </aside>
@@ -699,8 +711,10 @@ export default function Compose() {
                     when={`${when}${product ? ` · ${product}` : ''}`}
                     saving={pending}
                     generating={generating || recovering}
-                    canGenerate={draft.canGenerate && generatable && !generationInputError}
-                    readOnly={!canEditDeal(dealId)}
+                    canGenerate={
+                      draft.canGenerate && generatable && !generationInputError && !createDealOpen
+                    }
+                    readOnly={!canEditDeal(dealId) || createDealOpen}
                     onTitleChange={(value) => draft.setTitle(dealId, value)}
                     onChange={(body) => draft.applyDocument(dealId, body)}
                     onStartManual={() => draft.startManual(dealId)}
@@ -736,6 +750,33 @@ export default function Compose() {
         >
           <p>현재 편집 중인 내용은 아직 업무보고서로 저장되지 않았습니다.</p>
         </Modal>
+      )}
+      {createDealOpen && item.customerCompanyId && (
+        <MeetingDealForm
+          activityKey={item.id}
+          companyId={item.customerCompanyId}
+          contactId={item.customerContactId}
+          contactName={item.customerContactName}
+          fallbackContactName={item.contact}
+          onCreated={(created) => {
+            const key = `${item.id}:${item.customerCompanyId}`
+            if (
+              createDealKey.current !== key ||
+              item.id !== agendaId ||
+              created.customerCompanyId !== item.customerCompanyId
+            )
+              return
+            deals.addDeal(created)
+            draft.toggleSalesDeal(created.id)
+            createDealKey.current = ''
+            setCreateDealOpen(false)
+            showToast('새 딜을 생성하고 미팅에 연결했습니다.')
+          }}
+          onClose={() => {
+            createDealKey.current = ''
+            setCreateDealOpen(false)
+          }}
+        />
       )}
     </section>
   )

--- a/frontend/src/pages/Meetings/components/MeetingDealForm.tsx
+++ b/frontend/src/pages/Meetings/components/MeetingDealForm.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useRef, useState } from 'react'
+
+import { client } from '@/api/client'
+import { errorMessage } from '@/api/errorMessage'
+import Button from '@/components/Button'
+import type { ContactOption } from '@/components/ContactPicker'
+import Modal from '@/components/Modal'
+import { SkeletonBlocks } from '@/components/Skeleton'
+import SalesDealForm from '@/pages/Deals/SalesDealForm'
+import {
+  createSalesDealRecord,
+  mutationErrorMessage,
+  toColumn,
+  type SalesDeal,
+  type SalesDealColumn,
+  type SalesDealSaveInput,
+} from '@/pages/Deals/useSalesDeals'
+import type { CustomerCompanyResponse, SalesPipelineResponse } from '@/types'
+import type { SalesPipelineStageResponse } from '@/types'
+
+interface Props {
+  activityKey: string
+  companyId: string
+  contactId?: string | null
+  contactName?: string
+  fallbackContactName?: string
+  onCreated: (deal: SalesDeal) => void
+  onClose: () => void
+}
+
+interface LookupState {
+  company: CustomerCompanyResponse | null
+  pipeline: SalesPipelineResponse | null
+  columns: SalesDealColumn[]
+  loading: boolean
+  error: string | null
+}
+
+const EMPTY_STATE: LookupState = {
+  company: null,
+  pipeline: null,
+  columns: [],
+  loading: true,
+  error: null,
+}
+
+function lookupError(reason: unknown): string {
+  if (reason instanceof Error && reason.message === 'published_pipeline_missing') {
+    return '게시된 영업 파이프라인이 없어 새 딜을 만들 수 없습니다.'
+  }
+  if (reason instanceof Error && reason.message === 'pipeline_stage_missing') {
+    return '게시된 영업 파이프라인에 생성 가능한 단계가 없어 새 딜을 만들 수 없습니다.'
+  }
+  return errorMessage(reason, '새 딜 선택지를 불러오지 못했습니다. 다시 시도해 주세요.')
+}
+
+export default function MeetingDealForm({
+  activityKey,
+  companyId,
+  contactId,
+  contactName,
+  fallbackContactName,
+  onCreated,
+  onClose,
+}: Props) {
+  const [retryKey, setRetryKey] = useState(0)
+  const [state, setState] = useState<LookupState>(EMPTY_STATE)
+  const activeKey = `${activityKey}:${companyId}`
+  const mountedKey = useRef(activeKey)
+
+  useEffect(() => {
+    mountedKey.current = activeKey
+    return () => {
+      if (mountedKey.current === activeKey) mountedKey.current = ''
+    }
+  }, [activeKey])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    let live = true
+    setState({ ...EMPTY_STATE, loading: true })
+
+    void Promise.all([
+      client.get<CustomerCompanyResponse>(`/customer-companies/${companyId}`, {
+        signal: controller.signal,
+      }),
+      client.get<SalesPipelineResponse[]>('/sales-pipelines', { signal: controller.signal }),
+    ])
+      .then(async ([companyResponse, pipelineResponse]) => {
+        const pipeline =
+          pipelineResponse.data.find(
+            (item) => item.is_default && item.status_code === 'published',
+          ) ?? pipelineResponse.data.find((item) => item.status_code === 'published')
+        if (!pipeline) throw new Error('published_pipeline_missing')
+        const { data: stages } = await client.get<SalesPipelineStageResponse[]>(
+          `/sales-pipelines/${pipeline.id}/stages`,
+          { signal: controller.signal },
+        )
+        if (stages.length === 0) throw new Error('pipeline_stage_missing')
+        if (!live || mountedKey.current !== activeKey) return
+        setState({
+          company: companyResponse.data,
+          pipeline,
+          columns: stages.map(toColumn),
+          loading: false,
+          error: null,
+        })
+      })
+      .catch((reason: unknown) => {
+        if (!live || controller.signal.aborted || mountedKey.current !== activeKey) return
+        setState({
+          company: null,
+          pipeline: null,
+          columns: [],
+          loading: false,
+          error: lookupError(reason),
+        })
+      })
+
+    return () => {
+      live = false
+      controller.abort()
+    }
+  }, [activeKey, companyId, retryKey])
+
+  if (state.loading || state.error || !state.company || !state.pipeline) {
+    return (
+      <Modal
+        title="새 딜 생성"
+        onClose={onClose}
+        footer={
+          <>
+            <Button type="button" variant="outline" onClick={onClose}>
+              취소
+            </Button>
+            {state.error && (
+              <Button type="button" onClick={() => setRetryKey((key) => key + 1)}>
+                다시 시도
+              </Button>
+            )}
+          </>
+        }
+      >
+        {state.loading ? (
+          <SkeletonBlocks label="새 딜 선택지를 불러오는 중입니다." count={3} height={48} />
+        ) : (
+          <p role="alert">{state.error}</p>
+        )}
+      </Modal>
+    )
+  }
+
+  const initialContact: ContactOption | undefined = contactId
+    ? {
+        id: contactId,
+        name: contactName?.trim() || fallbackContactName?.trim() || '담당자',
+        companyId,
+        org: state.company.name,
+        dept: '',
+        title: '',
+      }
+    : undefined
+
+  const submit = async (input: SalesDealSaveInput) => {
+    if (mountedKey.current !== activeKey) return
+    if (input.customerCompanyId !== companyId) {
+      throw new Error('미팅 회사와 다른 고객사를 선택할 수 없습니다.')
+    }
+    let data: SalesDeal
+    try {
+      data = await createSalesDealRecord(input, state.pipeline!.id)
+    } catch (reason: unknown) {
+      throw new Error(mutationErrorMessage(reason, '영업 딜을 등록'))
+    }
+    if (mountedKey.current === activeKey) onCreated(data)
+  }
+
+  return (
+    <SalesDealForm
+      columns={state.columns}
+      initialCompany={state.company}
+      initialContact={initialContact}
+      onSubmit={submit}
+      onClose={onClose}
+    />
+  )
+}

--- a/frontend/src/pages/Meetings/components/MeetingInfoPanel/MeetingInfoPanel.tsx
+++ b/frontend/src/pages/Meetings/components/MeetingInfoPanel/MeetingInfoPanel.tsx
@@ -1,6 +1,7 @@
 // 미팅 맥락과 선택한 딜은 항상 보여 주고, 추가 정보와 선택 목록만 펼칩니다.
 import type { SalesDeal } from '@/pages/Deals/useSalesDeals'
 import type { AgendaItem } from '@/types'
+import Button from '@/components/Button'
 import { fmtDot, parseISO } from '@/utils/date'
 
 import DealPicker from '../DealPicker'
@@ -18,6 +19,7 @@ interface Props {
   selectedDealIds: string[]
   fixedDealIds?: string[]
   onToggleDeal: (id: string) => void
+  onCreateDeal?: () => void
   disabled: boolean
 }
 
@@ -30,6 +32,7 @@ export default function MeetingInfoPanel({
   selectedDealIds,
   fixedDealIds,
   onToggleDeal,
+  onCreateDeal,
   disabled,
 }: Props) {
   const selectedNames = selectedDealIds.map((id) => {
@@ -74,6 +77,17 @@ export default function MeetingInfoPanel({
           onToggle={onToggleDeal}
           disabled={disabled}
         />
+        {onCreateDeal && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={disabled || dealsLoading || !item.customerCompanyId}
+            onClick={onCreateDeal}
+          >
+            새 딜 생성
+          </Button>
+        )}
       </details>
     </div>
   )

--- a/frontend/tests/reportDrafts.browser.html
+++ b/frontend/tests/reportDrafts.browser.html
@@ -21,6 +21,7 @@
       import { meetingFinalizeRequestOf } from '../src/pages/Meetings/useMeetingReports.ts'
       import { toCreateRequest } from '../src/pages/Deals/useSalesDeals.ts'
       import MeetingCompose from '../src/pages/Meetings/Compose.tsx'
+      import { addDays, iso, TODAY } from '../src/utils/date.ts'
 
       window.IS_REACT_ACT_ENVIRONMENT = true
       const root = createRoot(document.getElementById('root'))
@@ -553,13 +554,8 @@
         // 미팅 보고서에서 새 딜을 여는 실제 흐름. 모든 요청은 이 합성 adapter 안에서만
         // 처리해 실제 영업·고객 데이터와 네트워크를 건드리지 않습니다.
         await render(null)
-        const meetingDate = '2026-08-20'
-        const defaultOpenedOnDate = new Date()
-        defaultOpenedOnDate.setHours(0, 0, 0, 0)
-        defaultOpenedOnDate.setDate(defaultOpenedOnDate.getDate() + 1)
-        const expectedDefaultOpenedOn = new Intl.DateTimeFormat('en-CA').format(
-          defaultOpenedOnDate,
-        )
+        const meetingDate = iso(addDays(TODAY, -1))
+        const expectedDefaultOpenedOn = iso(addDays(TODAY, 1))
         const company = {
           id: 'company-1',
           name: '아크메드',

--- a/frontend/tests/reportDrafts.browser.html
+++ b/frontend/tests/reportDrafts.browser.html
@@ -19,6 +19,7 @@
       import useDailyReports from '../src/pages/Daily/useDailyReports.ts'
       import useMeetingDraft from '../src/pages/Meetings/useMeetingDraft.ts'
       import { meetingFinalizeRequestOf } from '../src/pages/Meetings/useMeetingReports.ts'
+      import { toCreateRequest } from '../src/pages/Deals/useSalesDeals.ts'
       import MeetingCompose from '../src/pages/Meetings/Compose.tsx'
 
       window.IS_REACT_ACT_ENVIRONMENT = true
@@ -55,6 +56,69 @@
         attachments: [],
         deal_sections: [],
         updated_at: '2026-08-31T00:00:00Z',
+      })
+      const deal = (id, title, companyId = 'company-1', openedOn = '2026-08-20') => ({
+        id,
+        deal_no: `D-${id}`,
+        title,
+        customer_company_id: companyId,
+        customer_company_name: '아크메드',
+        customer_company_region_code: null,
+        customer_company_business_no: null,
+        customer_contact_id: 'contact-1',
+        customer_contact_name: '김하나',
+        product_id: 'product-1',
+        product_name: '제품 A',
+        deal_amount: 0,
+        deal_type_code: 'new-business',
+        deal_type_name: '신규 영업',
+        source_code: null,
+        owner_member_id: 'author',
+        owner_display_name: '합성 작성자',
+        opened_on: openedOn,
+        memo: null,
+        description: null,
+        closed_on: null,
+        sales_pipeline_id: 'pipeline-1',
+        sales_pipeline_name: '기본 파이프라인',
+        sales_pipeline_status_code: 'published',
+        sales_pipeline_stage_id: 'stage-1',
+        sales_pipeline_stage_code: 'new',
+        sales_pipeline_stage_name: '신규',
+        sales_pipeline_stage_tone: 'blue',
+        sales_pipeline_stage_phase_code: 'in_progress',
+        sales_pipeline_stage_position: 0,
+        stage_position: 0,
+        quote_no: null,
+        quote_issued_on: null,
+        quote_valid_until: null,
+        contract_no: null,
+        contract_signed_on: null,
+        contract_ends_on: null,
+        warranty_terms: null,
+        expected_delivery_at: null,
+        quote_status_id: null,
+        quote_status_code: null,
+        quote_status_name: null,
+        quote_status_tone: null,
+        contract_status_id: null,
+        contract_status_code: null,
+        contract_status_name: null,
+        contract_status_tone: null,
+        quote_amount: null,
+        contract_amount: null,
+        quote_delivery_terms: null,
+        contract_payment_terms: null,
+        contract_late_interest_terms: null,
+        team_company_name: null,
+        team_business_no: null,
+        items: [],
+        participants: [],
+        order_status_code: null,
+        order_status_name: null,
+        order_status_tone: null,
+        created_at: '2026-08-20T00:00:00Z',
+        updated_at: '2026-08-20T00:00:00Z',
       })
       const session = {
         session: { memberId: 'author', role: 'member', profile: {}, isAdmin: false },
@@ -484,6 +548,314 @@
         check(
           generated.length === generationCount && finalized.length === finalCount,
           '실제 미팅 초과 원문은 생성·최종 제출 POST 0회',
+        )
+
+        // 미팅 보고서에서 새 딜을 여는 실제 흐름. 모든 요청은 이 합성 adapter 안에서만
+        // 처리해 실제 영업·고객 데이터와 네트워크를 건드리지 않습니다.
+        await render(null)
+        const meetingDate = '2026-08-20'
+        const defaultOpenedOnDate = new Date()
+        defaultOpenedOnDate.setHours(0, 0, 0, 0)
+        defaultOpenedOnDate.setDate(defaultOpenedOnDate.getDate() + 1)
+        const expectedDefaultOpenedOn = new Intl.DateTimeFormat('en-CA').format(
+          defaultOpenedOnDate,
+        )
+        const company = {
+          id: 'company-1',
+          name: '아크메드',
+          address: null,
+          business_no: null,
+          region_code: null,
+        }
+        const contact = {
+          id: 'contact-1',
+          company_id: 'company-1',
+          company_name: '아크메드',
+          name: '김하나',
+          department: '영업부',
+          job_title: '팀장',
+          email: null,
+          phone: null,
+        }
+        const product = { id: 'product-1', name: '제품 A' }
+        const initialReport = {
+          ...report('meeting', 'saved-create-deal', 'saved-submission'),
+          source_activity_id: 'create-deal-agenda',
+          report_date: meetingDate,
+          status_code: 'draft',
+          title: '합성 미팅 보고서',
+          content: {
+            time: '09:30',
+            hospital: company.name,
+            dept: '영업부',
+            contact: '김하나 팀장',
+            place: '본사',
+            title: '합성 미팅',
+          },
+          direct_transcript: '원문 보존 내용',
+          transcript: '원문 보존 내용',
+          common_body: '공통 편집 본문',
+          unassigned_body: null,
+          attachments: [
+            {
+              id: 'stored-source',
+              kind: 'image',
+              purpose: 'meeting_source',
+              name: '원문.png',
+              byte_size: 12,
+              extract: '원문 첨부 보존',
+              original_stored: true,
+            },
+          ],
+          deal_sections: [],
+        }
+        let meetingDeals = []
+        let dealListCalls = 0
+        let createInputs = []
+        let createShouldFail = true
+        const pipeline = {
+          id: 'pipeline-1',
+          name: '기본 파이프라인',
+          status_code: 'published',
+          is_default: true,
+        }
+        const stage = {
+          id: 'stage-1',
+          name: '신규',
+          code: 'new',
+          tone: 'blue',
+          outcome_code: 'in_progress',
+          phase_code: 'in_progress',
+          position: 0,
+        }
+        client.defaults.adapter = async (config) => {
+          if (config.url === '/activities/create-deal-agenda')
+            return response(config, {
+              id: 'create-deal-agenda',
+              owner_member_id: 'author',
+              owner_display_name: '합성 작성자',
+              starts_at: `${meetingDate}T00:30:00.000Z`,
+              ends_at: `${meetingDate}T01:30:00.000Z`,
+              title: '합성 미팅',
+              category_code: 'meeting',
+              completed_at: null,
+              customer_company_id: company.id,
+              customer_company_name: company.name,
+              customer_contact_id: contact.id,
+              customer_contact_name: contact.name,
+              customer_contact_department: contact.department,
+              customer_contact_job_title: contact.job_title,
+              product_name: product.name,
+              location: '본사',
+              action_tag: 'meeting',
+              note: '',
+              all_day: false,
+              briefing_queue_warning: null,
+              schedule_conflict_warning: null,
+              product_id: product.id,
+              sales_deal_id: null,
+            })
+          if (config.url === '/reports') return response(config, page([initialReport]))
+          if (config.url === '/report-generations/latest') throw failure(config, 404)
+          if (config.url === '/sales-deals' && config.method === 'get') {
+            dealListCalls += 1
+            return response(config, page(meetingDeals))
+          }
+          if (config.url === `/customer-companies/${company.id}`)
+            return response(config, company)
+          if (config.url === '/sales-pipelines') return response(config, [pipeline])
+          if (config.url === `/sales-pipelines/${pipeline.id}/stages`)
+            return response(config, [stage])
+          if (config.url === '/sales-deal-types')
+            return response(config, [{ code: 'new-business', name: '신규 영업' }])
+          if (config.url === '/products') return response(config, page([product]))
+          if (config.url === '/customer-contacts') return response(config, page([contact]))
+          if (config.url === '/sales-deals' && config.method === 'post') {
+            const input = JSON.parse(config.data)
+            createInputs.push(input)
+            if (createShouldFail) throw failure(config, 403)
+            const created = deal('created-deal', input.title ?? '아크메드 제품 A', company.id, input.opened_on)
+            meetingDeals = [created]
+            return response(config, created)
+          }
+          throw new Error(`허용하지 않은 새 딜 합성 요청: ${config.method} ${config.url}`)
+        }
+        await render(
+          createElement(
+            MemoryRouter,
+            { initialEntries: ['/?agenda=create-deal-agenda'] },
+            createElement(MeetingCompose),
+          ),
+        )
+        await act(async () => {
+          await Promise.resolve()
+          await Promise.resolve()
+        })
+        const summaries = [...document.querySelectorAll('summary')]
+        const dealsSummary = summaries.find((node) => node.textContent.includes('관련 딜 선택'))
+        check(dealsSummary, '기존 딜 0건이어도 관련 딜 선택 영역이 표시됨')
+        await act(async () => dealsSummary.click())
+        const createDealButton = [...document.querySelectorAll('button')].find(
+          (button) => button.textContent.trim() === '새 딜 생성',
+        )
+        check(createDealButton && !createDealButton.disabled, '새 딜 생성 버튼은 유효 상태에서 활성화됨')
+        const commonEditor = () => {
+          const label = [...document.querySelectorAll('label')].find(
+            (item) => item.textContent.trim() === '공통 내용',
+          )
+          return label ? document.getElementById(label.htmlFor) : null
+        }
+        check(
+          commonEditor()?.value === '공통 편집 본문' &&
+            document.getElementById('transcript')?.value === '원문 보존 내용' &&
+            document.body.textContent.includes('원문.png'),
+          '새 딜을 열기 전 원문·첨부·공통 편집 본문이 존재함',
+        )
+
+        await act(async () => createDealButton.click())
+        const loadingDialog = document.querySelector('[role="dialog"]')
+        check(
+          loadingDialog &&
+            (loadingDialog.textContent.includes('새 딜 생성') ||
+              loadingDialog.textContent.includes('영업 딜 추가')),
+          '새 딜 선택지 조회 모달이 열림',
+        )
+        check(createDealButton.disabled, '새 딜 모달이 열린 동안 중복 열기 버튼을 잠금')
+        const loadingCancel = [...loadingDialog.querySelectorAll('button')].find(
+          (button) => button.textContent.trim() === '취소',
+        )
+        await act(async () => loadingCancel.click())
+        check(
+          createInputs.length === 0 &&
+            document.getElementById('transcript')?.value === '원문 보존 내용' &&
+            commonEditor()?.value === '공통 편집 본문' &&
+            !document.body.textContent.includes('1건 선택'),
+          '새 딜 취소 시 원문·첨부·공통 본문과 선택 상태 보존',
+        )
+
+        await act(async () => createDealButton.click())
+        await act(async () => {
+          await Promise.resolve()
+          await Promise.resolve()
+        })
+        let dialog = document.querySelector('[role="dialog"]')
+        check(dialog?.textContent.includes('영업 딜 추가'), '기존 SalesDealForm으로 새 딜 입력 모달을 엶')
+        const companyInput = dialog.querySelector('input[aria-label="회사명"]')
+        const contactInput = dialog.querySelector('input[aria-label="고객명"]')
+        check(
+          companyInput?.disabled && companyInput.value === company.name && contactInput?.disabled,
+          '미팅 회사·고객이 프리필되고 두 입력이 잠김',
+        )
+        check(dialog.textContent.includes(contact.name), '프리필 고객 이름이 입력 모달에 표시됨')
+        const closePreservingModal = [...dialog.querySelectorAll('button')].find(
+          (button) => button.textContent.trim() === '취소',
+        )
+        await act(async () => closePreservingModal.click())
+        check(
+          createInputs.length === 0 &&
+            document.getElementById('transcript')?.value === '원문 보존 내용' &&
+            commonEditor()?.value === '공통 편집 본문',
+          '입력 모달 취소도 편집 중인 원문과 공통 본문을 보존',
+        )
+
+        const fillDealForm = async () => {
+          await act(async () => createDealButton.click())
+          await act(async () => {
+            await Promise.resolve()
+            await Promise.resolve()
+          })
+          dialog = document.querySelector('[role="dialog"]')
+          const productInput = dialog.querySelector('input[aria-label="제품"]')
+          await act(async () => productInput.focus())
+          await act(async () => {
+            await Promise.resolve()
+            await Promise.resolve()
+          })
+          const productOption = [...document.querySelectorAll('[role="option"]')].find((option) =>
+            option.textContent.includes(product.name),
+          )
+          await act(async () => productOption.click())
+          const titleLabel = [...dialog.querySelectorAll('label')].find(
+            (label) => label.textContent.trim() === '제목',
+          )
+          const titleInput = titleLabel.querySelector('input')
+          const inputSetter = Object.getOwnPropertyDescriptor(
+            HTMLInputElement.prototype,
+            'value',
+          ).set
+          await act(async () => {
+            inputSetter.call(titleInput, '미팅 신규 딜')
+            titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+          })
+        }
+        await fillDealForm()
+        await act(async () =>
+          [...dialog.querySelectorAll('button')]
+            .find((button) => button.textContent.trim() === '영업 딜 추가')
+            .click(),
+        )
+        check(
+          createInputs.length === 1 &&
+            [...document.querySelectorAll('[role="alert"]')].some((item) =>
+              item.textContent.includes('영업 딜을 등록할 권한이 없습니다.'),
+            ),
+          '403 딜 생성 API 실패가 일반 딜과 같은 한국어 권한 오류로 표시되고 POST 입력이 기록됨',
+        )
+        check(
+          !document.body.textContent.includes('1건 선택'),
+          '딜 생성 실패 시 선택 딜을 추가하지 않음',
+        )
+
+        createShouldFail = false
+        await act(async () =>
+          [...dialog.querySelectorAll('button')]
+            .find((button) => button.textContent.trim() === '영업 딜 추가')
+            .click(),
+        )
+        await act(async () => {
+          await Promise.resolve()
+          await Promise.resolve()
+        })
+        check(
+          createInputs.length === 2 &&
+            createInputs[1].customer_company_id === company.id &&
+            createInputs[1].customer_contact_id === contact.id &&
+            createInputs[1].opened_on === expectedDefaultOpenedOn &&
+            createInputs[1].opened_on !== meetingDate &&
+            createInputs[1].owner_member_id === undefined,
+          `성공 POST 날짜 확인: opened_on=${createInputs[1]?.opened_on} expected=${expectedDefaultOpenedOn}`,
+        )
+        equal(
+          createInputs[1],
+          toCreateRequest(
+            {
+              customerCompanyId: company.id,
+              customerContactId: contact.id,
+              productId: product.id,
+              title: '미팅 신규 딜',
+              amount: 0,
+              dealTypeCode: 'new-business',
+              date: expectedDefaultOpenedOn,
+              memo: null,
+              sourceCode: null,
+              stageId: stage.id,
+              participantContactIds: [],
+            },
+            pipeline.id,
+          ),
+          '미팅 새 딜 입력은 일반 딜 생성 공통 payload 변환과 동일함',
+        )
+        check(
+          document.body.textContent.includes('1건 선택') &&
+            document.body.textContent.includes('미팅 신규 딜'),
+          '생성 성공 딜을 즉시 선택하고 제목을 목록에 표시',
+        )
+        check(dealListCalls === 1, '생성 성공 후 기존 회사 딜 첫 목록을 재조회하지 않음')
+        check(
+          meetingDeals[0]?.id === 'created-deal' &&
+            meetingDeals[0]?.customer_company_id === company.id &&
+            meetingDeals[0]?.owner_member_id === 'author',
+          '생성 응답의 회사·담당 영업자 정보가 목록에 보존됨',
         )
         document.getElementById('result').textContent =
           `PASS ${checks.length}\n${checks.join('\n')}`


### PR DESCRIPTION
## 변경 요약

미팅 후 새 영업 기회가 생겼을 때 보고서 작성 화면에서 딜을 생성하고 바로 선택할 수 있습니다.

- 일반 딜 화면과 동일한 `SalesDealForm`, `createSalesDealRecord`, 오류 처리를 사용합니다. 영업 시작일 등 기본값도 기존 폼을 따릅니다.
- 미팅 회사·고객을 미리 채우고 생성 응답을 목록에 즉시 추가해 선택합니다. 기존 원문·첨부·편집 본문은 유지하며, 취소하거나 생성에 실패하면 선택 상태를 변경하지 않습니다.
- 고객 가져오기 단위 테스트의 Node 경로 오류를 상대 import로 복구했습니다. 이 한 줄은 현재 `develop`의 `aa47d32`에도 동일하게 반영되어 있습니다.

## 검증

- `npm test`: 96/96 통과, 고객 가져오기 4개 검사 포함
- `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run build`: 모두 통과
- 합성 API 응답을 사용하는 실제 React 브라우저 회귀: 107항목 통과. 빈 딜 목록, 회사·고객 미리 채우기, 취소 시 내용 보존, 403 실패 처리, 일반 딜과 같은 생성 payload, 생성 후 자동 선택을 확인했습니다.
- `git diff --check`: 통과

## 영향 및 주의 사항

- 프런트엔드 변경이며 기존 백엔드 API를 사용합니다. DB 스키마 변경이나 수동 데이터 적용은 없습니다.
- 딜은 생성 성공 시 일반 딜로 즉시 저장됩니다. 보고서와의 연결은 초안에 반영한 뒤 작성 완료 시 저장됩니다.
- 실제 음성 업로드·AI 분석·보고서 저장을 잇는 E2E는 미실행입니다. 이번 브라우저 검증은 합성 API 응답으로 진행했으며 로컬 분석 워커는 기동하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 미팅 보고서 작성 화면에서 새 딜을 생성할 수 있습니다.
  * 회사와 영업 파이프라인 및 단계를 선택해 딜을 생성할 수 있습니다.
  * 생성된 딜은 목록에 즉시 추가되고 자동으로 선택됩니다.
  * 회사와 고객사 정보가 자동 입력되며, 생성 중에는 관련 편집 및 저장 작업이 제한됩니다.
  * 생성 실패 시 재시도와 권한 오류 안내를 제공합니다.

* **개선**
  * 기존 딜 목록에 새 딜이 중복 없이 반영됩니다.
  * 미팅 보고서의 원문과 첨부 정보가 딜 생성 취소 후에도 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->