### PR TITLE
feat: 콘텐츠 이미지를 눌러 크게 봅니다

### DIFF
--- a/frontend/src/components/AttachmentPanel/AttachmentPanel.module.scss
+++ b/frontend/src/components/AttachmentPanel/AttachmentPanel.module.scss
@@ -168,6 +168,16 @@
   margin-top: var(--s3);
 }
 
+/* 사진을 그대로 감싸기만 합니다. 눌러서 전체보기를 여는 자리라 버튼 모양은 두지 않습니다. */
+.previewZoom {
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: zoom-in;
+}
+
 .previewImage {
   display: block;
   max-width: 100%;

--- a/frontend/src/components/AttachmentPanel/AttachmentPanel.tsx
+++ b/frontend/src/components/AttachmentPanel/AttachmentPanel.tsx
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom'
 import { errorMessage } from '@/api/errorMessage'
 import { downloadReportAttachment } from '@/api/reportAttachments'
 import { buttonClass } from '@/components/Button'
+import ImageLightbox from '@/components/ImageLightbox'
 import Modal from '@/components/Modal'
 import { TrashIcon, UploadIcon } from '@/components/icons'
 import type { AttachmentKind, ReportAttachment } from '@/types'
@@ -56,6 +57,7 @@ export default function AttachmentPanel({
     item: ReportAttachment
     url: string
   } | null>(null)
+  const [zoom, setZoom] = useState(false)
   const [loadingFile, setLoadingFile] = useState<{ reportId: string; id: string } | null>(null)
   const [fileError, setFileError] = useState<{ reportId: string; message: string } | null>(null)
   const requestRef = useRef<AbortController | null>(null)
@@ -76,6 +78,8 @@ export default function AttachmentPanel({
       URL.revokeObjectURL(preview.url)
       objectUrls.current.delete(preview.url)
     }
+    // 전체보기가 이 주소를 그대로 씁니다. 주소를 거두기 전에 함께 내립니다.
+    setZoom(false)
     setPreview(null)
   }
 
@@ -298,7 +302,19 @@ export default function AttachmentPanel({
             >
               <div tabIndex={0} role="group" aria-label="원본 파일 미리보기">
                 {preview.item.kind === 'image' ? (
-                  <img className={styles.previewImage} src={preview.url} alt={preview.item.name} />
+                  /* 모달 폭에 맞춰 줄여 놓은 사진입니다. 글자가 작으면 눌러서 전체보기로 엽니다. */
+                  <button
+                    type="button"
+                    className={styles.previewZoom}
+                    aria-label={`${preview.item.name} 크게 보기`}
+                    onClick={() => setZoom(true)}
+                  >
+                    <img
+                      className={styles.previewImage}
+                      src={preview.url}
+                      alt={preview.item.name}
+                    />
+                  </button>
                 ) : preview.item.kind === 'audio' ? (
                   <audio className={styles.previewAudio} src={preview.url} controls />
                 ) : (
@@ -313,6 +329,16 @@ export default function AttachmentPanel({
           </div>,
           document.body,
         )}
+      {/* previewHost 바깥에 둡니다. 안에 두면 그 div 의 Escape 캡처 핸들러가 먼저 잡아
+          전체보기만 닫으려 한 것이 미리보기 모달까지 닫습니다. */}
+      {preview && preview.reportId === reportId && zoom && (
+        <ImageLightbox
+          src={preview.url}
+          alt={preview.item.name}
+          caption={`${preview.item.name} · ${sizeLabel(preview.item.byteSize)}`}
+          onClose={() => setZoom(false)}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/components/Drawer/Drawer.tsx
+++ b/frontend/src/components/Drawer/Drawer.tsx
@@ -7,6 +7,7 @@
 import { useEffect, useId, useRef, type ReactNode } from 'react'
 
 import { CloseIcon } from '@/components/icons'
+import { pushOverlay } from '@/shared/overlayStack'
 import { lockScroll } from '@/shared/scrollLock'
 
 import styles from './Drawer.module.scss'
@@ -45,10 +46,23 @@ export default function Drawer({
   const panelRef = useRef<HTMLElement>(null)
   const bodyRef = useRef<HTMLDivElement>(null)
   const titleId = useId()
+  // Modal 과 같습니다. 드로어 위에 이미지 전체보기가 열리면 Escape 한 번에 둘 다
+  // 닫히지 않도록, 겹친 것 중 맨 위일 때만 답합니다.
+  const overlayRef = useRef<{ isTop: () => boolean; release: () => void } | null>(null)
+
+  // 닫기 함수는 호출부에서 매 렌더 새로 만들어지는 일이 흔합니다. 그것을 효과의 의존성으로
+  // 두면 글자 하나 칠 때마다 효과가 풀렸다 다시 걸려 스크롤 잠금과 포커스가 흔들립니다.
+  const onCloseRef = useRef(onClose)
+  useEffect(() => {
+    onCloseRef.current = onClose
+  })
 
   useEffect(() => {
+    const overlay = pushOverlay()
+    overlayRef.current = overlay
+
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') onClose()
+      if (event.key === 'Escape' && overlay.isTop()) onCloseRef.current()
     }
     document.addEventListener('keydown', onKeyDown)
 
@@ -56,11 +70,13 @@ export default function Drawer({
     const unlockScroll = lockScroll()
 
     return () => {
+      overlay.release()
+      overlayRef.current = null
       document.removeEventListener('keydown', onKeyDown)
       unlockScroll()
       previouslyFocused?.focus()
     }
-  }, [onClose])
+  }, [])
 
   // 본문에 누를 것이 없는 드로어(값만 늘어놓은 상세)도 있습니다.
   // 그럴 때는 패널 자체를 잡아 두어야 포커스가 드로어 밖에 남지 않습니다.
@@ -77,7 +93,12 @@ export default function Drawer({
   }, [resetKey])
 
   return (
-    <div className={styles.scrim} onPointerDown={onClose}>
+    <div
+      className={styles.scrim}
+      onPointerDown={() => {
+        if (overlayRef.current?.isTop() === true) onClose()
+      }}
+    >
       <aside
         ref={panelRef}
         className={`${styles.panel} ${wide ? styles.wide : ''}`}

--- a/frontend/src/components/ImageLightbox/ImageLightbox.module.scss
+++ b/frontend/src/components/ImageLightbox/ImageLightbox.module.scss
@@ -1,0 +1,95 @@
+.scrim {
+  position: fixed;
+  inset: 0;
+  // Modal 의 스크림이 70 입니다. 전체보기는 그 위에서 열립니다.
+  z-index: 80;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--s8) var(--s6) var(--s6);
+  // 사진에 눈이 가도록 모달 스크림보다 짙게 깔고 흐림은 걷어 냅니다.
+  background: rgba(12, 13, 18, 0.86);
+  animation: fade var(--t-fast) var(--ease-out);
+
+  @include sm {
+    padding: calc(var(--s8) + env(safe-area-inset-top)) var(--s3)
+      calc(var(--s4) + env(safe-area-inset-bottom));
+  }
+}
+
+.frame {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--s3);
+  // 사진과 아래 한 줄이 함께 화면 안에 들어와야 합니다.
+  max-width: 100%;
+  max-height: 100%;
+  min-height: 0;
+  animation: rise var(--t) var(--ease-spring);
+}
+
+/*
+ * 원본 비율은 그대로 두고 화면보다 크면 줄입니다. width/height 를 auto 로 두면
+ * 원본보다 크게 늘어나지 않아 작은 명함 사진이 뿌옇게 번지지 않습니다.
+ */
+.image {
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+  min-height: 0;
+  object-fit: contain;
+  border-radius: var(--r-sm);
+  box-shadow: var(--sh-pop);
+}
+
+.notice {
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 13px;
+  text-align: center;
+}
+
+.caption {
+  flex: none;
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 13px;
+  text-align: center;
+}
+
+.close {
+  position: absolute;
+  top: var(--s4);
+  right: var(--s4);
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: rgba(255, 255, 255, 0.14);
+  color: #fff;
+  cursor: pointer;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.24);
+  }
+
+  @include sm {
+    top: max(var(--s3), env(safe-area-inset-top));
+    right: var(--s3);
+  }
+}
+
+@keyframes fade {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes rise {
+  from {
+    opacity: 0;
+    transform: scale(0.97);
+  }
+}

--- a/frontend/src/components/ImageLightbox/ImageLightbox.tsx
+++ b/frontend/src/components/ImageLightbox/ImageLightbox.tsx
@@ -1,0 +1,109 @@
+// 화면에 보이는 콘텐츠 이미지를 그 자리에서 크게 보는 오버레이입니다.
+// 명함처럼 작게 눌러 놓은 사진을 새 탭으로 나가지 않고 앱 안에서 확인하려고 만들었습니다.
+//
+// 동작 규칙은 Modal / Drawer 와 맞춥니다. Escape 로 닫고 배경은 스크롤을 멈추며,
+// 닫으면 눌렀던 자리로 포커스가 돌아갑니다. 다만 이 오버레이는 늘 그 둘 "위"에 뜨므로
+// overlayStack 으로 자기가 꼭대기일 때만 답합니다.
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+
+import { CloseIcon } from '@/components/icons'
+import { pushOverlay } from '@/shared/overlayStack'
+import { lockScroll } from '@/shared/scrollLock'
+
+import styles from './ImageLightbox.module.scss'
+
+interface Props {
+  src: string
+  alt: string
+  /** 이미지 아래 한 줄. 파일명·용량 같은 것. */
+  caption?: ReactNode
+  onClose: () => void
+}
+
+export default function ImageLightbox({ src, alt, caption, onClose }: Props) {
+  const closeRef = useRef<HTMLButtonElement>(null)
+  const overlayRef = useRef<{ isTop: () => boolean; release: () => void } | null>(null)
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading')
+
+  // Modal 과 같은 이유로 최신 닫기 함수는 ref 로만 듭니다. 호출부가 매 렌더 새로 만드는
+  // 함수를 의존성에 두면 효과가 풀렸다 다시 걸리며 스크롤 잠금과 포커스가 흔들립니다.
+  const onCloseRef = useRef(onClose)
+  useEffect(() => {
+    onCloseRef.current = onClose
+  })
+
+  useEffect(() => {
+    const overlay = pushOverlay()
+    overlayRef.current = overlay
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && overlay.isTop()) onCloseRef.current()
+    }
+    document.addEventListener('keydown', onKeyDown)
+
+    const previouslyFocused = document.activeElement as HTMLElement | null
+    const unlockScroll = lockScroll()
+    closeRef.current?.focus()
+
+    return () => {
+      overlay.release()
+      overlayRef.current = null
+      document.removeEventListener('keydown', onKeyDown)
+      unlockScroll()
+      previouslyFocused?.focus()
+    }
+  }, [])
+
+  // 주소가 바뀌면 다시 여는 것과 같습니다. 앞 이미지의 성패를 물려받지 않게 되돌립니다.
+  useEffect(() => {
+    setStatus('loading')
+  }, [src])
+
+  return createPortal(
+    <div
+      className={styles.scrim}
+      role="dialog"
+      aria-modal="true"
+      aria-label={alt}
+      // portal 로 꺼내도 React 이벤트는 컴포넌트 트리를 타므로, 여기서 멈추지 않으면
+      // 이 오버레이를 연 드로어·모달의 스크림까지 눌린 것으로 칩니다.
+      onPointerDown={(event) => {
+        event.stopPropagation()
+        if (overlayRef.current?.isTop() === true) onClose()
+      }}
+    >
+      <button
+        ref={closeRef}
+        type="button"
+        className={styles.close}
+        aria-label="닫기"
+        onPointerDown={(event) => event.stopPropagation()}
+        onClick={onClose}
+      >
+        <CloseIcon />
+      </button>
+
+      <figure className={styles.frame} onPointerDown={(event) => event.stopPropagation()}>
+        {status === 'error' ? (
+          <p className={styles.notice} role="alert">
+            원본을 미리 볼 수 없습니다.
+          </p>
+        ) : (
+          <>
+            {status === 'loading' && <p className={styles.notice}>원본을 여는 중…</p>}
+            <img
+              className={styles.image}
+              src={src}
+              alt={alt}
+              onLoad={() => setStatus('ready')}
+              onError={() => setStatus('error')}
+            />
+          </>
+        )}
+        {caption && <figcaption className={styles.caption}>{caption}</figcaption>}
+      </figure>
+    </div>,
+    document.body,
+  )
+}

--- a/frontend/src/components/ImageLightbox/clickedImage.ts
+++ b/frontend/src/components/ImageLightbox/clickedImage.ts
@@ -1,0 +1,16 @@
+import type { MouseEvent } from 'react'
+
+/**
+ * dangerouslySetInnerHTML 로 그린 본문에서 눌린 이미지를 찾습니다. 그 안의 <img> 에는
+ * 핸들러를 하나씩 달 수 없어, 감싸는 요소가 클릭을 받아 이 함수에 넘깁니다.
+ * 이미지가 아니면 null 입니다.
+ */
+export function clickedImage(event: MouseEvent): { src: string; alt: string } | null {
+  const target = event.target as HTMLElement
+  if (target.tagName !== 'IMG') return null
+
+  const image = target as HTMLImageElement
+  // 본문 편집기는 사진을 링크로 감싸기도 합니다. 새 탭으로 나가지 않고 여기서 봅니다.
+  event.preventDefault()
+  return { src: image.currentSrc || image.src, alt: image.alt || '본문 이미지' }
+}

--- a/frontend/src/components/ImageLightbox/index.ts
+++ b/frontend/src/components/ImageLightbox/index.ts
@@ -1,0 +1,2 @@
+export { default } from './ImageLightbox'
+export { clickedImage } from './clickedImage'

--- a/frontend/src/components/Modal/Modal.tsx
+++ b/frontend/src/components/Modal/Modal.tsx
@@ -1,16 +1,10 @@
 import { useEffect, useId, useRef, type ReactNode } from 'react'
 
 import { CloseIcon } from '@/components/icons'
+import { pushOverlay } from '@/shared/overlayStack'
 import { lockScroll } from '@/shared/scrollLock'
 
 import styles from './Modal.module.scss'
-
-/**
- * 열려 있는 모달들. 일정 모달 위에 고객 등록 모달을 얹는 것처럼 두 장이 겹치면,
- * Escape 한 번에 둘 다 닫히고 안쪽 스크림을 눌러도 바깥 핸들러까지 올라갑니다
- * (portal 로 꺼내도 React 이벤트는 컴포넌트 트리를 탑니다). 맨 위의 것만 답합니다.
- */
-const stack: symbol[] = []
 
 const SIZE_CLASS: Record<'md' | 'lg', string> = {
   md: '',
@@ -46,8 +40,9 @@ export default function Modal({
 }: ModalProps) {
   const bodyRef = useRef<HTMLDivElement>(null)
   const titleId = useId()
-  const token = useRef(Symbol('modal')).current
-  const isTop = () => stack[stack.length - 1] === token
+  // 겹쳐 있는 오버레이 중 맨 위인지. 아니면 Escape 와 스크림 클릭에 답하지 않습니다.
+  const overlayRef = useRef<{ isTop: () => boolean; release: () => void } | null>(null)
+  const isTop = () => overlayRef.current?.isTop() === true
 
   // 닫기 함수는 호출부에서 매 렌더 새로 만들어지는 일이 흔합니다. 그것을 아래
   // 효과의 의존성으로 두면 글자 하나 칠 때마다 효과가 풀렸다 다시 걸리고,
@@ -60,10 +55,11 @@ export default function Modal({
 
   // AppShell 의 드로어와 같은 처리입니다. Escape 로 닫고 뒤 배경은 스크롤을 멈춥니다.
   useEffect(() => {
-    stack.push(token)
+    const overlay = pushOverlay()
+    overlayRef.current = overlay
 
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape' && stack[stack.length - 1] === token) onCloseRef.current()
+      if (event.key === 'Escape' && overlay.isTop()) onCloseRef.current()
     }
     document.addEventListener('keydown', onKeyDown)
 
@@ -71,12 +67,13 @@ export default function Modal({
     const unlockScroll = lockScroll()
 
     return () => {
-      stack.splice(stack.indexOf(token), 1)
+      overlay.release()
+      overlayRef.current = null
       document.removeEventListener('keydown', onKeyDown)
       unlockScroll()
       previouslyFocused?.focus()
     }
-  }, [token])
+  }, [])
 
   // 열리면 첫 입력으로 바로 타이핑할 수 있게 포커스를 옮깁니다.
   useEffect(() => {

--- a/frontend/src/pages/Customers/components/CustomerDrawer/CustomerDrawer.module.scss
+++ b/frontend/src/pages/Customers/components/CustomerDrawer/CustomerDrawer.module.scss
@@ -139,6 +139,8 @@
     width: 100%;
     height: 100%;
     object-fit: contain;
+    // 눌러서 여는 것이 새 탭이 아니라 전체보기임을 알립니다.
+    cursor: zoom-in;
   }
 }
 

--- a/frontend/src/pages/Customers/components/CustomerDrawer/CustomerDrawer.tsx
+++ b/frontend/src/pages/Customers/components/CustomerDrawer/CustomerDrawer.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactNode } from 'react'
 
 import Drawer from '@/components/Drawer'
 import { DocumentsIcon, EditIcon, MoreIcon, TrashIcon } from '@/components/icons'
+import ImageLightbox from '@/components/ImageLightbox'
 import Popover from '@/components/Popover'
 import useCompanyDeals from '@/hooks/useCompanyDeals'
 import useCustomerAttachments from '@/pages/Customers/useCustomerAttachments'
@@ -45,10 +46,14 @@ const KIND_LABEL: Record<CustomerAttachment['kind'], string> = {
 
 /**
  * 등록에 쓴 원본 한 건. 사진은 어느 명함인지 알아볼 만큼만 줄여 놓고, 크게 볼 일은
- * 눌러서 원본을 엽니다. PDF 는 미리 보여 줄 수 없어 같은 크기의 자리에 받는 길만 둡니다.
+ * 눌러서 전체보기로 엽니다. PDF 는 미리 보여 줄 수 없어 같은 크기의 자리에 받는 길만 둡니다.
  * 둘을 같은 타일로 맞춰 두면 첨부가 늘어도 세로로 길어지지 않고 옆으로 늡니다.
+ *
+ * 사진이어도 href 는 그대로 둡니다. 가운데 클릭이나 주소 복사로 원본을 따로 여는 길이
+ * 남고, 자바스크립트가 늦게 붙어도 링크로는 열립니다.
  */
 function Attachment({ attachment }: { attachment: CustomerAttachment }) {
+  const [zoom, setZoom] = useState(false)
   const label = KIND_LABEL[attachment.kind]
   const image = attachment.media_type?.startsWith('image/') === true
 
@@ -59,7 +64,15 @@ function Attachment({ attachment }: { attachment: CustomerAttachment }) {
         href={attachment.url}
         target="_blank"
         rel="noopener noreferrer"
-        title={image ? `${label} 원본 열기` : `${label} 원본 받기`}
+        title={image ? `${label} 크게 보기` : `${label} 원본 받기`}
+        onClick={
+          image
+            ? (event) => {
+                event.preventDefault()
+                setZoom(true)
+              }
+            : undefined
+        }
       >
         {image ? (
           <img src={attachment.url} alt={`${label} 원본`} />
@@ -73,6 +86,14 @@ function Attachment({ attachment }: { attachment: CustomerAttachment }) {
       <figcaption className={styles.shotNote}>
         {label} · {sizeLabel(attachment.byte_size)}
       </figcaption>
+      {zoom && (
+        <ImageLightbox
+          src={attachment.url}
+          alt={`${label} 원본`}
+          caption={`${label} · ${sizeLabel(attachment.byte_size)}`}
+          onClose={() => setZoom(false)}
+        />
+      )}
     </figure>
   )
 }

--- a/frontend/src/pages/Dashboard/components/NoticeDrawer/NoticeDrawer.module.scss
+++ b/frontend/src/pages/Dashboard/components/NoticeDrawer/NoticeDrawer.module.scss
@@ -113,6 +113,8 @@
     height: auto;
     margin: var(--s3) 0;
     border-radius: var(--r-sm);
+    // 눌러서 전체보기로 엽니다. 본문 폭에 맞춰 줄여 놓아 작은 글자가 안 보입니다.
+    cursor: zoom-in;
   }
 
   > :global(*:last-child) {

--- a/frontend/src/pages/Dashboard/components/NoticeDrawer/NoticeDrawer.tsx
+++ b/frontend/src/pages/Dashboard/components/NoticeDrawer/NoticeDrawer.tsx
@@ -12,6 +12,7 @@ import { useState } from 'react'
 
 import Button from '@/components/Button'
 import Drawer from '@/components/Drawer'
+import ImageLightbox, { clickedImage } from '@/components/ImageLightbox'
 import Skeleton from '@/components/Skeleton'
 import StatusBadge from '@/components/StatusBadge'
 import { errorMessage } from '@/api/errorMessage'
@@ -52,6 +53,8 @@ export default function NoticeDrawer({ label, notice, onStatusChange, onClose }:
   const [saved, setSaved] = useState<NoticeStatusResponse | null>(null)
   const [missing, setMissing] = useState(false)
   const [busy, setBusy] = useState(false)
+  // 본문 안의 사진을 눌렀을 때 크게 볼 것. 누르지 않았으면 null 입니다.
+  const [zoom, setZoom] = useState<{ src: string; alt: string } | null>(null)
 
   const status = saved ?? notice.myStatus ?? null
   const badge = status === null ? null : statusLabel(status.status_code)
@@ -172,9 +175,18 @@ export default function NoticeDrawer({ label, notice, onStatusChange, onClose }:
              허용목록을 넓힐 일이 생기면 반드시 서버 쪽을 먼저 봅니다.
              사진도 본문 안에 있습니다. 주소는 서버가 응답할 때마다 새로 발급합니다. */
           // oxlint-disable-next-line react/no-danger
-          <div className={styles.detail} dangerouslySetInnerHTML={{ __html: body.body }} />
+          <div
+            className={styles.detail}
+            dangerouslySetInnerHTML={{ __html: body.body }}
+            onClick={(event) => {
+              const image = clickedImage(event)
+              if (image) setZoom(image)
+            }}
+          />
         )}
       </Drawer>
+
+      {zoom && <ImageLightbox {...zoom} onClose={() => setZoom(null)} />}
 
       {missing && (
         <MissReasonModal

--- a/frontend/src/pages/Notices/components/NoticeDrawer/NoticeDrawer.module.scss
+++ b/frontend/src/pages/Notices/components/NoticeDrawer/NoticeDrawer.module.scss
@@ -179,6 +179,8 @@
     height: auto;
     margin: var(--s3) 0;
     border-radius: var(--r-sm);
+    // 눌러서 전체보기로 엽니다. 본문 폭에 맞춰 줄여 놓아 작은 글자가 안 보입니다.
+    cursor: zoom-in;
   }
 
   > :global(*:last-child) {

--- a/frontend/src/pages/Notices/components/NoticeDrawer/NoticeDrawer.tsx
+++ b/frontend/src/pages/Notices/components/NoticeDrawer/NoticeDrawer.tsx
@@ -14,6 +14,7 @@ import { useEffect, useState } from 'react'
 import { errorMessage } from '@/api/errorMessage'
 import Button from '@/components/Button'
 import Drawer from '@/components/Drawer'
+import ImageLightbox, { clickedImage } from '@/components/ImageLightbox'
 import { EditIcon, EyeIcon, EyeOffIcon, MoreIcon, TrashIcon } from '@/components/icons'
 import Popover from '@/components/Popover'
 import Skeleton from '@/components/Skeleton'
@@ -62,6 +63,8 @@ export default function NoticeDrawer({
   const [error, setError] = useState<string | null>(null)
   const [menuOpen, setMenuOpen] = useState(false)
   const [reloadKey, setReloadKey] = useState(0)
+  // 본문 안의 사진을 눌렀을 때 크게 볼 것. 누르지 않았으면 null 입니다.
+  const [zoom, setZoom] = useState<{ src: string; alt: string } | null>(null)
 
   const isDirective = row.type === 'DIRECTIVE'
   const state = stateOf(row)
@@ -85,170 +88,181 @@ export default function NoticeDrawer({
   }, [row.id, loadNotice, reloadKey])
 
   return (
-    <Drawer
-      title={row.title}
-      sub={
-        <span className={styles.when}>
-          {row.author_display_name} · {periodLabel(row)}
-        </span>
-      }
-      meta={
-        <>
-          <StatusBadge label={state.label} tone={state.tone} />
-          {row.tag !== null && <i className={styles.badge}>{row.tag}</i>}
-          {isDirective && <StatusBadge label={rollup.label} tone={rollup.tone} />}
-        </>
-      }
-      actions={
-        <Popover
-          open={menuOpen}
-          onClose={() => setMenuOpen(false)}
-          align="end"
-          compact
-          label="공지 메뉴"
-          trigger={
-            <button
-              type="button"
-              className={styles.menuBtn}
-              aria-label="공지 메뉴"
-              aria-expanded={menuOpen}
-              disabled={busy}
-              onClick={() => setMenuOpen((value) => !value)}
-            >
-              <MoreIcon width={18} height={18} />
-            </button>
-          }
-        >
-          <div className={styles.menu}>
-            <button
-              type="button"
-              onClick={() => {
-                setMenuOpen(false)
-                onEdit()
-              }}
-            >
-              <EditIcon width={15} height={15} />
-              수정
-            </button>
-            <button
-              type="button"
-              aria-pressed={row.is_hidden}
-              onClick={() => {
-                setMenuOpen(false)
-                onToggleHidden()
-              }}
-            >
-              {row.is_hidden ? (
-                <EyeIcon width={15} height={15} />
-              ) : (
-                <EyeOffIcon width={15} height={15} />
-              )}
-              {row.is_hidden ? '보이기' : '숨기기'}
-            </button>
-            <button
-              type="button"
-              className={styles.danger}
-              onClick={() => {
-                setMenuOpen(false)
-                onDelete()
-              }}
-            >
-              <TrashIcon width={15} height={15} />
-              삭제
-            </button>
-          </div>
-        </Popover>
-      }
-      onClose={onClose}
-    >
-      {/* 머리 정보. 목록에서 이미 들고 온 값이라 기다리지 않고 바로 섭니다. */}
-      <dl className={styles.facts}>
-        <div>
-          <dt>수신자</dt>
-          <dd>{targetsLabel(row)}</dd>
-        </div>
-        <div>
-          <dt>노출 순서</dt>
-          <dd className="tnum">{row.sort_order}</dd>
-        </div>
-        {isDirective && (
+    <>
+      <Drawer
+        title={row.title}
+        sub={
+          <span className={styles.when}>
+            {row.author_display_name} · {periodLabel(row)}
+          </span>
+        }
+        meta={
+          <>
+            <StatusBadge label={state.label} tone={state.tone} />
+            {row.tag !== null && <i className={styles.badge}>{row.tag}</i>}
+            {isDirective && <StatusBadge label={rollup.label} tone={rollup.tone} />}
+          </>
+        }
+        actions={
+          <Popover
+            open={menuOpen}
+            onClose={() => setMenuOpen(false)}
+            align="end"
+            compact
+            label="공지 메뉴"
+            trigger={
+              <button
+                type="button"
+                className={styles.menuBtn}
+                aria-label="공지 메뉴"
+                aria-expanded={menuOpen}
+                disabled={busy}
+                onClick={() => setMenuOpen((value) => !value)}
+              >
+                <MoreIcon width={18} height={18} />
+              </button>
+            }
+          >
+            <div className={styles.menu}>
+              <button
+                type="button"
+                onClick={() => {
+                  setMenuOpen(false)
+                  onEdit()
+                }}
+              >
+                <EditIcon width={15} height={15} />
+                수정
+              </button>
+              <button
+                type="button"
+                aria-pressed={row.is_hidden}
+                onClick={() => {
+                  setMenuOpen(false)
+                  onToggleHidden()
+                }}
+              >
+                {row.is_hidden ? (
+                  <EyeIcon width={15} height={15} />
+                ) : (
+                  <EyeOffIcon width={15} height={15} />
+                )}
+                {row.is_hidden ? '보이기' : '숨기기'}
+              </button>
+              <button
+                type="button"
+                className={styles.danger}
+                onClick={() => {
+                  setMenuOpen(false)
+                  onDelete()
+                }}
+              >
+                <TrashIcon width={15} height={15} />
+                삭제
+              </button>
+            </div>
+          </Popover>
+        }
+        onClose={onClose}
+      >
+        {/* 머리 정보. 목록에서 이미 들고 온 값이라 기다리지 않고 바로 섭니다. */}
+        <dl className={styles.facts}>
           <div>
-            <dt>마감</dt>
-            <dd className="tnum">{row.due_text ?? stamp(row.due_at)}</dd>
+            <dt>수신자</dt>
+            <dd>{targetsLabel(row)}</dd>
           </div>
-        )}
-        <div>
-          <dt>최근 수정</dt>
-          <dd className="tnum">{stamp(row.updated_at)}</dd>
-        </div>
-      </dl>
+          <div>
+            <dt>노출 순서</dt>
+            <dd className="tnum">{row.sort_order}</dd>
+          </div>
+          {isDirective && (
+            <div>
+              <dt>마감</dt>
+              <dd className="tnum">{row.due_text ?? stamp(row.due_at)}</dd>
+            </div>
+          )}
+          <div>
+            <dt>최근 수정</dt>
+            <dd className="tnum">{stamp(row.updated_at)}</dd>
+          </div>
+        </dl>
 
-      <section className={styles.section}>
-        <h3 className={styles.heading}>본문</h3>
+        <section className={styles.section}>
+          <h3 className={styles.heading}>본문</h3>
 
-        {error !== null ? (
-          <p className={styles.detail} role="alert">
-            {error}{' '}
-            <Button variant="outline" size="sm" onClick={() => setReloadKey((key) => key + 1)}>
-              다시 시도
-            </Button>
-          </p>
-        ) : body === null ? (
-          /* 본문은 글줄입니다. 한 덩어리로 덮으면 무엇이 오는지 읽히지 않아
+          {error !== null ? (
+            <p className={styles.detail} role="alert">
+              {error}{' '}
+              <Button variant="outline" size="sm" onClick={() => setReloadKey((key) => key + 1)}>
+                다시 시도
+              </Button>
+            </p>
+          ) : body === null ? (
+            /* 본문은 글줄입니다. 한 덩어리로 덮으면 무엇이 오는지 읽히지 않아
              실제 문단과 같은 줄 간격으로 줄을 세웁니다. 문단 끝줄은 짧게 둡니다. */
-          <div className={styles.pending} role="status">
-            <span className="sr-only">본문을 불러오는 중입니다.</span>
-            {BODY_LINES.map((paragraph, at) => (
-              <p key={at} className={styles.pendingParagraph}>
-                {paragraph.map((width, line) => (
-                  <Skeleton key={line} width={width} height={11} />
-                ))}
-              </p>
-            ))}
-          </div>
-        ) : (
-          /* 본문은 팀장이 편집기로 쓴 HTML 입니다. 서버(app/services/html_sanitize.py)가
+            <div className={styles.pending} role="status">
+              <span className="sr-only">본문을 불러오는 중입니다.</span>
+              {BODY_LINES.map((paragraph, at) => (
+                <p key={at} className={styles.pendingParagraph}>
+                  {paragraph.map((width, line) => (
+                    <Skeleton key={line} width={width} height={11} />
+                  ))}
+                </p>
+              ))}
+            </div>
+          ) : (
+            /* 본문은 팀장이 편집기로 쓴 HTML 입니다. 서버(app/services/html_sanitize.py)가
              저장할 때 허용 태그만 남기므로 여기서 다시 자르지 않고 그대로 그립니다.
              허용목록을 넓힐 일이 생기면 반드시 서버 쪽을 먼저 봅니다. */
-          // oxlint-disable-next-line react/no-danger
-          <div className={styles.detail} dangerouslySetInnerHTML={{ __html: body }} />
-        )}
-      </section>
-
-      {/* 지시사항에만 섭니다. 공지는 수신자가 팀 전체라 이행이라는 것이 없습니다. */}
-      {isDirective && (
-        <section className={styles.section}>
-          <h3 className={styles.heading}>
-            이행 현황
-            <span className={styles.summary}>{progressLabel(row.targets)}</span>
-          </h3>
-
-          {row.targets.length === 0 ? (
-            <p className={styles.empty}>수신자가 없습니다.</p>
-          ) : (
-            <ul className={styles.targets}>
-              {row.targets.map((target) => {
-                const badge = statusLabel(target.status_code)
-                return (
-                  <li key={target.id}>
-                    <div className={styles.targetHead}>
-                      <strong className={styles.name}>{target.display_name}</strong>
-                      <StatusBadge label={badge.label} tone={badge.tone} />
-                      <span className={`${styles.changed} tnum`}>
-                        {stamp(target.status_changed_at)}
-                      </span>
-                    </div>
-                    {/* 미이행일 때만 옵니다. 이행으로 돌리면 서버가 지웁니다. */}
-                    {target.status_reason !== null && target.status_reason !== '' && (
-                      <p className={styles.reason}>{target.status_reason}</p>
-                    )}
-                  </li>
-                )
-              })}
-            </ul>
+            // oxlint-disable-next-line react/no-danger
+            <div
+              className={styles.detail}
+              dangerouslySetInnerHTML={{ __html: body }}
+              onClick={(event) => {
+                const image = clickedImage(event)
+                if (image) setZoom(image)
+              }}
+            />
           )}
         </section>
-      )}
-    </Drawer>
+
+        {/* 지시사항에만 섭니다. 공지는 수신자가 팀 전체라 이행이라는 것이 없습니다. */}
+        {isDirective && (
+          <section className={styles.section}>
+            <h3 className={styles.heading}>
+              이행 현황
+              <span className={styles.summary}>{progressLabel(row.targets)}</span>
+            </h3>
+
+            {row.targets.length === 0 ? (
+              <p className={styles.empty}>수신자가 없습니다.</p>
+            ) : (
+              <ul className={styles.targets}>
+                {row.targets.map((target) => {
+                  const badge = statusLabel(target.status_code)
+                  return (
+                    <li key={target.id}>
+                      <div className={styles.targetHead}>
+                        <strong className={styles.name}>{target.display_name}</strong>
+                        <StatusBadge label={badge.label} tone={badge.tone} />
+                        <span className={`${styles.changed} tnum`}>
+                          {stamp(target.status_changed_at)}
+                        </span>
+                      </div>
+                      {/* 미이행일 때만 옵니다. 이행으로 돌리면 서버가 지웁니다. */}
+                      {target.status_reason !== null && target.status_reason !== '' && (
+                        <p className={styles.reason}>{target.status_reason}</p>
+                      )}
+                    </li>
+                  )
+                })}
+              </ul>
+            )}
+          </section>
+        )}
+      </Drawer>
+
+      {zoom && <ImageLightbox {...zoom} onClose={() => setZoom(null)} />}
+    </>
   )
 }

--- a/frontend/src/pages/Products/components/ProductDrawer/ProductDrawer.module.scss
+++ b/frontend/src/pages/Products/components/ProductDrawer/ProductDrawer.module.scss
@@ -84,6 +84,16 @@
 /* ---- 사진 ---- */
 
 // 목록의 썸네일과 달리 자르지 않습니다. 사양을 보려고 여는 자리라 원래 비율이 중요합니다.
+/* 사진을 그대로 감싸기만 합니다. 테두리와 여백은 사진 쪽이 그대로 갖습니다. */
+.photoZoom {
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: zoom-in;
+}
+
 .photo {
   display: block;
   width: 100%;

--- a/frontend/src/pages/Products/components/ProductDrawer/ProductDrawer.tsx
+++ b/frontend/src/pages/Products/components/ProductDrawer/ProductDrawer.tsx
@@ -8,6 +8,7 @@
 import { useState } from 'react'
 
 import Drawer from '@/components/Drawer'
+import ImageLightbox from '@/components/ImageLightbox'
 import { EditIcon, MoreIcon, ProductIcon, TrashIcon } from '@/components/icons'
 import Popover from '@/components/Popover'
 import type { ProductResponse } from '@/types'
@@ -29,6 +30,7 @@ interface Props {
 
 export default function ProductDrawer({ product, busy, onEdit, onDelete, onClose }: Props) {
   const [menuOpen, setMenuOpen] = useState(false)
+  const [zoom, setZoom] = useState(false)
   const url = useProductImage(product)
 
   return (
@@ -91,7 +93,25 @@ export default function ProductDrawer({ product, busy, onEdit, onDelete, onClose
           <span>{product.has_image ? '사진을 불러오는 중입니다.' : '등록된 사진이 없습니다.'}</span>
         </p>
       ) : (
-        <img className={styles.photo} src={url} alt={`${product.name} 사진`} />
+        <>
+          {/* 눌러서 전체보기로 엽니다. 드로어 폭에 맞춰 줄여 놓아 라벨의 작은 글자가 안 보입니다. */}
+          <button
+            type="button"
+            className={styles.photoZoom}
+            aria-label={`${product.name} 사진 크게 보기`}
+            onClick={() => setZoom(true)}
+          >
+            <img className={styles.photo} src={url} alt={`${product.name} 사진`} />
+          </button>
+          {zoom && (
+            <ImageLightbox
+              src={url}
+              alt={`${product.name} 사진`}
+              caption={product.name}
+              onClose={() => setZoom(false)}
+            />
+          )}
+        </>
       )}
 
       <dl className={styles.facts}>

--- a/frontend/src/shared/overlayStack.ts
+++ b/frontend/src/shared/overlayStack.ts
@@ -1,0 +1,23 @@
+/**
+ * 겹쳐 있는 오버레이들 중 어느 것이 맨 위인지 함께 봅니다.
+ *
+ * 일정 모달 위에 고객 등록 모달을 얹거나 드로어 위에 이미지 전체보기를 띄우는 것처럼 두
+ * 장이 겹치면, Escape 한 번에 둘 다 닫히고 안쪽 스크림을 눌러도 바깥 핸들러까지 올라갑니다
+ * (portal 로 꺼내도 React 이벤트는 컴포넌트 트리를 탑니다). 맨 위의 것만 답하도록,
+ * 열려 있는 것을 쌓아 두고 각자 자기가 꼭대기인지 물어봅니다.
+ */
+const stack: symbol[] = []
+
+/** 얹고, 맨 위인지 묻는 함수와 내리는 함수를 돌려줍니다. 효과에서 열고 닫으면 됩니다. */
+export function pushOverlay(): { isTop: () => boolean; release: () => void } {
+  const token = Symbol('overlay')
+
+  stack.push(token)
+
+  return {
+    isTop: () => stack[stack.length - 1] === token,
+    release: () => {
+      stack.splice(stack.indexOf(token), 1)
+    },
+  }
+}


### PR DESCRIPTION
## 변경 요약

화면에 보이는 실제 콘텐츠 이미지를 누르면 그 자리에서 크게 볼 수 있게 합니다.
지금까지 명함은 새 탭으로 원본 파일을 열어야 했고, 첨부 미리보기는 모달 폭에
갇혀 있었으며, 상품 사진과 공지 본문 사진은 확대할 방법이 없었습니다.

- `components/ImageLightbox` 추가 — body 로 포털해 어두운 오버레이를 깔고 원본
  비율을 지키며 화면에 맞춰 줄입니다. 원본보다 크게 늘리지 않아 작은 사진이
  번지지 않습니다. 닫기는 우측 상단 버튼·배경 클릭·Escape 셋 다 받고, 배경
  스크롤은 `lockScroll` 로 멈춥니다. 못 불러오면 안내 문구를 세웁니다
- `shared/overlayStack.ts` 추가 — `Modal` 안에 갇혀 있던 "겹친 것 중 맨 위만
  답한다" 규칙을 꺼내 `Modal`·`Drawer`·라이트박스가 함께 씁니다. 가드가 없던
  `Drawer` 도 참여시켜, 위에 무엇이 떠 있으면 Escape 가 한 장씩 닫습니다
- 적용 — 고객 상세의 명함·사업자등록증 타일, 보고서 첨부 원본 미리보기, 상품
  상세 사진, 공지 상세 본문 이미지(대시보드·공지관리)
- 고객 상세 타일은 `href` 를 남겨 가운데 클릭·주소 복사로 원본을 여는 길을
  그대로 뒀습니다. PDF 첨부는 지금처럼 받는 링크입니다

명함 등록 모달의 미리보기는 누르면 파일을 다시 고르는 자리라 건드리지 않았고,
목록의 작은 썸네일과 이미 확대·회전을 갖춘 `SourceDocumentViewer` 도 뺐습니다.

## 검증

- `npm run lint` · `npm run typecheck` · `npm run format:check` · `npm run build` 통과
- `npm test` 104개 통과
- 브라우저(로컬 백엔드) 확인 — 고객 상세 명함과 상품 상세 사진에서:
  원본 1722×400 이 723×168 로 비율 유지 축소, 240×407 작은 이미지는 확대 없이
  그대로 / Escape 한 번은 라이트박스만, 두 번째에 드로어가 닫히고 스크롤 복원 /
  배경 클릭은 닫히고 이미지 클릭은 안 닫힘 / 닫은 뒤 눌렀던 자리로 포커스 복귀 /
  좁은 폭에서 화면 안에 맞고 가로 스크롤 없음, 닫기 버튼 40px
- 회귀 확인 — 명함 등록 모달은 그대로 파일 선택창이 열리고 Escape 로 닫힙니다
- **못 돌린 것** — 첨부 원본 미리보기와 공지 본문 이미지는 로컬 DB에 이미지
  데이터가 한 건도 없어 실제로 눌러 보지 못했습니다. 정적 검사까지만 통과한
  상태이며, 코드 경로는 확인을 마친 상품 상세와 같은 방식입니다

## 영향 및 주의 사항

- `Drawer` 의 Escape 동작이 바뀝니다. 드로어와 다른 오버레이가 겹쳐 있을 때
  지금은 Escape 한 번에 둘 다 닫히지만, 앞으로는 위쪽 한 장만 닫힙니다.
  `Modal` 이 이미 택하고 있던 규칙을 맞춘 것입니다
- 기존 화면의 레이아웃과 디자인은 그대로입니다. 전체보기가 되는 사진에
  `cursor: zoom-in` 이 붙는 것이 유일한 겉모습 변화입니다
- 수동 작업·마이그레이션 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 첨부파일, 상품 사진, 고객·공지·대시보드 이미지 클릭 시 새 탭 대신 전체보기로 확대할 수 있습니다.
  - 전체보기에서 이미지, 캡션 및 파일 정보를 확인하고 닫기 버튼이나 Escape 키로 종료할 수 있습니다.
  - 이미지 비율을 유지하며 화면 크기에 맞춰 표시하고, 모바일 환경에서도 편리하게 이용할 수 있습니다.
  - PDF 등 이미지가 아닌 첨부파일은 기존처럼 새 탭에서 열립니다.

- **버그 수정**
  - 여러 오버레이가 겹친 경우 최상단 화면만 Escape 키와 바깥 영역 클릭에 응답하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->