### PR TITLE
보고서 이력 필터 UI 개선

### DIFF
--- a/frontend/src/components/DayPicker/DayPicker.module.scss
+++ b/frontend/src/components/DayPicker/DayPicker.module.scss
@@ -23,3 +23,44 @@
     box-shadow: 0 0 0 3px var(--blue-ring);
   }
 }
+
+// ✕ 가 앉을 자리를 비웁니다. 비워 두지 않으면 날짜 글자가 그 밑으로 들어갑니다.
+.isClearable .input {
+  padding-right: 32px;
+}
+
+// 지우기 ✕ 는 라이브러리 기본 스킨이 파란 원으로 그립니다. 이 앱의 어느 조작부와도
+// 닮지 않아 토큰으로 다시 칠합니다. 라이브러리 클래스라 :global 로 잡습니다.
+.root :global {
+  .react-datepicker-wrapper {
+    display: block;
+  }
+
+  .react-datepicker__close-icon {
+    top: 50%;
+    right: var(--s2);
+    width: 20px;
+    height: 20px;
+    padding: 0;
+    transform: translateY(-50%);
+
+    &::after {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 20px;
+      height: 20px;
+      padding: 0;
+      background: transparent;
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1;
+      content: '✕';
+      transition: color var(--t-fast) var(--ease-out);
+    }
+
+    &:hover::after {
+      color: var(--ink);
+    }
+  }
+}

--- a/frontend/src/components/DayPicker/DayPicker.tsx
+++ b/frontend/src/components/DayPicker/DayPicker.tsx
@@ -40,8 +40,12 @@ export default function DayPicker({
   fixed,
   className,
 }: Props) {
+  // 지우기가 켜지면 ✕ 가 입력 위에 겹쳐 뜹니다. 글자가 그 밑으로 들어가지 않게
+  // 오른쪽 여백을 넓히는 표시를 겉에 둡니다.
+  const root = [styles.root, isClearable && styles.isClearable, className].filter(Boolean).join(' ')
+
   return (
-    <div className={[styles.root, className].filter(Boolean).join(' ')}>
+    <div className={root}>
       <DatePicker
         selected={selected}
         onChange={onChange}

--- a/frontend/src/components/Tabs/Tabs.module.scss
+++ b/frontend/src/components/Tabs/Tabs.module.scss
@@ -2,8 +2,12 @@
 // 여백으로 높이를 맞추면 글자 크기가 조금만 달라져도 줄이 어긋납니다.
 //
 // 모양이 두 가지입니다.
-//   pill      — 알약 하나하나가 36px 짜리 조작부. 고른 것에 테두리가 생깁니다.
-//   segmented — 회색 통이 36px 이고 알약은 그 안을 채웁니다.
+//   pill      — 칩 하나하나가 36px 짜리 조작부. 고른 것에 테두리가 생깁니다.
+//   segmented — 회색 통이 36px 이고 칩은 그 안을 채웁니다.
+//
+// 모서리는 둘 다 --r-sm 입니다. 옆에 서는 검색창·드롭다운·버튼과 같은 값이라
+// 한 줄에 세워 두면 각이 맞습니다. 알약은 상태 배지(_mixins 의 tag-pill)만 씁니다 —
+// 누를 수 있는 것과 읽기만 하는 것을 모양으로 가릅니다.
 .root {
   display: flex;
   gap: var(--s1);
@@ -24,7 +28,7 @@
   justify-content: center;
   gap: 6px;
   flex: 0 0 auto;
-  border-radius: var(--r-pill);
+  border-radius: var(--r-sm);
   background: transparent;
   color: var(--muted);
   font-weight: 600;

--- a/frontend/src/pages/Daily/Daily.tsx
+++ b/frontend/src/pages/Daily/Daily.tsx
@@ -312,7 +312,6 @@ export default function Daily() {
         filters={filters}
         onFiltersChange={setFilters}
         period={period}
-        onReset={resetAll}
       />
 
       {visible.length === 0 ? (

--- a/frontend/src/pages/Daily/components/HistoryToolbar/HistoryToolbar.module.scss
+++ b/frontend/src/pages/Daily/components/HistoryToolbar/HistoryToolbar.module.scss
@@ -10,7 +10,9 @@
   width: 100%;
 }
 
-.range {
+// 상태·기간이 함께 서는 둘째 줄. 다 담으려면 1180px 남짓 필요해서, 그보다 좁으면
+// 기간 빠른 선택부터 다음 줄로 접힙니다. 잘리는 것보다 접히는 편이 낫습니다.
+.filters {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -18,28 +20,26 @@
   width: 100%;
 }
 
+// Tabs 가 스스로 옆으로 흐르므로(overflow-x) 줄어들 수 있게만 열어 둡니다.
+// 그래야 칩이 늘어나도 옆의 날짜칸을 밀어내지 않습니다.
+.status {
+  min-width: 0;
+  // pill 은 고른 칩의 그림자가 잘리지 않게 아래만 2px 비워 둡니다. 그 탓에 통이
+  // 한쪽으로만 두꺼워져 옆의 날짜칸보다 칩이 1px 높이 앉습니다. 위도 같이 비웁니다.
+  padding-top: 2px;
+}
+
+.divider {
+  flex: 0 0 auto;
+  width: 1px;
+  height: 20px;
+  background: var(--line);
+}
+
 .day {
-  flex: 0 1 152px;
+  flex: 0 1 136px;
 }
 
 .tilde {
   color: var(--muted);
-}
-
-.clear {
-  margin-left: auto;
-  padding: 0 var(--s3);
-  height: var(--control-h);
-  border: 1px solid var(--line-2);
-  border-radius: var(--r-sm);
-  background: var(--surface);
-  color: var(--ink-2);
-  font-size: 12px;
-  font-weight: 600;
-  cursor: pointer;
-
-  &:hover {
-    border-color: var(--red);
-    color: var(--red-ink);
-  }
 }

--- a/frontend/src/pages/Daily/components/HistoryToolbar/HistoryToolbar.tsx
+++ b/frontend/src/pages/Daily/components/HistoryToolbar/HistoryToolbar.tsx
@@ -1,9 +1,15 @@
 // 작성 리스트의 찾기 줄입니다. 유형은 기간 탭이 정하므로 여기에는 없고,
-// 위에서부터 검색어 → 상태 → 기간 순으로 넓은 조건이 먼저 옵니다.
+// 검색어 → 상태 → 기간 순으로 넓은 조건이 먼저 옵니다. 검색어만 한 줄을 쓰고
+// 나머지 조건은 둘째 줄에 나란히 섭니다 — 조건마다 한 줄씩 쓰면 목록이 화면
+// 아래로 밀려납니다.
 //
 // 조건을 접어 두지 않습니다. 보이지 않는 필터가 목록을 걸러 버리면 왜 비었는지
 // 알 길이 없습니다. 검색어만 기존대로 검색 버튼·Enter 로 확정하고, 상태와 기간은
 // 고르는 즉시 목록에 걸립니다(딜·계약 화면의 탭·드롭다운과 같은 방식).
+//
+// 초기화 버튼은 두지 않습니다. 상태의 '전체'와 기간의 '전체'가 이미 되돌리는
+// 자리라 같은 일을 하는 버튼이 하나 더 서 있을 뿐이었습니다. 목록이 비었을 때는
+// Daily 가 빈 자리에 '필터 초기화'를 띄웁니다 — 그때는 되돌릴 곳이 멀어집니다.
 import { useMemo } from 'react'
 
 import DayPicker from '@/components/DayPicker'
@@ -14,7 +20,6 @@ import { iso, parseISO } from '@/utils/date'
 
 import {
   activePreset,
-  countFilters,
   FILTER_STATUSES,
   presetRange,
   RANGE_PRESETS,
@@ -34,8 +39,6 @@ interface Props {
   onFiltersChange: (next: HistoryFilters) => void
   /** 지금 보고 있는 탭. 미팅에는 작성중이 없습니다. */
   period: Period
-  /** 검색어까지 함께 푸는 전체 해제. */
-  onReset: () => void
 }
 
 /** 빈 문자열은 조건 없음이라 달력에는 아무것도 고르지 않은 것으로 넘깁니다. */
@@ -48,7 +51,6 @@ export default function HistoryToolbar({
   filters,
   onFiltersChange,
   period,
-  onReset,
 }: Props) {
   const statusItems = useMemo<TabItem<StatusValue>[]>(
     () => [
@@ -70,14 +72,18 @@ export default function HistoryToolbar({
         onSearch={onSearch}
       />
 
-      <Tabs
-        items={statusItems}
-        value={filters.status}
-        label="보고서 상태"
-        onChange={(status) => onFiltersChange({ ...filters, status })}
-      />
+      <div className={styles.filters}>
+        <Tabs
+          className={styles.status}
+          items={statusItems}
+          value={filters.status}
+          label="보고서 상태"
+          onChange={(status) => onFiltersChange({ ...filters, status })}
+        />
 
-      <div className={styles.range}>
+        {/* 성격이 다른 두 조건이 한 줄에 서므로 눈으로 갈라 줍니다. */}
+        <span className={styles.divider} aria-hidden="true" />
+
         <DayPicker
           className={styles.day}
           selected={toDate(filters.start)}
@@ -104,18 +110,11 @@ export default function HistoryToolbar({
             날짜를 직접 고치면 어느 칸과도 맞지 않게 되어 모두 꺼집니다. */}
         <Tabs
           variant="segmented"
-          size="sm"
           items={RANGE_PRESETS}
           value={activePreset(filters) ?? ''}
           label="기간 빠른 선택"
           onChange={(value) => onFiltersChange({ ...filters, ...presetRange(value) })}
         />
-
-        {(countFilters(filters) > 0 || query !== '') && (
-          <button type="button" className={styles.clear} onClick={onReset}>
-            초기화
-          </button>
-        )}
       </div>
     </div>
   )

--- a/frontend/src/pages/Daily/historyFilters.ts
+++ b/frontend/src/pages/Daily/historyFilters.ts
@@ -4,7 +4,7 @@
 // 조건은 주소에 둡니다. 걸러 둔 목록을 링크로 건네면 받는 쪽도 같은 화면을 봅니다.
 // 계약·발주·자료실 화면과 같은 방식입니다.
 import type { ColumnTone, ReportStatus } from '@/types'
-import { addMonths, iso, startOfMonth, startOfWeek, TODAY } from '@/utils/date'
+import { addDays, addMonths, endOfMonth, iso, startOfMonth, startOfWeek, TODAY } from '@/utils/date'
 
 import type { Period } from './periods'
 
@@ -37,13 +37,19 @@ export const RANGE_PRESETS: { value: string; label: string }[] = [
 ]
 
 /**
- * 빠른 선택이 채우는 구간. 끝은 비워 두어 오늘 이후로 열어 둡니다.
- * 앞으로 잡힌 미팅 보고서를 잘라 내면 '이번 달' 이 이번 달을 다 보여 주지 못합니다.
+ * 빠른 선택이 채우는 구간. 시작·끝을 모두 채웁니다. 눌렀는데 종료일 칸이 비어 있으면
+ * 고장으로 보입니다.
+ *
+ * 끝은 오늘이 아니라 그 구간의 마지막 날입니다. 오늘로 자르면 앞으로 잡힌 미팅
+ * 보고서가 빠져 '이번 달' 이 이번 달을 다 보여 주지 못합니다.
  */
 export function presetRange(value: string): { start: string; end: string } {
-  if (value === 'week') return { start: iso(startOfWeek(TODAY)), end: '' }
-  if (value === 'month') return { start: iso(startOfMonth(TODAY)), end: '' }
-  if (value === 'quarter') return { start: iso(addMonths(TODAY, -3)), end: '' }
+  if (value === 'week') {
+    const first = startOfWeek(TODAY)
+    return { start: iso(first), end: iso(addDays(first, 6)) }
+  }
+  if (value === 'month') return { start: iso(startOfMonth(TODAY)), end: iso(endOfMonth(TODAY)) }
+  if (value === 'quarter') return { start: iso(addMonths(TODAY, -3)), end: iso(endOfMonth(TODAY)) }
   return { start: '', end: '' }
 }
 


### PR DESCRIPTION
## 변경 요약

- 보고서 이력의 상태와 기간 조건을 한 줄에 배치하고, 중복 초기화 버튼을 제거했습니다.
- 빠른 기간 선택이 시작일과 종료일을 모두 표시하도록 변경했습니다.
- 날짜 선택기의 지우기 버튼과 탭 모서리를 화면 조작부 스타일에 맞췄습니다.

## 검증

- `git diff --cached --check` 통과
- 로컬 프론트 CI 재현은 의존성 디렉터리의 네이티브 파일 잠금(`EPERM`)으로 완료하지 못했습니다. GitHub Actions에서 새 환경으로 lint, 포맷, 테스트, 빌드를 확인합니다.

## 영향 및 주의 사항

- 일일 업무 보고서 이력의 필터 도구 모음 UI와 빠른 기간 필터 동작에만 영향이 있습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 날짜 선택기에서 지우기 버튼이 입력 내용과 겹치지 않도록 여백과 위치를 조정했습니다.
  * 주간·월간·분기 기간 프리셋이 시작일과 종료일을 모두 포함하도록 수정했습니다.
  * 필터 영역에서 날짜 선택기와 상태 탭이 안정적으로 표시되도록 레이아웃을 개선했습니다.

* **스타일**
  * 날짜 선택기의 닫기 아이콘 색상, 크기 및 호버 스타일을 앱 디자인에 맞게 조정했습니다.
  * 탭 모서리 스타일을 변경했습니다.

* **변경 사항**
  * 일일 기록 필터 툴바의 필터 초기화 버튼을 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->