### PR TITLE
자료실에서 원본 파일을 함께 봅니다

### DIFF
--- a/frontend/src/components/Drawer/Drawer.module.scss
+++ b/frontend/src/components/Drawer/Drawer.module.scss
@@ -16,6 +16,8 @@
   background: var(--surface);
   box-shadow: var(--sh-3);
   animation: slide-in var(--t) var(--ease-spring);
+  // 옆 패널을 펴고 접을 때 폭이 이어집니다. 무엇이 늘어났는지 보여 주는 움직임입니다.
+  transition: width var(--t) var(--ease-spring);
 
   @include sm {
     // 좁은 화면에서는 Modal 과 같이 바텀시트가 됩니다.
@@ -24,12 +26,65 @@
     max-height: 88vh;
     border-radius: var(--r-xl) var(--r-xl) 0 0;
     animation-name: slide-up;
+    transition: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
   }
 }
 
 // layout_v3 의 .is-wide. 본문을 2열로 나눠 담는 드로어입니다.
 .wide {
   width: min(760px, 100vw);
+}
+
+/*
+ * 머리말·본문·바닥을 묶는 칸. 옆 패널이 없으면 display:contents 로 레이아웃에서
+ * 사라져, 이 칸을 두기 전과 똑같이 패널이 직접 세 덩이를 세로로 쌓습니다.
+ */
+.main {
+  display: contents;
+}
+
+// 옆 패널이 붙은 드로어. 본문은 화면 끝에서 원래 폭을 지키고,
+// 왼쪽으로 열린 자리를 패널이 가져갑니다.
+.hasSide {
+  flex-direction: row;
+  width: min(1040px, 100vw);
+
+  .main {
+    display: flex;
+    flex-direction: column;
+    flex: none;
+    width: 420px;
+    min-width: 0;
+  }
+
+  @include md {
+    // 나란히 둘 폭이 없습니다. 펴 둔 동안에는 원본만 보이고,
+    // 패널 머리말의 화살표로 본문으로 돌아옵니다.
+    .main {
+      display: none;
+    }
+  }
+
+  @include sm {
+    // 바텀시트는 내용만큼만 높이를 잡습니다. 원본만 남은 자리에서는 그 내용이
+    // 다시 시트 높이를 재서 그려지므로, 높이를 못 박아야 문서가 제 크기로 펴집니다.
+    height: 88vh;
+  }
+}
+
+.side {
+  flex: 1;
+  min-width: 0;
+  border-right: 1px solid var(--line);
+  background: var(--surface);
+
+  @include md {
+    border-right: 0;
+  }
 }
 
 @keyframes slide-in {

--- a/frontend/src/components/Drawer/Drawer.tsx
+++ b/frontend/src/components/Drawer/Drawer.tsx
@@ -25,6 +25,15 @@ interface Props {
   /** 머리말과 본문 사이에 고정으로 붙는 줄. 목록 드로어의 필터 칩이 여기 옵니다. */
   filters?: ReactNode
   footer?: ReactNode
+  /**
+   * 본문 왼쪽에 나란히 붙는 패널. 드로어가 그만큼 넓어집니다. 원본 문서 뷰어처럼
+   * 스크롤과 높이를 스스로 감당하는 것만 옵니다. 본문 스크롤과는 따로 놉니다.
+   *
+   * 드로어는 화면 오른쪽 끝에 붙어 있습니다. 패널을 오른쪽에 붙이면 늘어난 폭만큼
+   * 본문이 왼쪽으로 밀려, 읽던 요약과 제목·닫기 버튼이 통째로 움직입니다. 왼쪽으로
+   * 열면 본문은 있던 자리에 그대로 있고 새로 열린 자리에 패널이 들어옵니다.
+   */
+  side?: ReactNode
   /** 값이 바뀌면 본문 스크롤을 맨 위로 되돌립니다. 필터를 갈아탈 때 씁니다. */
   resetKey?: string
   onClose: () => void
@@ -39,6 +48,7 @@ export default function Drawer({
   actions,
   filters,
   footer,
+  side,
   resetKey,
   onClose,
   children,
@@ -101,34 +111,40 @@ export default function Drawer({
     >
       <aside
         ref={panelRef}
-        className={`${styles.panel} ${wide ? styles.wide : ''}`}
+        className={`${styles.panel} ${wide ? styles.wide : ''} ${side ? styles.hasSide : ''}`}
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}
         tabIndex={-1}
         onPointerDown={(event) => event.stopPropagation()}
       >
-        <header className={styles.head}>
-          <div className={styles.heading}>
-            <h2 id={titleId}>{title}</h2>
-            {sub && <p className={styles.sub}>{sub}</p>}
-            {meta && <div className={styles.meta}>{meta}</div>}
-          </div>
-          <div className={styles.tools}>
-            {actions}
-            <button type="button" className={styles.close} onClick={onClose} aria-label="닫기">
-              <CloseIcon />
-            </button>
-          </div>
-        </header>
+        {side && <div className={styles.side}>{side}</div>}
 
-        {filters && <div className={styles.filters}>{filters}</div>}
+        {/* 옆 패널이 없을 때 이 칸은 display:contents 로 사라집니다.
+            머리말·본문·바닥이 지금까지처럼 패널의 직접 자식으로 놓입니다. */}
+        <div className={styles.main}>
+          <header className={styles.head}>
+            <div className={styles.heading}>
+              <h2 id={titleId}>{title}</h2>
+              {sub && <p className={styles.sub}>{sub}</p>}
+              {meta && <div className={styles.meta}>{meta}</div>}
+            </div>
+            <div className={styles.tools}>
+              {actions}
+              <button type="button" className={styles.close} onClick={onClose} aria-label="닫기">
+                <CloseIcon />
+              </button>
+            </div>
+          </header>
 
-        <div className={styles.body} ref={bodyRef}>
-          {children}
+          {filters && <div className={styles.filters}>{filters}</div>}
+
+          <div className={styles.body} ref={bodyRef}>
+            {children}
+          </div>
+
+          {footer && <div className={styles.foot}>{footer}</div>}
         </div>
-
-        {footer && <div className={styles.foot}>{footer}</div>}
       </aside>
     </div>
   )

--- a/frontend/src/components/Popover/Popover.module.scss
+++ b/frontend/src/components/Popover/Popover.module.scss
@@ -37,9 +37,23 @@
   right: 0;
 }
 
+// 트리거가 스크롤 영역 맨 아래에 있는 메뉴. 아래로 열면 화면 밖으로 잘립니다.
+.up {
+  top: auto;
+  bottom: calc(100% + var(--s2));
+  animation-name: pop-up;
+}
+
 @keyframes pop {
   from {
     opacity: 0;
     transform: translateY(-4px);
+  }
+}
+
+@keyframes pop-up {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
   }
 }

--- a/frontend/src/components/Popover/Popover.tsx
+++ b/frontend/src/components/Popover/Popover.tsx
@@ -11,6 +11,8 @@ interface PopoverProps {
   align?: 'start' | 'end'
   /** 항목 몇 개짜리 메뉴. 기본 폭(240px)과 안쪽 여백을 줄입니다. */
   compact?: boolean
+  /** 트리거 위로 열지. 스크롤 영역 맨 아래에 놓인 버튼에 씁니다. */
+  up?: boolean
   label: string
   children: ReactNode
 }
@@ -21,6 +23,7 @@ export default function Popover({
   trigger,
   align = 'start',
   compact,
+  up,
   label,
   children,
 }: PopoverProps) {
@@ -54,7 +57,7 @@ export default function Popover({
 
       {open && (
         <div
-          className={`${styles.panel} ${align === 'end' ? styles.alignEnd : ''} ${compact ? styles.compact : ''}`}
+          className={`${styles.panel} ${align === 'end' ? styles.alignEnd : ''} ${compact ? styles.compact : ''} ${up ? styles.up : ''}`}
           role="dialog"
           aria-label={label}
         >

--- a/frontend/src/pages/Customers/components/SourceDocumentViewer/SourceDocumentViewer.module.scss
+++ b/frontend/src/pages/Customers/components/SourceDocumentViewer/SourceDocumentViewer.module.scss
@@ -1,6 +1,9 @@
 /*
  * 이미지와 PDF 가 같은 껍데기를 씁니다. 안에 그리는 것만 <img> 와 <canvas> 로 갈리고
  * 머리말·무대·도구 막대의 자리는 바뀌지 않아, 무엇을 올렸든 같은 화면으로 읽힙니다.
+ *
+ * 브라우저가 그리지 못하는 형식은 무대에 글을 세웁니다(.textPage). 그때는 확대·회전할
+ * 것이 없어 도구 막대가 빠지고, 무대만 위에서 아래로 흐릅니다.
  */
 .viewer {
   display: flex;
@@ -81,6 +84,42 @@
   @media (prefers-reduced-motion: reduce) {
     transition: none;
   }
+}
+
+/*
+ * 글은 종이처럼 한 장으로 놓입니다. 무대가 가운데로 모으는 자리라, 위에서 시작해
+ * 아래로 읽히도록 정렬만 되돌립니다.
+ */
+.textPage {
+  align-self: start;
+  justify-self: stretch;
+  width: 100%;
+  max-width: 78ch;
+  margin-inline: auto;
+  padding: var(--s4);
+  border-radius: var(--r-xs);
+  background: var(--surface);
+  box-shadow: var(--sh-2);
+}
+
+// 원본이 아니라 추출한 글이라는 것을 먼저 알립니다.
+.textHint {
+  margin: 0 0 var(--s3);
+  padding-bottom: var(--s3);
+  border-bottom: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 12px;
+}
+
+// 마크다운이 아닌 글. 원본의 줄바꿈과 들여쓰기를 그대로 살립니다.
+.plain {
+  margin: 0;
+  color: var(--ink);
+  font-family: inherit;
+  font-size: 13px;
+  line-height: 1.7;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .notice {

--- a/frontend/src/pages/Customers/components/SourceDocumentViewer/SourceDocumentViewer.tsx
+++ b/frontend/src/pages/Customers/components/SourceDocumentViewer/SourceDocumentViewer.tsx
@@ -2,9 +2,11 @@ import { useEffect, useRef, useState } from 'react'
 import type { PDFDocumentLoadingTask, PDFDocumentProxy, RenderTask } from 'pdfjs-dist'
 
 import Button from '@/components/Button'
+import ReportBody from '@/components/ReportBody'
 import {
   ChevronLeftIcon,
   ChevronRightIcon,
+  CloseIcon,
   MinusIcon,
   PlusIcon,
   RotateIcon,
@@ -12,14 +14,34 @@ import {
 
 import styles from './SourceDocumentViewer.module.scss'
 
-interface Props {
-  /** OCR 에 쓴 원본. 이미지와 PDF 를 같은 껍데기 안에서 보여 줍니다. */
-  file: File
-  /** 오른쪽 패널을 접습니다. 접힌 상태는 부른 쪽이 들고 있습니다. */
-  onCollapse: () => void
+/** 원본 대신 글을 세울 때 부른 쪽이 준비해 넘기는 내용. */
+interface TextSource {
+  /** 비어 있지 않은 본문. 준비되기 전에는 부른 쪽이 패널을 열지 않습니다. */
+  body: string
+  /** 마크다운으로 읽을 글인지. 아니면 줄바꿈만 살려 그대로 보여 줍니다. */
+  markdown: boolean
+  /** 원본을 그리지 못해 추출한 글로 대신하는 자리인지. 그럴 때만 안내를 답니다. */
+  extracted: boolean
 }
 
-type Kind = 'image' | 'pdf'
+interface Props {
+  /**
+   * 원본. 그릴 수 있는 형식은 파일째로 받고, 글로 대신 보여 주는 형식은 머리말에
+   * 세울 이름만 받습니다.
+   */
+  file: File | { name: string }
+  /** 이 값이 있으면 원본을 그리는 대신 이 글을 세웁니다. */
+  text?: TextSource
+  /** 패널을 접습니다. 접힌 상태는 부른 쪽이 들고 있습니다. */
+  onCollapse: () => void
+  /**
+   * 원본이 화면을 통째로 덮는 자리인지. 좁은 화면의 드로어처럼 이 패널만 보일
+   * 때는 옆으로 접는 것이 아니라 닫는 것으로 읽혀, 화살표 대신 X 를 세웁니다.
+   */
+  fullScreen?: boolean
+}
+
+type Kind = 'image' | 'pdf' | 'text'
 type Status = 'loading' | 'ready' | 'error'
 
 interface Size {
@@ -36,8 +58,10 @@ const EMPTY_SIZE: Size = { width: 0, height: 0 }
  * 확장자와 MIME 을 함께 봅니다. 끌어다 놓은 파일은 type 이 비어 오는 일이 있어
  * businessLicense.ts 의 검사와 같은 기준을 씁니다.
  */
-function documentKind(file: File): Kind {
-  return file.type === 'application/pdf' || /\.pdf$/i.test(file.name) ? 'pdf' : 'image'
+function documentKind(file: File | { name: string }, text?: TextSource): Kind {
+  if (text !== undefined) return 'text'
+  const type = file instanceof File ? file.type : ''
+  return type === 'application/pdf' || /\.pdf$/i.test(file.name) ? 'pdf' : 'image'
 }
 
 /** 90도 돌리면 가로세로가 바뀝니다. 패널에 맞출 배율은 돌아간 뒤 크기로 잽니다. */
@@ -49,8 +73,16 @@ function fitScale(content: Size, stage: Size, rotation: number): number {
   return Math.min(stage.width / width, stage.height / height)
 }
 
-export default function SourceDocumentViewer({ file, onCollapse }: Props) {
-  const kind = documentKind(file)
+export default function SourceDocumentViewer({
+  file,
+  text,
+  onCollapse,
+  fullScreen = false,
+}: Props) {
+  const kind = documentKind(file, text)
+  // 그릴 원본만 남깁니다. 글로 대신 보여 주는 자리에는 이름만 오므로 여기가 비고,
+  // 아래 효과들이 이 값 하나만 보고 다시 돌지 말지 정합니다.
+  const blob = kind !== 'text' && file instanceof File ? file : null
   const stageRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
 
@@ -65,17 +97,23 @@ export default function SourceDocumentViewer({ file, onCollapse }: Props) {
   const [pdf, setPdf] = useState<PDFDocumentProxy | null>(null)
 
   // 원본은 아직 서버에 올라가기 전이라 파일 그대로 브라우저 주소로 만들어 씁니다.
+  // 글로 대신 보여 주는 자리에는 파일이 없어 만들 주소도 없습니다.
   useEffect(() => {
-    const created = URL.createObjectURL(file)
-    setUrl(created)
-    setStatus('loading')
     setZoom(1)
     setRotation(0)
     setPage(1)
     setPageCount(1)
     setNatural(EMPTY_SIZE)
+    if (blob === null) {
+      setUrl(null)
+      setStatus('ready')
+      return
+    }
+    const created = URL.createObjectURL(blob)
+    setUrl(created)
+    setStatus('loading')
     return () => URL.revokeObjectURL(created)
-  }, [file])
+  }, [blob])
 
   // 패널을 접었다 펴거나 창을 줄이면 맞춤 배율이 달라집니다.
   useEffect(() => {
@@ -191,16 +229,29 @@ export default function SourceDocumentViewer({ file, onCollapse }: Props) {
           variant="ghost"
           size="sm"
           iconOnly
-          aria-label="원본 문서 접기"
+          aria-label={fullScreen ? '원본 문서 닫기' : '원본 문서 접기'}
           onClick={onCollapse}
         >
-          <ChevronRightIcon />
+          {fullScreen ? <CloseIcon /> : <ChevronRightIcon />}
         </Button>
       </header>
 
       <div className={styles.stage} ref={stageRef}>
         {status === 'error' ? (
           <p className={styles.notice}>원본을 미리 볼 수 없습니다. 파일은 그대로 보관됩니다.</p>
+        ) : text !== undefined ? (
+          <div className={styles.textPage}>
+            {text.extracted && (
+              <p className={styles.textHint}>
+                원본 그대로 볼 수 없는 형식이라, 문서에서 추출한 글을 보여 줍니다.
+              </p>
+            )}
+            {text.markdown ? (
+              <ReportBody body={text.body} />
+            ) : (
+              <pre className={styles.plain}>{text.body}</pre>
+            )}
+          </div>
         ) : kind === 'pdf' ? (
           <canvas className={styles.canvas} ref={canvasRef} />
         ) : (
@@ -228,81 +279,84 @@ export default function SourceDocumentViewer({ file, onCollapse }: Props) {
         {status === 'loading' && <p className={styles.notice}>원본을 여는 중…</p>}
       </div>
 
-      <div className={styles.toolbar}>
-        <div className={styles.group}>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            iconOnly
-            aria-label="축소"
-            disabled={zoom <= ZOOM_MIN}
-            onClick={() => zoomBy(-ZOOM_STEP)}
-          >
-            <MinusIcon />
-          </Button>
-          <button
-            type="button"
-            className={styles.zoomLabel}
-            title="화면에 맞추기"
-            onClick={() => setZoom(1)}
-          >
-            {Math.round(zoom * 100)}%
-          </button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            iconOnly
-            aria-label="확대"
-            disabled={zoom >= ZOOM_MAX}
-            onClick={() => zoomBy(ZOOM_STEP)}
-          >
-            <PlusIcon />
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            iconOnly
-            aria-label="90도 회전"
-            onClick={() => setRotation((previous) => (previous + 90) % 360)}
-          >
-            <RotateIcon />
-          </Button>
-        </div>
-
-        {/* 여러 장짜리 PDF 일 때만 나옵니다. 이미지와 한 장짜리에는 넘길 곳이 없습니다. */}
-        {pageCount > 1 && (
+      {/* 확대·회전·페이지는 그림에만 뜻이 있습니다. 글은 그대로 흐르게 둡니다. */}
+      {kind !== 'text' && (
+        <div className={styles.toolbar}>
           <div className={styles.group}>
             <Button
               type="button"
               variant="ghost"
               size="sm"
               iconOnly
-              aria-label="이전 페이지"
-              disabled={page <= 1}
-              onClick={() => setPage((previous) => Math.max(1, previous - 1))}
+              aria-label="축소"
+              disabled={zoom <= ZOOM_MIN}
+              onClick={() => zoomBy(-ZOOM_STEP)}
             >
-              <ChevronLeftIcon />
+              <MinusIcon />
             </Button>
-            <span className={styles.pageLabel} aria-live="polite">
-              {page} / {pageCount}
-            </span>
+            <button
+              type="button"
+              className={styles.zoomLabel}
+              title="화면에 맞추기"
+              onClick={() => setZoom(1)}
+            >
+              {Math.round(zoom * 100)}%
+            </button>
             <Button
               type="button"
               variant="ghost"
               size="sm"
               iconOnly
-              aria-label="다음 페이지"
-              disabled={page >= pageCount}
-              onClick={() => setPage((previous) => Math.min(pageCount, previous + 1))}
+              aria-label="확대"
+              disabled={zoom >= ZOOM_MAX}
+              onClick={() => zoomBy(ZOOM_STEP)}
             >
-              <ChevronRightIcon />
+              <PlusIcon />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              iconOnly
+              aria-label="90도 회전"
+              onClick={() => setRotation((previous) => (previous + 90) % 360)}
+            >
+              <RotateIcon />
             </Button>
           </div>
-        )}
-      </div>
+
+          {/* 여러 장짜리 PDF 일 때만 나옵니다. 이미지와 한 장짜리에는 넘길 곳이 없습니다. */}
+          {pageCount > 1 && (
+            <div className={styles.group}>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                iconOnly
+                aria-label="이전 페이지"
+                disabled={page <= 1}
+                onClick={() => setPage((previous) => Math.max(1, previous - 1))}
+              >
+                <ChevronLeftIcon />
+              </Button>
+              <span className={styles.pageLabel} aria-live="polite">
+                {page} / {pageCount}
+              </span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                iconOnly
+                aria-label="다음 페이지"
+                disabled={page >= pageCount}
+                onClick={() => setPage((previous) => Math.min(pageCount, previous + 1))}
+              >
+                <ChevronRightIcon />
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
     </section>
   )
 }

--- a/frontend/src/pages/Documents/catalog.ts
+++ b/frontend/src/pages/Documents/catalog.ts
@@ -62,6 +62,25 @@ export function kindOfFile(file: Pick<File, 'name'>): DocumentFileKind {
   return EXT_KIND[ext] ?? 'etc'
 }
 
+/**
+ * 원본을 어떻게 보여 줄지.
+ *
+ * - render: 브라우저가 원본을 그대로 그립니다(PDF·이미지).
+ * - plain: 원본이 곧 글입니다. 받아서 그대로 읽습니다.
+ * - extracted: 브라우저가 그리지 못하는 형식(docx·pptx·hwp·html)이라, 문서에서
+ *   뽑아 둔 글로 대신합니다.
+ */
+export type SourceMode = 'render' | 'plain' | 'extracted'
+
+const PLAIN_TEXT_EXT = new Set(['txt', 'md', 'markdown'])
+
+export function sourceMode(file: Pick<File, 'name'>): SourceMode {
+  const kind = kindOfFile(file)
+  if (kind === 'pdf' || kind === 'image') return 'render'
+  const ext = file.name.split('.').pop()?.toLowerCase() ?? ''
+  return PLAIN_TEXT_EXT.has(ext) ? 'plain' : 'extracted'
+}
+
 const NAME_HINTS: [RegExp, DocumentCategory][] = [
   [/계약|contract/i, '계약서'],
   [/발주|구매요청|po[-_]/i, '발주서'],

--- a/frontend/src/pages/Documents/components/DocumentDrawer/DocumentDrawer.module.scss
+++ b/frontend/src/pages/Documents/components/DocumentDrawer/DocumentDrawer.module.scss
@@ -66,6 +66,69 @@
   }
 }
 
+// 받을 수 있는 것을 한 목록에 모읍니다. 무엇을 받는지가 왼쪽,
+// 형식과 크기가 오른쪽입니다. 형식 이름이 항목을 대표하지 않게 합니다.
+.downloadMenu {
+  display: flex;
+  flex-direction: column;
+  min-width: 208px;
+
+  button {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: baseline;
+    gap: var(--s3);
+    padding: 7px 10px;
+    border: 0;
+    border-radius: var(--r-sm);
+    background: none;
+    color: var(--ink);
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 500;
+    text-align: left;
+    cursor: pointer;
+
+    span {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    i {
+      flex: none;
+      color: var(--muted);
+      font-size: 11px;
+      font-style: normal;
+      font-variant-numeric: tabular-nums;
+    }
+
+    &:hover:not(:disabled) {
+      background: var(--fill-2);
+    }
+
+    &:disabled {
+      cursor: wait;
+      opacity: 0.6;
+    }
+  }
+}
+
+.menuGroup {
+  padding: var(--s2) 10px 4px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+// 원본과 처리 결과 사이에만 선이 옵니다.
+.menuDivider {
+  margin-top: var(--s2);
+  padding-top: var(--s3);
+  border-top: 1px solid var(--line);
+}
+
 .rows {
   display: grid;
   gap: var(--s3);
@@ -88,27 +151,12 @@
   }
 }
 
-.tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--s1);
-  margin-top: var(--s3);
-
-  li {
-    padding: 3px var(--s2);
-    border-radius: var(--r-pill);
-    background: var(--fill);
-    color: var(--muted);
-    font-size: 11px;
-    font-weight: 600;
-  }
-}
-
 /* ---- 파일 ---- */
 
+// 이 제목 아래에 마크다운 소제목이 다시 선다. 부모가 자식보다 커야 위계가 읽힌다.
 .sectionTitle {
-  color: var(--ink-2);
-  font-size: 12px;
+  color: var(--ink);
+  font-size: 13px;
   font-weight: 600;
 }
 
@@ -116,13 +164,21 @@
 // 파일에 대한 값이 한 줄씩 섞여 있으면 무엇이 무엇에 걸린 값인지 읽기 어렵습니다.
 .fileCard {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 4px var(--s3);
-  margin-top: var(--s4);
+  gap: 4px;
+  margin-top: var(--s3);
   padding: var(--s3);
   border: 1px solid var(--line);
   border-radius: var(--r-sm);
   background: var(--surface-2);
+}
+
+// 조작은 카드 안 마지막 줄입니다. 원본 보기가 흰 바탕으로 한 걸음 앞에 섭니다.
+.fileActions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--s2);
+  margin-top: var(--s2);
 }
 
 .fileName {
@@ -135,7 +191,6 @@
 }
 
 .fileMeta {
-  grid-column: 1 / -1;
   color: var(--muted);
   font-size: 12px;
 }
@@ -144,25 +199,6 @@
   margin-top: var(--s4);
   color: var(--muted);
   font-size: 13px;
-}
-
-.download {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  flex: none;
-  align-self: start;
-  padding: 0;
-  border: 0;
-  background: none;
-  color: var(--blue);
-  font-size: 12px;
-  font-weight: 600;
-  cursor: pointer;
-
-  &:hover {
-    text-decoration: underline;
-  }
 }
 
 .summaryHead {
@@ -190,19 +226,76 @@
 
 .summary {
   margin-top: var(--s5);
+  padding-bottom: var(--s5);
+  border-bottom: 1px solid var(--line);
 }
 
-/* 마크다운으로 그린 요약 본문. 제목·목록 모양은 ReportBody 가 맡고
-   여기서는 기존 요약 상자의 크기·배경만 그대로 유지합니다. */
+// 요약과 원본은 다루는 대상이 다릅니다. 여백만으로는 경계가 보이지 않습니다.
+.source {
+  margin-top: var(--s5);
+}
+
+/*
+ * 마크다운으로 그린 요약 본문. 기본 모양은 ReportBody 가 잡고, 소제목·목록의
+ * 크기와 간격만 이 드로어의 위계에 맞춰 다시 잡습니다.
+ *
+ * 높이를 매지 않습니다. 드로어 본문이 이미 스크롤을 맡고 있어서 여기에 다시
+ * max-height 를 걸면 한 화면에 스크롤 막대가 둘 생깁니다. 회색 상자도 함께
+ * 걷었습니다. 요약이 이 드로어의 본문이 된 자리에서 상자는 장식입니다.
+ */
 .summaryBody {
-  max-height: 420px;
-  overflow: auto;
-  padding: var(--s3);
-  border-radius: var(--r-sm);
-  background: var(--surface-2);
   color: var(--ink-2);
-  font-size: 12px;
+  font-size: 13px;
+  font-variant-numeric: tabular-nums; // 금액·수량이 자리를 맞춰 서게
   line-height: 1.7;
+
+  /*
+   * 소제목은 본문보다 작고 옅게 두고, 위쪽 여백으로 묶음을 만든다. 굵기만으로
+   * 나누면 '주요 내용'과 그 아래 항목이 같은 크기로 서서 한 덩어리로 읽힌다.
+   */
+  :global(h1),
+  :global(h2),
+  :global(h3),
+  :global(h4),
+  :global(h5),
+  :global(h6) {
+    margin: var(--s5) 0 var(--s2);
+    color: var(--muted);
+    font-size: 12px;
+    font-weight: 600;
+  }
+
+  > :global(:first-child) {
+    margin-top: 0;
+  }
+
+  // 첫 문단이 요약의 도입부다. 한 걸음 앞에 세워 무엇에 대한 문서인지 먼저 읽히게 한다.
+  > :global(p:first-child) {
+    color: var(--ink);
+    font-size: 14px;
+    line-height: 1.65;
+  }
+
+  :global(ul),
+  :global(ol) {
+    padding-left: 1.15em;
+  }
+
+  :global(li) {
+    margin-bottom: 6px;
+
+    &::marker {
+      color: var(--muted);
+    }
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  :global(strong) {
+    color: var(--ink);
+  }
 
   :global(pre) {
     overflow-x: auto;
@@ -277,31 +370,9 @@
   line-height: 1.5;
 }
 
-.artifactActions {
+.approveRow {
   display: flex;
-  flex-wrap: wrap;
-  gap: var(--s2);
-  margin-top: var(--s2);
-}
-
-.artifactDownload {
-  padding: 5px var(--s2);
-  border: 1px solid var(--line);
-  border-radius: var(--r-sm);
-  background: var(--surface-2);
-  color: var(--ink-2);
-  font-size: 11px;
-  cursor: pointer;
-
-  &:hover {
-    border-color: var(--blue);
-    color: var(--blue);
-  }
-
-  &:disabled {
-    cursor: wait;
-    opacity: 0.6;
-  }
+  margin-top: var(--s3);
 }
 
 .approve {
@@ -318,12 +389,6 @@
     cursor: wait;
     opacity: 0.6;
   }
-}
-
-.demo {
-  flex: none;
-  color: var(--muted);
-  font-size: 11px;
 }
 
 .note {

--- a/frontend/src/pages/Documents/components/DocumentDrawer/DocumentDrawer.tsx
+++ b/frontend/src/pages/Documents/components/DocumentDrawer/DocumentDrawer.tsx
@@ -1,20 +1,36 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { errorMessage } from '@/api/errorMessage'
+import Button from '@/components/Button'
 import Drawer from '@/components/Drawer'
 import ErrorToast from '@/components/ErrorToast'
 import Popover from '@/components/Popover'
 import ReportBody from '@/components/ReportBody'
 import { SkeletonBlocks } from '@/components/Skeleton'
-import { DownloadIcon, EditIcon, MoreIcon, TrashIcon } from '@/components/icons'
+import {
+  ChevronDownIcon,
+  DownloadIcon,
+  EditIcon,
+  EyeIcon,
+  MoreIcon,
+  TrashIcon,
+} from '@/components/icons'
+import { BP_DESKTOP } from '@/constants/breakpoints'
+import useMediaQuery from '@/hooks/useMediaQuery'
+import SourceDocumentViewer from '@/pages/Customers/components/SourceDocumentViewer'
 import type { SalesDocument } from '@/types'
 import type { DocumentSummaryResponse } from '@/types'
 import { sizeLabel } from '@/utils/attachment'
 import { fmtDay, parseISO } from '@/utils/date'
 
-import { KIND_LABEL, fileOf } from '../../catalog'
+import { KIND_LABEL, fileOf, sourceMode } from '../../catalog'
 import { linkLabel } from '../../columns'
-import { downloadArtifact, downloadFile, type DocumentArtifact } from '../../download'
+import {
+  downloadArtifact,
+  downloadFile,
+  fetchSourceFile,
+  type DocumentArtifact,
+} from '../../download'
 import { pollSummary } from '@/api/polling'
 
 import styles from './DocumentDrawer.module.scss'
@@ -36,6 +52,19 @@ interface Props {
 }
 
 /**
+ * 내려받기 목록에 세울 처리 결과. 무엇을 받는지로 부르고 형식은 뒤에 작게 붙인다.
+ *
+ * API 의 'text' 는 'txt' 와 같은 값(extracted_text)을 확장자만 바꿔 내려준다.
+ * 같은 것을 두 번 세워 둘 이유가 없어 화면에서는 'txt' 만 쓴다.
+ */
+const ARTIFACTS: { key: DocumentArtifact; label: string; ext: string }[] = [
+  { key: 'txt', label: '추출 텍스트', ext: '.txt' },
+  { key: 'md', label: '추출 마크다운', ext: '.md' },
+  { key: 'json', label: '인식 데이터', ext: '.json' },
+  { key: 'summary', label: 'AI 요약', ext: '.md' },
+]
+
+/**
  * 새 요약은 서버에서 추출 필드·출처를 본문에 넣지 않는다. 이미 저장된 구버전 요약도
  * 드로어에서는 같은 기준으로 보여야 하므로, 해당 섹션을 렌더링 직전에 제외한다.
  */
@@ -43,13 +72,19 @@ function summaryWithoutHiddenSections(markdown: string): string {
   const lines = markdown.split('\n')
   const hiddenHeadings = new Set(['## 추출 필드', '## 출처'])
   const hiddenTitles = new Set(['# 문서 요약', '# 문서요약'])
+  // 'AI 문서 요약' 바로 아래에 '핵심 요약'이 또 서면 라벨만 두 줄이 된다. 본문은
+  // 남기고 소제목만 걷어, 첫 문단이 요약의 도입부가 되게 한다.
+  const unlabeledHeadings = new Set(['## 핵심 요약', '## 요약'])
   const visibleLines: string[] = []
   let hiding = false
 
   for (const line of lines) {
     // 새 요약은 제목을 만들지 않지만, 구버전의 제목도 화면에서는 표시하지 않는다.
     if (hiddenTitles.has(line.trim())) continue
-    if (/^#{1,2}\s+/.test(line)) hiding = hiddenHeadings.has(line.trim())
+    if (/^#{1,2}\s+/.test(line)) {
+      hiding = hiddenHeadings.has(line.trim())
+      if (unlabeledHeadings.has(line.trim())) continue
+    }
     if (!hiding) visibleLines.push(line)
   }
   return visibleLines.join('\n')
@@ -79,7 +114,37 @@ export default function DocumentDrawer({
   const [artifactLoading, setArtifactLoading] = useState<DocumentArtifact | null>(null)
   const [approvalLoading, setApprovalLoading] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
+  const [downloadOpen, setDownloadOpen] = useState(false)
+  // 오른쪽 패널을 펼쳐 두었는지. 무엇을 세우는지는 아래 mode 가 가릅니다.
+  const [sourceOpen, setSourceOpen] = useState(false)
+  // 그림으로 그릴 원본. 통째로 받아 둔 파일이라 서명 주소 만료와 상관없습니다.
+  const [source, setSource] = useState<File | null>(null)
+  // 원본이 곧 글인 형식(txt·md)을 받아서 읽어 둔 것입니다.
+  const [sourceText, setSourceText] = useState<string | null>(null)
+  const [sourceLoading, setSourceLoading] = useState(false)
+  const [sourceError, setSourceError] = useState<string | null>(null)
   const file = fileOf(doc)
+  // 이 폭 아래에서는 드로어가 본문을 감추고 원본만 남깁니다(Drawer.module.scss 의
+  // .hasSide). 접기가 아니라 닫기로 읽히는 자리라 버튼 모양도 그에 맞춥니다.
+  const sourceFullScreen = useMediaQuery(`(max-width: ${BP_DESKTOP - 1}px)`)
+  // 원본을 그대로 그릴 수 있는지, 글로 대신 보여 줄지 가릅니다.
+  const mode = sourceMode({ name: file.fileName })
+  // 브라우저가 그리지 못하는 형식은 처리 과정에서 뽑아 둔 글로 대신합니다. 요약을
+  // 불러올 때 같은 응답으로 이미 받아 둔 값이라 따로 조회하지 않습니다.
+  const extractedBody = summary?.extracted_markdown ?? summary?.extracted_text ?? ''
+  // 추출한 글이 아직 없으면 보여 줄 것이 없습니다. 처리가 끝나면 버튼이 섭니다.
+  const canOpenSource = mode !== 'extracted' || extractedBody !== ''
+  // 그림으로 그리는 형식에는 넘길 글이 없습니다. 그때는 뷰어가 파일을 직접 그립니다.
+  const textSource =
+    mode === 'render'
+      ? undefined
+      : mode === 'plain'
+        ? {
+            body: sourceText ?? '',
+            markdown: /\.(md|markdown)$/i.test(file.fileName),
+            extracted: false,
+          }
+        : { body: extractedBody, markdown: Boolean(summary?.extracted_markdown), extracted: true }
   // 문서에 대한 것과 파일에 대한 것을 갈라 둡니다. 파일 쪽은 아래 카드가 맡습니다.
   const rows: [string, string][] = [
     ['메모', doc.description || '—'],
@@ -135,6 +200,12 @@ export default function DocumentDrawer({
     setSummaryError(null)
     setSummaryLoading(false)
     setApprovalLoading(false)
+    // 앞 문서의 원본이 오른쪽에 남아 있으면 다른 문서를 보고 있는 것처럼 읽힙니다.
+    setSourceOpen(false)
+    setSource(null)
+    setSourceText(null)
+    setSourceError(null)
+    setDownloadOpen(false)
     // 배치 접수 직후에는 아래 폴링이 같은 GET 을 돌리므로 단발 조회를 건너뜁니다.
     if (autoLoadSummaryFileId === file.id) return
     loadSavedSummary(file.id)
@@ -218,6 +289,38 @@ export default function DocumentDrawer({
       await downloadArtifact(doc.id, file.id, artifact)
     } finally {
       setArtifactLoading(null)
+      setDownloadOpen(false)
+    }
+  }
+
+  function closeSource() {
+    setSourceOpen(false)
+    setSource(null)
+    setSourceText(null)
+  }
+
+  async function openSource() {
+    if (!file.id) return
+    // 드로어가 pointerdown 을 막고 있어 팝오버의 바깥 클릭 닫기가 여기까지 오지
+    // 않습니다. 원본을 여는 김에 열려 있던 목록도 함께 걷습니다.
+    setDownloadOpen(false)
+    setSourceError(null)
+    // 추출한 글은 이미 손에 있습니다. 받아 올 것이 없어 바로 펼칩니다.
+    if (mode === 'extracted') {
+      setSourceOpen(true)
+      return
+    }
+    setSourceLoading(true)
+    try {
+      const opened = await fetchSourceFile(file)
+      // 원본이 곧 글인 형식은 글만 남기면 됩니다. 파일은 들고 있지 않습니다.
+      if (mode === 'plain') setSourceText(await opened.text())
+      else setSource(opened)
+      setSourceOpen(true)
+    } catch (reason: unknown) {
+      setSourceError(errorMessage(reason, '원본을 열지 못했습니다. 내려받아서 확인해 주세요.'))
+    } finally {
+      setSourceLoading(false)
     }
   }
 
@@ -278,6 +381,16 @@ export default function DocumentDrawer({
           <i className={styles.pill}>{KIND_LABEL[doc.kind]}</i>
         </>
       }
+      side={
+        sourceOpen && (
+          <SourceDocumentViewer
+            file={source ?? { name: file.fileName }}
+            text={textSource}
+            fullScreen={sourceFullScreen}
+            onCollapse={closeSource}
+          />
+        )
+      }
     >
       <ErrorToast
         key={`${file.id ?? 'empty'}-${summaryLoadRetry}`}
@@ -288,6 +401,12 @@ export default function DocumentDrawer({
           loadSavedSummary(file.id)
         }}
       />
+      {/* 원본을 열지 못한 것은 요약과 다른 문제라 따로 알립니다. */}
+      <ErrorToast
+        key={`source-${file.id ?? 'empty'}`}
+        message={sourceError}
+        onRetry={() => void openSource()}
+      />
       <dl className={styles.rows}>
         {rows.map(([label, value]) => (
           <div key={label}>
@@ -296,20 +415,6 @@ export default function DocumentDrawer({
           </div>
         ))}
       </dl>
-
-      {file.id ? (
-        <div className={styles.fileCard}>
-          <div className={styles.fileName}>{file.fileName}</div>
-          <button type="button" className={styles.download} onClick={() => void downloadFile(file)}>
-            <DownloadIcon width={14} height={14} />
-            내려받기
-          </button>
-          <p className={styles.fileMeta}>{fileMeta}</p>
-        </div>
-      ) : (
-        <p className={styles.fileEmpty}>파일 없음</p>
-      )}
-      {file.note && <p className={styles.note}>{file.note}</p>}
 
       {file.id && (
         <section className={styles.summary}>
@@ -361,7 +466,7 @@ export default function DocumentDrawer({
                 className={styles.summaryBody}
               />
               {summary?.processing_status === 'review_required' && (
-                <div className={styles.artifactActions}>
+                <div className={styles.approveRow}>
                   <button
                     type="button"
                     className={styles.approve}
@@ -378,33 +483,96 @@ export default function DocumentDrawer({
                   </button>
                 </div>
               )}
-              {summary?.processing_status === 'completed' && (
-                <div className={styles.artifactActions}>
-                  {(
-                    [
-                      ['text', 'TEXT'],
-                      ['txt', 'TXT'],
-                      ['md', 'Markdown'],
-                      ['json', 'JSON'],
-                      ['summary', '요약 MD'],
-                    ] as [DocumentArtifact, string][]
-                  ).map(([artifact, label]) => (
-                    <button
-                      key={artifact}
-                      type="button"
-                      className={styles.artifactDownload}
-                      disabled={artifactLoading !== null}
-                      onClick={() => void handleArtifact(artifact)}
-                    >
-                      {artifactLoading === artifact ? '준비 중…' : `${label} 다운로드`}
-                    </button>
-                  ))}
-                </div>
-              )}
             </>
           )}
         </section>
       )}
+
+      <section className={styles.source}>
+        <h3 className={styles.sectionTitle}>원본 파일</h3>
+        {file.id ? (
+          <div className={styles.fileCard}>
+            <div className={styles.fileName}>{file.fileName}</div>
+            <p className={styles.fileMeta}>{fileMeta}</p>
+            <div className={styles.fileActions}>
+              {canOpenSource &&
+                (sourceOpen ? (
+                  <Button variant="outline" size="sm" onClick={closeSource}>
+                    <EyeIcon width={14} height={14} />
+                    원본 닫기
+                  </Button>
+                ) : (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={sourceLoading}
+                    onClick={() => void openSource()}
+                  >
+                    <EyeIcon width={14} height={14} />
+                    {sourceLoading ? '원본 여는 중…' : '원본 보기'}
+                  </Button>
+                ))}
+
+              {/* 받을 것이 여럿이라 버튼을 늘어놓는 대신 한 곳에 모읍니다.
+                  머리말의 '…' 메뉴와 같은 팝오버입니다. */}
+              <Popover
+                open={downloadOpen}
+                onClose={() => setDownloadOpen(false)}
+                align="end"
+                compact
+                up
+                label="내려받기"
+                trigger={
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    aria-expanded={downloadOpen}
+                    onClick={() => setDownloadOpen((value) => !value)}
+                  >
+                    <DownloadIcon width={14} height={14} />
+                    내려받기
+                    <ChevronDownIcon width={14} height={14} />
+                  </Button>
+                }
+              >
+                <div className={styles.downloadMenu}>
+                  <p className={styles.menuGroup}>원본</p>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setDownloadOpen(false)
+                      void downloadFile(file)
+                    }}
+                  >
+                    <span>{file.fileName}</span>
+                    <i>{sizeLabel(file.bytes)}</i>
+                  </button>
+
+                  {summary?.processing_status === 'completed' && (
+                    <>
+                      <p className={`${styles.menuGroup} ${styles.menuDivider}`}>처리 결과</p>
+                      {ARTIFACTS.map(({ key, label, ext }) => (
+                        <button
+                          key={key}
+                          type="button"
+                          disabled={artifactLoading !== null}
+                          onClick={() => void handleArtifact(key)}
+                        >
+                          <span>{label}</span>
+                          <i>{artifactLoading === key ? '준비 중…' : ext}</i>
+                        </button>
+                      ))}
+                    </>
+                  )}
+                </div>
+              </Popover>
+            </div>
+          </div>
+        ) : (
+          <p className={styles.fileEmpty}>파일 없음</p>
+        )}
+        {file.note && <p className={styles.note}>{file.note}</p>}
+      </section>
     </Drawer>
   )
 }

--- a/frontend/src/pages/Documents/download.ts
+++ b/frontend/src/pages/Documents/download.ts
@@ -26,6 +26,28 @@ export async function downloadFile(file: DocumentFile) {
   }
 }
 
+/**
+ * 원본을 화면에서 그대로 보여 주기 위해 한 번에 받아 옵니다.
+ *
+ * 서명 주소는 60초만 삽니다(DOWNLOAD_EXPIRES_IN). 그 주소를 pdf.js 에 넘기면
+ * 페이지를 넘길 때마다 뒤늦게 조각을 더 받으러 가다가 만료된 주소를 만납니다.
+ * 통째로 받아 File 로 감싸 두면 만료와 무관해지고, 원본 뷰어가 지금까지 다루던
+ * 것과 같은 File 이 됩니다.
+ */
+export async function fetchSourceFile(file: DocumentFile): Promise<File> {
+  if (!file.documentId || !file.id) throw new Error('document_file_missing')
+
+  const { data } = await client.get<DownloadResponse>(
+    `/documents/${file.documentId}/files/${file.id}/download`,
+  )
+  const response = await fetch(data.url)
+  if (!response.ok) throw new Error(`document_source_fetch_failed:${response.status}`)
+  // media_type 이 비어 오는 행이 있습니다. 뷰어는 그럴 때 확장자로 갈라 봅니다.
+  return new File([await response.blob()], data.file_name || file.fileName, {
+    type: data.media_type ?? '',
+  })
+}
+
 export async function downloadArtifact(
   documentId: string,
   fileId: string,


### PR DESCRIPTION
## 변경 요약

- 공통 드로어에 원본 문서용 사이드 패널을 추가했습니다.
- PDF·이미지·텍스트·추출 텍스트를 원본 보기에서 지원하고, 모바일에서는 전면 패널로 표시합니다.
- 자료실 드로어에서 원본 보기와 원본·처리 결과 통합 다운로드 메뉴를 제공합니다.

## 검증

- npm run typecheck 통과
- npm run lint 통과
- git diff --check 통과
- 브라우저 수동 검증은 실행하지 않았습니다.

## 영향 및 주의 사항

- 자료실 문서 상세와 공통 Drawer·Popover에 영향이 있습니다.
- 데이터 마이그레이션이나 수동 적용 작업은 없습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 문서 드로어에서 원본 파일을 별도 사이드 패널 또는 전체 화면으로 열어볼 수 있습니다.
  - PDF·이미지뿐 아니라 추출된 텍스트와 마크다운 문서도 읽을 수 있습니다.
  - 원본 파일과 처리 결과 파일을 하나의 내려받기 메뉴에서 다운로드할 수 있습니다.
  - 화면 위쪽으로 열리는 팝오버를 지원합니다.

- **개선 사항**
  - 드로어 열기·닫기 전환 효과와 반응형 레이아웃이 개선되었습니다.
  - 텍스트 문서의 제목, 목록, 강조 표시가 더 읽기 쉽게 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->