### PR TITLE
fix: 겹친 오버레이의 배경 스크롤 잠금과 모달 본문 잘림을 고친다

### DIFF
--- a/frontend/src/components/Drawer/Drawer.tsx
+++ b/frontend/src/components/Drawer/Drawer.tsx
@@ -7,6 +7,7 @@
 import { useEffect, useId, useRef, type ReactNode } from 'react'
 
 import { CloseIcon } from '@/components/icons'
+import { lockScroll } from '@/shared/scrollLock'
 
 import styles from './Drawer.module.scss'
 
@@ -51,13 +52,12 @@ export default function Drawer({
     }
     document.addEventListener('keydown', onKeyDown)
 
-    const previousOverflow = document.body.style.overflow
     const previouslyFocused = document.activeElement as HTMLElement | null
-    document.body.style.overflow = 'hidden'
+    const unlockScroll = lockScroll()
 
     return () => {
       document.removeEventListener('keydown', onKeyDown)
-      document.body.style.overflow = previousOverflow
+      unlockScroll()
       previouslyFocused?.focus()
     }
   }, [onClose])

--- a/frontend/src/components/Modal/Modal.module.scss
+++ b/frontend/src/components/Modal/Modal.module.scss
@@ -20,6 +20,8 @@
 .dialog {
   width: min(100%, 520px);
   max-height: min(86vh, 720px);
+  display: flex;
+  flex-direction: column;
   background: var(--surface);
   border-radius: var(--r-xl);
   box-shadow: var(--sh-pop);
@@ -40,7 +42,10 @@
 .form {
   display: flex;
   flex-direction: column;
-  max-height: inherit;
+  // 다이얼로그가 max-height 에서 멈추면 그 안을 이 폼이 채우고, 넘치는 것은
+  // 본문이 스크롤로 받습니다. auto 로 두면 폼이 내용만큼 자라 본문이 잘립니다.
+  flex: 1;
+  min-height: 0;
 }
 
 .head {

--- a/frontend/src/components/Modal/Modal.tsx
+++ b/frontend/src/components/Modal/Modal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useRef, type ReactNode } from 'react'
 
 import { CloseIcon } from '@/components/icons'
+import { lockScroll } from '@/shared/scrollLock'
 
 import styles from './Modal.module.scss'
 
@@ -55,14 +56,13 @@ export default function Modal({
     }
     document.addEventListener('keydown', onKeyDown)
 
-    const previousOverflow = document.body.style.overflow
     const previouslyFocused = document.activeElement as HTMLElement | null
-    document.body.style.overflow = 'hidden'
+    const unlockScroll = lockScroll()
 
     return () => {
       stack.splice(stack.indexOf(token), 1)
       document.removeEventListener('keydown', onKeyDown)
-      document.body.style.overflow = previousOverflow
+      unlockScroll()
       previouslyFocused?.focus()
     }
   }, [token])

--- a/frontend/src/components/layout/AppShell/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell/AppShell.tsx
@@ -7,6 +7,7 @@ import Topbar from '@/components/layout/Topbar'
 import { BP_DESKTOP, BP_RAIL_DEFAULT } from '@/constants/breakpoints'
 import useMediaQuery from '@/hooks/useMediaQuery'
 import { useScopeKey } from '@/shared/scope'
+import { lockScroll } from '@/shared/scrollLock'
 
 import { SidebarContext } from './sidebarContext'
 
@@ -71,12 +72,11 @@ export default function AppShell() {
     }
     document.addEventListener('keydown', onKeyDown)
 
-    const previousOverflow = document.body.style.overflow
-    document.body.style.overflow = 'hidden'
+    const unlockScroll = lockScroll()
 
     return () => {
       document.removeEventListener('keydown', onKeyDown)
-      document.body.style.overflow = previousOverflow
+      unlockScroll()
     }
   }, [mobileOpen])
 

--- a/frontend/src/pages/Customers/businessLicense.ts
+++ b/frontend/src/pages/Customers/businessLicense.ts
@@ -77,8 +77,7 @@ export class BusinessLicenseScanError extends Error {
 }
 
 export type LicenseScanProgress =
-  | { phase: 'uploading'; percent: number }
-  | { phase: 'recognizing'; elapsedSeconds: number }
+  { phase: 'uploading'; percent: number } | { phase: 'recognizing'; elapsedSeconds: number }
 
 /** PDF 또는 이미지를 서버 OCR로 보내고 완료될 때까지 결과를 조회합니다. */
 export async function extractBusinessLicense(

--- a/frontend/src/shared/scrollLock.ts
+++ b/frontend/src/shared/scrollLock.ts
@@ -1,0 +1,23 @@
+/**
+ * 뒤 배경의 스크롤을 멈추는 일을 겹쳐 있는 오버레이들이 함께 씁니다.
+ *
+ * 각자 body 의 overflow 를 되돌리면, 드로어를 닫으면서 모달을 여는 자리처럼 둘의
+ * 정리와 준비가 한 커밋에 겹칠 때 늦게 도는 쪽이 먼저 건 잠금을 풀어 버립니다.
+ * 그래서 잠근 것을 세어 두고, 마지막 하나가 빠질 때만 원래 값으로 돌립니다.
+ */
+const locks: symbol[] = []
+let previousOverflow = ''
+
+/** 잠그고, 풀 함수를 돌려줍니다. 효과의 정리 단계에서 부르면 됩니다. */
+export function lockScroll(): () => void {
+  const token = Symbol('scroll-lock')
+
+  if (locks.length === 0) previousOverflow = document.body.style.overflow
+  locks.push(token)
+  document.body.style.overflow = 'hidden'
+
+  return () => {
+    locks.splice(locks.indexOf(token), 1)
+    if (locks.length === 0) document.body.style.overflow = previousOverflow
+  }
+}


### PR DESCRIPTION
## 변경 요약

- 드로어·모달·모바일 사이드바가 각자 `body`의 `overflow`를 저장·복원하던 것을 공용 `lockScroll()`로 바꿉니다. 잠금을 세어 두고 마지막 하나가 빠질 때만 원래 값으로 되돌리므로, 드로어를 닫으면서 모달을 여는 자리처럼 정리와 준비가 겹쳐도 뒤 배경이 스크롤되지 않습니다.
- 모달의 `.form`이 `max-height: inherit`으로 다이얼로그 높이를 받으려 했지만 `.dialog`가 block이라 이어지지 않아, 내용이 길면 폼이 넘쳐 아래쪽이 잘렸습니다. `.dialog`를 세로 flex로 바꾸고 `.form`에 `flex: 1; min-height: 0`을 줘서 넘치는 만큼을 본문 스크롤이 받게 했습니다.
- `businessLicense.ts`의 prettier 포맷 위반을 고칩니다. 이번 변경과는 무관하지만 `develop`에 이미 들어가 있어 CI의 `format:check`를 막고 있었습니다.

## 검증

로컬에서 CI 워크플로 단계를 그대로 실행했습니다.

- Frontend — lint(oxlint), format:check, `npm test` 96/96, build(`tsc -b` + vite): 모두 통과
- Backend — ruff, pytest 1416 passed / 8 skipped, 배포 스크립트 검증(`bash -n`, runtime-environment-test.sh): 모두 통과
- 미실행: 백엔드 CI의 Windows 로컬 OCR 스모크 2단계. 모델 다운로드가 필요하고, 이번 변경이 프론트 전용이라 `ci-backend.yml`의 path 필터상 트리거되지 않습니다.
- GitHub Actions 결과는 PR 생성 시점 기준 아직 확인 전입니다.

## 영향 및 주의 사항

- 오버레이를 쓰는 모든 화면에 영향이 갑니다. 특히 드로어→모달 연속 전환, 모바일 사이드바, 내용이 긴 모달(고객 등록 등)을 확인해 주세요.
- 수동 작업이나 후속 작업은 없습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 드로어, 모달, 모바일 메뉴가 열려 있을 때 배경 페이지가 스크롤되지 않도록 개선했습니다.
  - 여러 오버레이가 동시에 열려도 모든 오버레이가 닫힌 후에만 배경 스크롤이 복원됩니다.
  - 긴 모달 콘텐츠가 대화상자 영역을 벗어나지 않고 내부에서 스크롤되도록 수정했습니다.

- **코드 정리**
  - 오버레이 간 스크롤 동작을 일관되게 처리하도록 개선했습니다.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->