### PR TITLE
업무보고 일정 선택 화면을 개편합니다

### DIFF
--- a/frontend/src/components/WeekStrip/WeekStrip.module.scss
+++ b/frontend/src/components/WeekStrip/WeekStrip.module.scss
@@ -26,6 +26,11 @@
     background: var(--fill-2);
   }
 
+  &:disabled {
+    cursor: default;
+    opacity: 0.45;
+  }
+
   @include md {
     padding: var(--s2) 2px;
   }
@@ -102,6 +107,15 @@
 
   &:hover {
     background: var(--blue-press);
+  }
+}
+
+.isOutline {
+  border-color: var(--blue);
+  box-shadow: inset 0 0 0 1px var(--blue);
+
+  .num {
+    color: var(--blue);
   }
 }
 

--- a/frontend/src/components/WeekStrip/WeekStrip.tsx
+++ b/frontend/src/components/WeekStrip/WeekStrip.tsx
@@ -24,6 +24,10 @@ interface Props {
   label: string
   /** 선택 칸 아래 삼각형. 바로 아래로 내용이 이어지는 화면에서만 씁니다. */
   notch?: boolean
+  /** 배경을 채우지 않고 테두리만 강조해야 하는 날짜 선택 화면에서 씁니다. */
+  selectionStyle?: 'filled' | 'outline'
+  /** 이 날짜 뒤는 고를 수 없습니다. 미래의 업무보고를 막는 화면에서 씁니다. */
+  maxISO?: string
 }
 
 export default function WeekStrip({
@@ -34,6 +38,8 @@ export default function WeekStrip({
   renderMarks,
   label,
   notch = false,
+  selectionStyle = 'filled',
+  maxISO,
 }: Props) {
   const keys = days.map(iso)
 
@@ -45,6 +51,7 @@ export default function WeekStrip({
     const from = selectedISO || keys[0]
     const next = iso(addDays(parseISO(from), step))
 
+    if (maxISO && next > maxISO) return
     if (!keys.includes(next)) onOutOfRange?.(next)
     onSelect(next)
 
@@ -66,11 +73,12 @@ export default function WeekStrip({
         const dow = d.getDay()
         const isToday = key === TODAY_ISO
         const isSelected = key === selectedISO
+        const isDisabled = maxISO !== undefined && key > maxISO
 
         const cls = [
           styles.day,
           isToday && styles.isToday,
-          isSelected && styles.isSelected,
+          isSelected && (selectionStyle === 'outline' ? styles.isOutline : styles.isSelected),
           dow === 0 && styles.isSun,
           dow === 6 && styles.isSat,
         ]
@@ -85,6 +93,7 @@ export default function WeekStrip({
             className={cls}
             data-iso={key}
             aria-selected={isSelected}
+            disabled={isDisabled}
             // 선택이 없으면 첫 칸 하나만 탭 순서에 둡니다.
             tabIndex={(selectedISO ? isSelected : index === 0) ? 0 : -1}
             onClick={() => onSelect(key)}

--- a/frontend/src/pages/Daily/MeetingPick.module.scss
+++ b/frontend/src/pages/Daily/MeetingPick.module.scss
@@ -1,10 +1,13 @@
-// 목록 위로 빠져나가는 길입니다. 되돌아가기처럼 왼쪽에 섭니다.
+.page {
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
 .back {
   margin-bottom: var(--s3);
 }
 
-// 날짜 머리말부터 일정 줄까지 대시보드 하루 카드처럼 한 상자에 담깁니다.
-.card {
+.calendar {
   @include card;
 
   padding: var(--s5);
@@ -14,118 +17,291 @@
   }
 }
 
-// 목록이 들어설 자리라 목록과 같은 만큼 머리말에서 떨어집니다.
-.loading,
-.rows {
-  margin-top: var(--s4);
+.calendarHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s3);
+  margin-bottom: var(--s4);
 }
 
-// 대시보드 하루 카드의 줄과 같은 모양입니다. 왼쪽에 시간, 그 옆에 회사와 하는 일.
-// 줄 전체가 보고서로 가는 길이라 통째로 눌립니다.
-.row {
+.range {
+  font-size: 17px;
+  font-weight: 700;
+}
+
+.calendarTools {
+  display: flex;
+  align-items: center;
+  gap: var(--s2);
+
+  button {
+    display: grid;
+    place-items: center;
+    min-width: 36px;
+    height: 36px;
+    padding: 0 var(--s2);
+    border: 1px solid var(--line-2);
+    border-radius: var(--r-sm);
+    background: var(--surface);
+    color: var(--ink-2);
+    font: inherit;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+
+    &:hover:not(:disabled) {
+      background: var(--fill-2);
+    }
+
+    &:disabled {
+      color: var(--muted-2);
+      cursor: default;
+    }
+  }
+}
+
+.selectedDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--blue);
+}
+
+.filters {
+  display: flex;
+  align-items: center;
+  gap: var(--s2);
+  margin: var(--s5) 0 var(--s4);
+  overflow-x: auto;
+
+  button {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    padding: 9px var(--s3);
+    border: 0;
+    border-radius: var(--r-sm);
+    background: transparent;
+    color: var(--muted);
+    font: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    white-space: nowrap;
+    cursor: pointer;
+
+    span {
+      color: var(--muted-2);
+      font-size: 12px;
+    }
+
+    &:hover {
+      background: var(--fill-2);
+    }
+  }
+
+  .isActive {
+    border: 1px solid var(--line-2);
+    background: var(--surface);
+    color: var(--ink);
+    box-shadow: var(--sh-1);
+
+    span {
+      color: var(--blue);
+    }
+  }
+}
+
+.loading {
+  min-height: 360px;
+}
+
+.timeline {
+  position: relative;
   display: grid;
-  grid-template-columns: 52px minmax(0, 1fr);
   gap: var(--s3);
-  padding: var(--s4) var(--s3);
-  margin: 0 calc(var(--s3) * -1);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.entry {
+  position: relative;
+}
+
+.time {
+  position: relative;
+  display: grid;
+  place-items: center;
+  align-self: stretch;
+  padding: var(--s4) var(--s2);
+  border-right: 1px solid var(--line);
+  color: var(--ink-2);
+  font-size: 14px;
+  font-weight: 700;
+  text-align: center;
+}
+
+.dot {
+  position: absolute;
+  top: 50%;
+  right: -7px;
+  transform: translateY(-50%);
+  z-index: 1;
+  width: 14px;
+  height: 14px;
+  border: 3px solid var(--surface);
+  border-radius: 50%;
+  background: var(--muted-2);
+}
+
+.status검토대기 {
+  background: var(--blue);
+}
+.status확정 {
+  background: var(--green);
+}
+.status반려 {
+  background: var(--red);
+}
+
+.card {
+  display: grid;
+  grid-template-columns: 90px minmax(0, 1fr) auto;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--s4);
+  min-width: 0;
+  padding: var(--s4) var(--s5);
+  border: 1px solid var(--line);
   border-radius: var(--r-lg);
+  background: var(--surface);
   color: inherit;
-  transition: background var(--t-fast) var(--ease-out);
+  text-decoration: none;
+  transition:
+    border-color var(--t-fast),
+    box-shadow var(--t-fast),
+    transform var(--t-fast);
 
   &:hover {
-    background: var(--fill-2);
+    border-color: rgba(0, 122, 255, 0.55);
+    box-shadow: var(--sh-1);
   }
 
   &:active {
     transform: translateY(1px);
   }
 
-  @include md {
-    grid-template-columns: 46px minmax(0, 1fr);
-    gap: var(--s2);
-  }
-
-  @include sm {
-    grid-template-columns: minmax(0, 1fr);
-
-    .rail {
-      text-align: left;
-    }
-
-    .org {
-      font-size: 16px;
-    }
+  h2 {
+    font-size: 17px;
+    font-weight: 700;
+    letter-spacing: -0.016em;
   }
 }
 
-.rail {
-  text-align: right;
-}
-
-.time {
-  font-size: 13px;
-  font-weight: 600;
-}
-
-.body {
+.content {
   min-width: 0;
 }
 
-// 스캔할 때 먼저 찾는 것이 회사라 회사가 앞에 섭니다.
-// 부서와 담당자는 줄을 따로 차지하지 않고 옆에 붙습니다.
-.org {
-  display: flex;
-  align-items: baseline;
-  gap: var(--s2);
-  flex-wrap: wrap;
-  font-size: 17px;
-  font-weight: 700;
-  letter-spacing: -0.016em;
-}
-
-.who {
-  font-size: 12px;
-  font-weight: 400;
-  letter-spacing: normal;
+.who,
+.brief {
+  margin-top: 3px;
   color: var(--muted);
+  font-size: 12px;
 }
 
 .title {
-  margin-top: 3px;
+  margin-top: var(--s2);
   font-size: 14px;
   font-weight: 600;
-  letter-spacing: -0.008em;
 }
 
 .brief {
-  margin-top: var(--s2);
-  font-size: 13px;
-  line-height: 1.62;
-  color: var(--ink-2);
   display: -webkit-box;
-  -webkit-line-clamp: 1;
-  line-clamp: 1;
-  -webkit-box-orient: vertical;
   overflow: hidden;
-
-  @include md {
-    -webkit-line-clamp: 2;
-    line-clamp: 2;
-  }
+  line-height: 1.5;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
 }
 
-// 끝낸 일정은 훑을 때 걸러집니다.
-.isDone {
-  opacity: 0.45;
+.action {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex: none;
+  color: var(--blue);
+  font-size: 13px;
+  font-weight: 700;
+  white-space: nowrap;
 }
 
 .empty {
+  @include card;
+
   padding: var(--s8) var(--s4);
   text-align: center;
-  color: var(--ink-2);
-  font-size: 13px;
+  color: var(--muted);
+
+  button,
+  .emptyCta {
+    margin-top: var(--s3);
+  }
+
+  button {
+    padding: 8px var(--s3);
+    border: 0;
+    border-radius: var(--r-sm);
+    background: var(--blue-tint);
+    color: var(--blue);
+    font: inherit;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+  }
 }
 
-.emptyCta {
-  margin-top: var(--s3);
+@include sm {
+  .calendar {
+    margin: 0 calc(var(--s3) * -1);
+  }
+
+  .calendarHead {
+    align-items: flex-start;
+  }
+
+  .entry {
+    padding-left: 22px;
+  }
+
+  .time {
+    display: block;
+    min-height: 0;
+    padding: 0;
+    border-right: 0;
+    text-align: left;
+  }
+
+  .dot {
+    top: var(--s4);
+    right: auto;
+    left: -20px;
+    transform: none;
+  }
+
+  .card {
+    grid-template-columns: minmax(0, 1fr) auto;
+    padding: var(--s3);
+  }
+
+  .time {
+    grid-column: 1 / -1;
+  }
+
+  .content {
+    grid-column: 1;
+  }
+
+  .action {
+    font-size: 0;
+  }
 }

--- a/frontend/src/pages/Daily/MeetingPick.tsx
+++ b/frontend/src/pages/Daily/MeetingPick.tsx
@@ -1,34 +1,51 @@
-// 미팅 보고서를 쓰기 전에 기준 날짜와 일정을 고르는 화면입니다.
-//
-// 미팅 보고서는 일정 하나에 붙는 기록이라 빈 폼으로 열 수 없습니다. 그래서 종류를
-// 고른 다음 바로 작성으로 보내지 않고 여기서 어느 일정인지 먼저 정합니다.
-import { useMemo } from 'react'
+// 미팅 보고서를 쓰기 전에 날짜와 일정을 고르는 화면입니다.
+import { useEffect, useMemo, useState } from 'react'
 import { Link, useSearchParams } from 'react-router'
 
 import { buttonClass } from '@/components/Button'
-import DayHeader from '@/components/DayHeader'
 import ErrorToast from '@/components/ErrorToast'
-import { ChevronRightIcon } from '@/components/icons'
+import { ChevronLeftIcon, ChevronRightIcon } from '@/components/icons'
 import Skeleton from '@/components/Skeleton'
+import WeekStrip from '@/components/WeekStrip'
 import { dailyComposePath, ROUTES } from '@/constants/routes'
-import { useAgendaState } from '@/shared/agenda'
 import { useMeetingReportsOn } from '@/pages/Meetings/useMeetingReports'
-import { TODAY_ISO } from '@/utils/date'
+import { useAgendaState } from '@/shared/agenda'
+import { addDays, iso, startOfWeek, TODAY, TODAY_ISO, weekRangeLabel } from '@/utils/date'
 
-import DailyListLink from './components/DailyListLink'
 import { meetingLinkFor } from './sources'
+import DailyListLink from './components/DailyListLink'
 
 import styles from './MeetingPick.module.scss'
 
-/** 목록을 기다리는 동안 잡아 두는 높이. 네 줄쯤 들어가는 자리입니다. */
-const LIST_H = 240
+const LIST_H = 360
+const FILTERS = ['전체', '검토 대기', '확정', '반려'] as const
+type Filter = (typeof FILTERS)[number]
+
+const weekDays = (offset: number) => {
+  const first = addDays(startOfWeek(TODAY), offset * 7)
+  return Array.from({ length: 7 }, (_, index) => addDays(first, index))
+}
+
+const initialWeekOffset = (dateISO: string) => {
+  const todayStart = startOfWeek(TODAY).getTime()
+  return Math.round(
+    (startOfWeek(new Date(`${dateISO}T00:00:00`)).getTime() - todayStart) / 604800000,
+  )
+}
 
 export default function MeetingPick() {
   const [params, setParams] = useSearchParams()
-
-  // 아직 오지 않은 날은 기록할 것이 없습니다. 주소를 직접 쳐도 오늘로 당깁니다.
   const asked = params.get('date') ?? TODAY_ISO
   const dateISO = asked > TODAY_ISO ? TODAY_ISO : asked
+  const [weekOffset, setWeekOffset] = useState(() => initialWeekOffset(dateISO))
+  const [filter, setFilter] = useState<Filter>('전체')
+  const days = weekDays(weekOffset)
+
+  // 주소의 날짜를 뒤로/앞으로 이동해도 그 날짜가 든 주를 계속 보여 줍니다.
+  useEffect(() => {
+    const next = initialWeekOffset(dateISO)
+    setWeekOffset((current) => (current === next ? current : next))
+  }, [dateISO])
 
   const {
     items,
@@ -37,13 +54,13 @@ export default function MeetingPick() {
     reload: reloadAgenda,
   } = useAgendaState(dateISO, dateISO, true)
   const agenda = items.filter((item) => item.date === dateISO)
-  // 이 날 것만 봅니다. 하루치라 한 쪽에 다 들어옵니다.
   const {
     reports: meetings,
     loading: meetingLoading,
     error: meetingError,
     reload: reloadMeetings,
   } = useMeetingReportsOn(dateISO, { includeDrafts: true })
+
   const byAgenda = useMemo(() => {
     const grouped = new Map<string, typeof meetings>()
     for (const report of meetings) {
@@ -53,6 +70,25 @@ export default function MeetingPick() {
     }
     return grouped
   }, [meetings])
+
+  const rows = useMemo(
+    () => agenda.map((item) => ({ item, link: meetingLinkFor(item.id, byAgenda.get(item.id)) })),
+    [agenda, byAgenda],
+  )
+  const counts = useMemo(
+    () =>
+      FILTERS.reduce<Record<Filter, number>>(
+        (result, value) => {
+          result[value] =
+            value === '전체' ? rows.length : rows.filter(({ link }) => link.status === value).length
+          return result
+        },
+        {} as Record<Filter, number>,
+      ),
+    [rows],
+  )
+  const visible = filter === '전체' ? rows : rows.filter(({ link }) => link.status === filter)
+
   const changeDate = (next: string) => {
     if (next === '' || next > TODAY_ISO) return
     const query = new URLSearchParams(params)
@@ -60,84 +96,152 @@ export default function MeetingPick() {
     setParams(query, { replace: true })
   }
 
+  const changeWeek = (next: number) => {
+    setWeekOffset(next)
+    const first = weekDays(next)[0]
+    if (iso(first) <= TODAY_ISO) changeDate(iso(first))
+  }
+
+  const onSelectDate = (next: string) => {
+    changeDate(next)
+    if (next < iso(days[0]) || next > iso(days[6])) setWeekOffset(initialWeekOffset(next))
+  }
+
+  const loading = agendaLoading || meetingLoading
+  const error = agendaError ?? meetingError
+  const canShowNextWeek = iso(weekDays(weekOffset + 1)[0]) <= TODAY_ISO
+
   return (
-    <section>
+    <section className={styles.page} aria-busy={loading}>
       <h1 className="sr-only">미팅 보고서 작성</h1>
 
-      {/* 하루의 일정을 모두 고르는 화면이라 목록도 '전체' 로 엽니다. */}
       <DailyListLink back tab="meeting" className={styles.back} />
 
-      <div className={styles.card}>
-        {/* 날짜가 이 카드의 머리말입니다. 눌러 바꿀 수 있고 달력은 브라우저 것을 씁니다. */}
-        <DayHeader dateISO={dateISO} maxISO={TODAY_ISO} onDateChange={changeDate} />
-
-        <ErrorToast
-          message={agendaError ?? meetingError}
-          onRetry={() => {
-            reloadAgenda()
-            reloadMeetings()
-          }}
-        />
-        {!agendaError && !meetingError && (agendaLoading || meetingLoading) && (
-          <div role="status" className={styles.loading}>
-            <span className="sr-only">일정과 보고서를 불러오는 중입니다.</span>
-            <Skeleton height={LIST_H} radius="var(--r-lg)" />
+      <article className={styles.calendar}>
+        <div className={styles.calendarHead}>
+          <p className={`${styles.range} tnum`}>{weekRangeLabel(days)}</p>
+          <div className={styles.calendarTools}>
+            <button type="button" onClick={() => changeWeek(weekOffset - 1)} aria-label="이전 주">
+              <ChevronLeftIcon width={16} height={16} />
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setWeekOffset(0)
+                changeDate(TODAY_ISO)
+              }}
+              disabled={weekOffset === 0 && dateISO === TODAY_ISO}
+            >
+              오늘
+            </button>
+            <button
+              type="button"
+              onClick={() => changeWeek(weekOffset + 1)}
+              aria-label="다음 주"
+              disabled={!canShowNextWeek}
+            >
+              <ChevronRightIcon width={16} height={16} />
+            </button>
           </div>
-        )}
+        </div>
 
-        {!agendaLoading &&
-          !meetingLoading &&
-          !agendaError &&
-          !meetingError &&
-          (agenda.length === 0 ? (
-            <div className={styles.empty}>
-              <p>이 날짜에 등록된 일정이 없습니다.</p>
-              <Link
-                className={buttonClass({ variant: 'outline' }, styles.emptyCta)}
-                to={ROUTES.CALENDAR}
-              >
-                캘린더에서 일정 등록하기
-                <ChevronRightIcon />
-              </Link>
-            </div>
-          ) : (
-            <ul className={styles.rows}>
-              {agenda.map((item) => {
-                const link = meetingLinkFor(item.id, byAgenda.get(item.id))
+        <WeekStrip
+          days={days}
+          selectedISO={dateISO}
+          onSelect={onSelectDate}
+          onOutOfRange={(next) => setWeekOffset(initialWeekOffset(next))}
+          renderMarks={(key) => (key === dateISO ? <i className={styles.selectedDot} /> : null)}
+          label="미팅 보고서 날짜 선택"
+          selectionStyle="outline"
+          maxISO={TODAY_ISO}
+        />
+      </article>
 
-                return (
-                  <li key={item.id}>
-                    {/* 이 화면은 보고서를 쓰러 온 곳이라 줄 전체가 그 보고서로 가는 길입니다.
-                        이미 쓴 줄은 같은 자리에서 그 보고서로 갑니다. */}
-                    <Link
-                      className={`${styles.row} ${item.done ? styles.isDone : ''}`}
-                      to={link.to ?? dailyComposePath(dateISO, '일일')}
-                      aria-label={`${item.hospital || item.title} ${link.label}`}
-                    >
-                      <div className={styles.rail}>
-                        <span className={`${styles.time} tnum`}>{item.time}</span>
-                      </div>
-
-                      <div className={styles.body}>
-                        <h3 className={styles.org}>
-                          {item.hospital || item.title}
-                          {(item.dept || item.contact) && (
-                            <span className={styles.who}>
-                              {[item.dept, item.contact].filter(Boolean).join(' · ')}
-                            </span>
-                          )}
-                        </h3>
-
-                        {item.hospital && <p className={styles.title}>{item.title}</p>}
-                        {item.brief && <p className={styles.brief}>{item.brief}</p>}
-                      </div>
-                    </Link>
-                  </li>
-                )
-              })}
-            </ul>
-          ))}
+      <div className={styles.filters} role="tablist" aria-label="미팅 보고서 상태">
+        {FILTERS.map((value) => (
+          <button
+            key={value}
+            type="button"
+            role="tab"
+            aria-selected={filter === value}
+            className={filter === value ? styles.isActive : ''}
+            onClick={() => setFilter(value)}
+          >
+            {value}
+            <span className="tnum">{counts[value]}</span>
+          </button>
+        ))}
       </div>
+
+      <ErrorToast
+        message={error}
+        onRetry={() => {
+          reloadAgenda()
+          reloadMeetings()
+        }}
+      />
+
+      {!error && loading && (
+        <div role="status" className={styles.loading}>
+          <span className="sr-only">일정과 보고서를 불러오는 중입니다.</span>
+          <Skeleton height={LIST_H} radius="var(--r-lg)" />
+        </div>
+      )}
+
+      {!loading &&
+        !error &&
+        (agenda.length === 0 ? (
+          <div className={styles.empty}>
+            <p>이 날짜에 등록된 일정이 없습니다.</p>
+            <Link
+              className={buttonClass({ variant: 'outline' }, styles.emptyCta)}
+              to={ROUTES.CALENDAR}
+            >
+              캘린더에서 일정 등록하기
+              <ChevronRightIcon />
+            </Link>
+          </div>
+        ) : visible.length === 0 ? (
+          <div className={styles.empty}>
+            <p>{filter} 상태의 보고서가 없습니다.</p>
+            <button type="button" onClick={() => setFilter('전체')}>
+              전체 일정 보기
+            </button>
+          </div>
+        ) : (
+          <ol className={styles.timeline}>
+            {visible.map(({ item, link }) => (
+              <li key={item.id} className={styles.entry}>
+                <Link
+                  className={styles.card}
+                  to={link.to ?? dailyComposePath(dateISO, '일일')}
+                  aria-label={`${item.hospital || item.title} ${link.label}`}
+                >
+                  <span className={`${styles.time} tnum`}>
+                    {item.time}
+                    <i
+                      className={`${styles.dot} ${link.status ? styles[`status${link.status.replace(' ', '')}`] : ''}`}
+                    />
+                  </span>
+                  <div className={styles.content}>
+                    <h2>{item.hospital || item.title}</h2>
+                    {(item.dept || item.contact) && (
+                      <p className={styles.who}>
+                        {[item.dept, item.contact].filter(Boolean).join(' · ')}
+                      </p>
+                    )}
+                    {item.hospital && <p className={styles.title}>{item.title}</p>}
+                    {item.brief && <p className={styles.brief}>{item.brief}</p>}
+                  </div>
+                  <span className={styles.action}>
+                    {link.label}
+                    <ChevronRightIcon width={16} height={16} />
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ol>
+        ))}
     </section>
   )
 }


### PR DESCRIPTION
## 변경 요약

- 업무보고 일정 선택 화면을 주간 달력, 상태 태그, 타임라인 카드 구조로 개편합니다.
- 공통 주간 달력에 테두리 선택 및 미래 날짜 제한 옵션을 추가합니다.

## 검증

- npm run lint 통과
- npm test 통과 (105개)
- npm run build는 기존 pdfjs-dist 타입 선언 누락으로 실행되지 않습니다.

## 영향 및 주의 사항

- 업무보고 일정 선택 프런트엔드 화면에만 영향을 줍니다.
- 백엔드 수정은 아직 진행 중입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 주간 달력 기반으로 일정을 확인하고 이전·다음 주로 이동할 수 있습니다.
  - 날짜 선택 스타일로 채워진 표시 또는 파란색 윤곽선 표시를 지원합니다.
  - 선택 가능한 날짜 범위를 제한하며, 범위를 벗어난 날짜는 비활성화됩니다.
  - 검토 대기, 확정, 반려 등 상태별 일정 필터와 항목 수를 제공합니다.
  - 일정이 시간순 타임라인으로 표시되며 상태별 색상과 관련 작업 링크를 확인할 수 있습니다.
  - 일정이 없을 때 안내와 다음 작업을 위한 버튼을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->