### PR TITLE
feat: 고객 현황 OCR 등록 및 연락처 개선

### DIFF
--- a/backend/app/api/customers.py
+++ b/backend/app/api/customers.py
@@ -41,6 +41,7 @@ from app.schemas.customers import (
 )
 from app.services import customer_duplicates, storage
 from app.services.customer_duplicates import DuplicateProbe
+from app.services.regions import region_code_from_address
 from app.services.storage import StorageError
 
 router = APIRouter(tags=["customers"])
@@ -289,6 +290,7 @@ def _contact_read(
         job_title=contact.job_title,
         email=contact.email,
         phone=contact.phone,
+        fax=contact.fax,
         customer_contact_status_id=None if contact_status is None else contact_status.id,
         customer_contact_status_name=None if contact_status is None else contact_status.name,
         customer_contact_status_tone=None if contact_status is None else contact_status.tone,
@@ -406,10 +408,15 @@ async def create_customer_company(
     db: DbSession,
 ) -> CustomerCompany:
     team_id = member.team_id
+    values = payload.model_dump()
+    # 지역은 주소를 보면 알 수 있다. 등록 경로마다 따로 채우게 두지 않고 여기서 한 번 정한다.
+    # 보낸 쪽이 직접 지정했으면 그 값이 이긴다.
+    if values["region_code"] is None:
+        values["region_code"] = region_code_from_address(values["address"])
     company = CustomerCompany(
         id=uuid4(),
         team_id=team_id,
-        **payload.model_dump(),
+        **values,
     )
     db.add(company)
     try:
@@ -447,8 +454,12 @@ async def update_customer_company(
             detail="manager_required",
         )
     company = await _get_company(db, member, company_id)
-    for field_name, value in payload.model_dump(exclude_unset=True).items():
+    changed = payload.model_dump(exclude_unset=True)
+    for field_name, value in changed.items():
         setattr(company, field_name, value)
+    # 주소만 고쳤으면 지역도 그 주소를 따라간다. 지역을 함께 보냈으면 손대지 않는다.
+    if "address" in changed and "region_code" not in changed:
+        company.region_code = region_code_from_address(company.address)
     await _flush_and_commit(db)
     return company
 

--- a/backend/app/models/crm.py
+++ b/backend/app/models/crm.py
@@ -38,6 +38,8 @@ class CustomerContact(Base):
     job_title: Mapped[str | None]
     email: Mapped[str | None]
     phone: Mapped[str]
+    # 팩스. 선택 항목이라 없을 수 있다. 사람을 찾는 값이 아니라 검색은 phone 만 본다.
+    fax: Mapped[str | None]
     customer_contact_status_id: Mapped[UUID | None] = mapped_column(
         ForeignKey("public.customer_contact_status.id")
     )

--- a/backend/app/schemas/customers.py
+++ b/backend/app/schemas/customers.py
@@ -145,6 +145,7 @@ class CustomerContactCreate(_WriteModel):
     job_title: Text | None = None
     email: Email | None = None
     phone: Phone
+    fax: Phone | None = None
     status_code: OptionCode | None = None
     source_code: CustomerSource | None = None
     memo: Memo | None = None
@@ -161,6 +162,7 @@ class CustomerContactPatch(_WriteModel):
     job_title: Text | None = None
     email: Email | None = None
     phone: Phone | None = None
+    fax: Phone | None = None
     status_code: OptionCode | None = None
     source_code: CustomerSource | None = None
     memo: Memo | None = None
@@ -191,6 +193,7 @@ class CustomerContactRead(BaseModel):
     job_title: str | None
     email: str | None
     phone: str
+    fax: str | None
     customer_contact_status_id: UUID | None
     customer_contact_status_name: str | None
     customer_contact_status_tone: str | None

--- a/backend/app/services/regions.py
+++ b/backend/app/services/regions.py
@@ -1,0 +1,75 @@
+"""주소에서 지역 코드를 정한다.
+
+지역 코드는 프론트 shared/regionCodes.ts 와 같은 17개다. 다르면 지역별 실적이 맞물리지
+않는다. 회사를 만드는 경로가 넷(직접·명함·등록증·엑셀)이라 부르는 쪽마다 채우게 두지 않고
+저장 시점에 한 번만 정한다.
+"""
+
+# 주소 앞머리와 코드. 긴 앞머리를 먼저 봐야 "충청북도" 가 "충남" 규칙에 걸리지 않는다.
+_SIDO_PREFIXES: tuple[tuple[str, str], ...] = (
+    ("서울특별시", "seoul"),
+    ("서울", "seoul"),
+    ("부산광역시", "busan"),
+    ("부산", "busan"),
+    ("대구광역시", "daegu"),
+    ("대구", "daegu"),
+    ("인천광역시", "incheon"),
+    ("인천", "incheon"),
+    ("광주광역시", "gwangju"),
+    ("광주", "gwangju"),
+    ("대전광역시", "daejeon"),
+    ("대전", "daejeon"),
+    ("울산광역시", "ulsan"),
+    ("울산", "ulsan"),
+    ("세종특별자치시", "sejong"),
+    ("세종", "sejong"),
+    ("경기도", "gyeonggi"),
+    ("경기", "gyeonggi"),
+    ("강원특별자치도", "gangwon"),
+    ("강원도", "gangwon"),
+    ("강원", "gangwon"),
+    ("충청북도", "chungbuk"),
+    ("충북", "chungbuk"),
+    ("충청남도", "chungnam"),
+    ("충남", "chungnam"),
+    ("전북특별자치도", "jeonbuk"),
+    ("전라북도", "jeonbuk"),
+    ("전북", "jeonbuk"),
+    ("전라남도", "jeonnam"),
+    ("전남", "jeonnam"),
+    ("경상북도", "gyeongbuk"),
+    ("경북", "gyeongbuk"),
+    ("경상남도", "gyeongnam"),
+    ("경남", "gyeongnam"),
+    ("제주특별자치도", "jeju"),
+    ("제주", "jeju"),
+)
+
+
+def region_code_from_address(address: str | None) -> str | None:
+    """주소 앞머리의 시·도로 지역 코드를 정한다. 못 알아보면 None(미지정)이다.
+
+    틀린 지역이 들어가는 것보다 비어 있는 편이 낫다. 팀장이 회사 정보에서 고칠 수 있다.
+    """
+    if not address:
+        return None
+    head = address.lstrip()
+    for prefix, code in _SIDO_PREFIXES:
+        if head.startswith(prefix):
+            return code
+    return None
+
+
+def _self_check() -> None:
+    assert region_code_from_address("서울시 서초구 남부순환로 339길 23") == "seoul"
+    assert region_code_from_address("  경기도 성남시 분당구") == "gyeonggi"
+    assert region_code_from_address("충청북도 청주시") == "chungbuk"
+    assert region_code_from_address("전북특별자치도 전주시") == "jeonbuk"
+    assert region_code_from_address(None) is None
+    assert region_code_from_address("") is None
+    assert region_code_from_address("합성시 관계구 세일즈로 20") is None
+    print("regions self-check ok")
+
+
+if __name__ == "__main__":
+    _self_check()

--- a/backend/sql/20260911_0030_customer_contact_fax.sql
+++ b/backend/sql/20260911_0030_customer_contact_fax.sql
@@ -1,0 +1,15 @@
+-- 전화 한 칸을 휴대폰과 팩스로 나눈다.
+--
+-- 기존 phone 은 그대로 휴대폰(필수)으로 남는다. 명함에는 대표번호·팩스가 함께 적혀 있어
+-- 한 칸에 담으면 어느 번호인지 알 수 없다. 팩스는 사람을 찾는 값이 아니라 선택 항목이고,
+-- 검색·필터·엑셀 임포트는 지금처럼 phone 만 본다.
+
+BEGIN;
+
+ALTER TABLE public.customer_contact
+    ADD COLUMN fax text;
+
+COMMENT ON COLUMN public.customer_contact.fax IS
+    '팩스 번호. 숫자만 저장한다. 선택 항목이라 NULL 이 기본이다.';
+
+COMMIT;

--- a/backend/sql/README.md
+++ b/backend/sql/README.md
@@ -330,6 +330,13 @@
   앱은 소유자로 붙어 RLS 를 지나가고 PostgREST 로 들어오는 anon / authenticated 에게는 아무것도
   열리지 않는다는 뜻입니다. 이 표만 꺼져 있으면 고객불만의 예전 본문이 REST 로 새어 나갑니다.
 
+- `20260911_0030_customer_contact_fax.sql`: `customer_contact`에 `fax`(nullable)를 더합니다.
+  명함에는 대표번호와 팩스가 함께 적혀 있어 칸 하나에 담으면 어느 번호인지 알 수 없습니다.
+  기존 `phone`은 그대로 휴대폰(필수)으로 남고 팩스만 선택 항목으로 붙습니다. 검색(`_phone_search`),
+  목록 필터, 엑셀 임포트, 중복 확인은 지금처럼 `phone`만 봅니다 — 팩스로 사람을 찾지 않습니다.
+  기존 행은 전부 `NULL`이라 백필이 없고, 더하기만이라 구코드가 깨지지 않으므로 적용과 배포의
+  순서는 자유입니다.
+
 `20260819_0001`은 빈 `public` 스키마에 처음부터 만드는 것을 전제로 합니다. 되돌리는 마이그레이션이
 아니므로 적용 전에 아래 런북의 1~2단계를 먼저 수행합니다.
 
@@ -377,6 +384,7 @@
 | 2026-09-08 | 현재 연결된 개발 DB | `20260908_0027_member_region_code.sql` | transaction pooler(6543, `statement_cache_size=0`) | 성공. member 9→10컬럼(`region_code`, nullable, CHECK 공백 금지). 구성원 18행 보존(18→18)이고 `region_code`는 18행 모두 `NULL`(미지정)입니다. 더하기만이라 백필도 지우는 행도 없습니다. ORM(`app/models/workspace.py`)과 물리 스키마의 컬럼·nullable을 대조해 일치를 확인했습니다 — `test_models_match_configured_database`는 0025 때와 같이 트랜잭션 풀러에서 돌지 않아 같은 대조를 직접 수행했습니다 |
 | 2026-09-09 | 현재 연결된 개발 DB | `20260909_0028_support_request_edit.sql` | transaction pooler(6543, `statement_cache_size=0`) | 성공. support_request 11→12컬럼(`updated_at`, nullable)과 `support_request_edit_backup` 8컬럼 신설(PK 1 · FK 2 · 인덱스 `support_request_edit_backup_request_idx`). 불만 69행·응답 86행 보존(69→69 / 86→86)이고 `updated_at`은 69행 모두 `NULL`, 백업 표는 0행입니다. 더하기만이라 백필도 지우는 행도 없습니다. 적용 후 컬럼·nullable·기본값·FK·인덱스를 물리 스키마에서 직접 조회해 ORM(`app/models/crm.py`)과 일치를 확인했습니다 — `test_models_match_configured_database`는 0025 때와 같이 트랜잭션 풀러에서 돌지 않아 같은 대조를 직접 수행했습니다. **RLS 를 빠뜨렸습니다 — 0029 로 이어서 켭니다** |
 | 2026-09-09 | 현재 연결된 개발 DB | `20260909_0029_support_request_edit_backup_rls.sql` | — | **미적용(대기).** 0028 이 만든 백업 표만 42개 표 중 홀로 RLS 가 꺼져 있는 것을 적용 직후 확인했습니다. 정책 없이 켜기만 하므로 앱 동작은 바뀌지 않고, 켜기 전까지 PostgREST 로 예전 불만 본문이 열려 있습니다 |
+| 2026-09-11 | 현재 연결된 개발 DB | `20260911_0030_customer_contact_fax.sql` | transaction pooler(6543, `statement_cache_size=0`) | 성공. customer_contact 15→16컬럼(`fax` text, nullable, 기본값 없음). 고객 861행 보존(861→861)이고 `fax`는 861행 모두 `NULL`입니다 — 더하기만이라 백필도 지우는 행도 없습니다. 적용 전 ORM↔물리 스키마를 대조해 미적용 컬럼이 `customer_contact.fax` 하나뿐임을 확인했고, 적용 후 다시 대조해 차이가 사라진 것을 확인했습니다. `test_models_match_configured_database`는 0025·0028 때와 같이 트랜잭션 풀러에서 돌지 않아 같은 대조를 직접 수행했습니다. RLS·인덱스·제약은 건드리지 않았습니다 |
 
 ## 개발 DB 재구축 런북
 

--- a/backend/tests/test_customers.py
+++ b/backend/tests/test_customers.py
@@ -1011,6 +1011,7 @@ def _contact_read_payload(**overrides):
         "job_title": None,
         "email": None,
         "phone": "010-0000-0000",
+        "fax": None,
         "customer_contact_status_id": None,
         "customer_contact_status_name": None,
         "customer_contact_status_tone": None,

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -38,7 +38,7 @@ EXPECTED_COLUMN_COUNTS = {
     # 20260826_0009 로 customer_company 에 postcode/address/address_detail 이 늘었다.
     "customer_company": 9,
     # 20260824_0004 로 customer_contact 에 visited 가 늘었다.
-    "customer_contact": 15,
+    "customer_contact": 16,
     "customer_contact_assignee": 3,
     "customer_contact_status": 9,
     # 20260824_0004 로 product 에 category_code/unit_price/shelf_life_months/memo/

--- a/frontend/src/components/AddressField/AddressField.module.scss
+++ b/frontend/src/components/AddressField/AddressField.module.scss
@@ -5,16 +5,6 @@
   min-width: 0;
 }
 
-.line {
-  display: flex;
-  gap: var(--s2);
-}
-
-// 우편번호는 5자리라 나머지 자리를 버튼에 내줍니다.
-.postcode {
-  flex: 0 1 120px;
-}
-
 .error {
   color: var(--red-ink);
   font-size: 11px;

--- a/frontend/src/components/AddressField/AddressField.tsx
+++ b/frontend/src/components/AddressField/AddressField.tsx
@@ -1,19 +1,17 @@
 // 다음(카카오) 우편번호 서비스로 주소를 골라 넣는 입력입니다.
 //
 // 우편번호와 주소는 직접 치지 않습니다. 오타 난 주소는 지도에서 찾을 수 없어, 고른 값만
-// 그대로 담고 층·호수만 사람이 적습니다.
+// 그대로 담고 층·호수만 사람이 적습니다. 명함·사업자등록증에서 읽어 온 주소도 한 줄로
+// 오므로, 칸도 한 줄입니다. 주소 부분을 누르면 우편번호 창이 열리고, 줄 끝에 이어서 치면
+// 그게 상세주소가 됩니다. 한 줄을 만들고 되읽는 규칙은 addressLine 에 있습니다.
 import { useState } from 'react'
 
-import Button from '@/components/Button'
 import { loadDaumPostcode, pickAddress } from '@/utils/daumPostcode'
 
 import styles from './AddressField.module.scss'
+import { type AddressValue, caretPicksAddress, formatAddress, readAddressLine } from './addressLine'
 
-export interface AddressValue {
-  postcode: string
-  address: string
-  addressDetail: string
-}
+export type { AddressValue }
 
 interface Props {
   value: AddressValue
@@ -33,8 +31,10 @@ export default function AddressField({
   const [loadError, setLoadError] = useState<string | null>(null)
   const [opening, setOpening] = useState(false)
 
+  const shown = formatAddress(value)
+
   const search = async () => {
-    if (opening) return
+    if (opening || disabled || readOnly) return
     setOpening(true)
     setLoadError(null)
     try {
@@ -56,12 +56,19 @@ export default function AddressField({
     }
   }
 
-  // 이미 있는 회사의 주소는 고칠 데가 아닙니다. 세 칸을 늘어놓는 대신 한 줄로 읽힙니다.
+  /** 커서가 주소 부분에 있을 때만 다시 고릅니다. 열었으면 true 입니다. */
+  const pickHere = (caret: number | null): boolean => {
+    if (!caretPicksAddress(value, caret)) return false
+    void search()
+    return true
+  }
+
+  // 이미 있는 회사의 주소는 고칠 데가 아닙니다.
   if (readOnly) {
     return (
       <div className={styles.root}>
         <input
-          value={formatAddress(value)}
+          value={shown}
           placeholder="등록된 주소가 없습니다"
           aria-label="주소"
           readOnly
@@ -73,41 +80,26 @@ export default function AddressField({
 
   return (
     <div className={styles.root}>
-      <div className={styles.line}>
-        <input
-          className={styles.postcode}
-          value={value.postcode}
-          placeholder="우편번호"
-          aria-label="우편번호"
-          readOnly
-          disabled={disabled}
-        />
-        <Button
-          type="button"
-          variant="outline"
-          disabled={disabled || opening}
-          onClick={() => void search()}
-        >
-          주소 검색
-        </Button>
-      </div>
-
       <input
-        value={value.address}
-        placeholder={disabled ? '회사를 먼저 고르세요' : '주소 검색을 눌러 주소를 고르세요'}
+        value={shown}
+        placeholder={disabled ? '회사를 먼저 고르세요' : '눌러서 주소를 고르세요'}
         aria-label="주소"
-        readOnly
+        aria-describedby="address-field-hint"
+        maxLength={800}
         disabled={disabled}
-      />
-
-      <input
-        value={value.addressDetail}
-        placeholder="상세주소 (동·층·호수)"
-        aria-label="상세주소"
-        maxLength={254}
-        // 주소를 고르기 전에는 어디의 몇 층인지 말할 데가 없습니다.
-        disabled={disabled || value.address === ''}
-        onChange={(event) => onChange({ ...value, addressDetail: event.target.value })}
+        onClick={(event) => pickHere(event.currentTarget.selectionStart)}
+        onKeyDown={(event) => {
+          // 주소 위에서 누른 Enter 는 다시 고르라는 뜻입니다. 상세주소 쪽이면 폼이 받습니다.
+          if (event.key !== 'Enter') return
+          if (pickHere(event.currentTarget.selectionStart)) event.preventDefault()
+        }}
+        onChange={(event) => {
+          // 고른 주소가 그대로 남아 있을 때만 뒤에 붙은 만큼을 상세주소로 받습니다.
+          // 앞부분을 지웠으면 다시 고르겠다는 뜻이라 값을 망가뜨리지 않고 창을 엽니다.
+          const next = readAddressLine(value, event.target.value)
+          if (next === null) void search()
+          else onChange(next)
+        }}
       />
 
       {loadError !== null && (
@@ -117,11 +109,4 @@ export default function AddressField({
       )}
     </div>
   )
-}
-
-/** 읽기 전용으로 보여 줄 한 줄. 우편번호는 괄호에 넣습니다. */
-function formatAddress({ postcode, address, addressDetail }: AddressValue): string {
-  if (address === '') return ''
-  const head = postcode === '' ? address : `(${postcode}) ${address}`
-  return addressDetail === '' ? head : `${head} ${addressDetail}`
 }

--- a/frontend/src/components/AddressField/addressLine.ts
+++ b/frontend/src/components/AddressField/addressLine.ts
@@ -1,0 +1,45 @@
+// 한 줄로 보여 주는 주소를 만들고 되읽는 규칙입니다.
+//
+// 칸이 하나라 고른 주소와 사람이 적은 상세주소가 같은 줄에 섞입니다. 경계는 `head`
+// 하나이고, 그 앞은 우편번호 창이 정한 값이라 사람이 고칠 수 없습니다.
+
+export interface AddressValue {
+  postcode: string
+  address: string
+  addressDetail: string
+}
+
+/** 사람이 고친 부분과 고른 부분의 경계. 우편번호는 괄호에 넣습니다. */
+export function addressHead({ postcode, address }: AddressValue): string {
+  if (address === '') return ''
+  return postcode === '' ? address : `(${postcode}) ${address}`
+}
+
+/** 한 줄로 읽히는 주소 전체. 상세주소는 뒤에 이어 붙습니다. */
+export function formatAddress(value: AddressValue): string {
+  const head = addressHead(value)
+  if (head === '') return ''
+  return value.addressDetail === '' ? head : `${head} ${value.addressDetail}`
+}
+
+/**
+ * 한 줄을 고쳐 친 결과를 되읽습니다.
+ *
+ * 고른 주소가 그대로 남아 있으면 뒤에 붙은 만큼이 상세주소입니다. 주소가 아직 없거나
+ * 앞부분이 지워졌으면 다시 고르겠다는 뜻이라 `null` 입니다 — 부르는 쪽이 우편번호 창을
+ * 엽니다. 값을 반쯤 지워진 채로 두지 않습니다.
+ */
+export function readAddressLine(value: AddressValue, typed: string): AddressValue | null {
+  const head = addressHead(value)
+  if (head === '' || !typed.startsWith(head)) return null
+  return { ...value, addressDetail: typed.slice(head.length).trimStart() }
+}
+
+/**
+ * 커서가 그 자리에서 무엇을 뜻하는지. 주소 부분 안이면 다시 고르는 것이고, 줄 끝이면
+ * 상세주소를 적으려는 것입니다. 아직 주소가 없으면 어디를 눌러도 고르는 자리입니다.
+ */
+export function caretPicksAddress(value: AddressValue, caret: number | null): boolean {
+  const head = addressHead(value)
+  return head === '' || caret === null || caret < head.length
+}

--- a/frontend/src/components/Modal/Modal.module.scss
+++ b/frontend/src/components/Modal/Modal.module.scss
@@ -100,12 +100,15 @@
  */
 .isFlush {
   display: flex;
+  // 안내문을 본문 맨 위에 한 줄로 얹을 수 있게 세로로 쌓습니다.
+  flex-direction: column;
   overflow: hidden;
   padding: 0;
 
   > * {
     flex: 1;
     min-width: 0;
+    min-height: 0;
   }
 }
 

--- a/frontend/src/pages/Customers/Customers.tsx
+++ b/frontend/src/pages/Customers/Customers.tsx
@@ -391,7 +391,7 @@ export default function Customers() {
               ? { postcode: '', address: cardDraft.address.trim(), addressDetail: '' }
               : licenseDraft?.address.trim()
                 ? { postcode: '', address: licenseDraft.address.trim(), addressDetail: '' }
-              : undefined
+                : undefined
           }
         />
       )}

--- a/frontend/src/pages/Customers/components/BusinessCardModal/BusinessCardModal.module.scss
+++ b/frontend/src/pages/Customers/components/BusinessCardModal/BusinessCardModal.module.scss
@@ -3,8 +3,9 @@
  * 같아야 해서, 명함 비율(91×55mm)은 이 칸이 아니라 아래 사진이 이어받습니다.
  */
 .drop {
-  display: grid;
-  place-items: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 100%;
   height: var(--dropzone-h);
   overflow: hidden;
@@ -29,6 +30,12 @@
   // 전역 button:active 의 축소가 사진 위에서는 흔들림으로 보입니다.
   &:active {
     transform: none;
+  }
+
+  // 사진이 놓이면 남는 여백은 검게 비워 사진 경계가 또렷하게 보입니다.
+  &:has(img),
+  &:hover:not(:disabled):has(img) {
+    background: #111;
   }
 }
 
@@ -57,15 +64,14 @@
 }
 
 /*
- * 사진이 그대로 액자가 되어, 잘못 찍힌 각도나 잘린 가장자리가 등록을 누르기 전에
- * 눈에 띕니다. 명함 비율은 여기 있으므로 칸의 남는 좌우는 배경으로 비웁니다.
+ * 찍은 사진 전체가 보여야 잘못된 각도나 잘린 가장자리를 등록 전에 알아챕니다.
+ * 비율은 원본을 따르고, 칸의 남는 자리는 배경으로 비웁니다.
  */
 .shot {
   display: block;
-  width: auto;
-  height: 100%;
-  aspect-ratio: 91 / 55;
-  object-fit: cover;
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
 }
 
 .file {

--- a/frontend/src/pages/Customers/components/BusinessCardModal/BusinessCardModal.tsx
+++ b/frontend/src/pages/Customers/components/BusinessCardModal/BusinessCardModal.tsx
@@ -103,6 +103,9 @@ export default function BusinessCardModal({
     if (!reading) onClose()
   }
 
+  // 읽다 실패한 뒤에도 사진은 그대로 있습니다. 같은 버튼이 다시 읽는 버튼이 됩니다.
+  const failed = image !== null && (error !== null || unavailable)
+
   // 읽는 동안에는 사용자가 손댈 것이 없습니다. 미리보기와 눌리지 않는 버튼까지
   // 함께 두면 화면만 길어지므로, 어디까지 왔는지 하나만 남깁니다.
   if (reading && progress) {
@@ -120,14 +123,9 @@ export default function BusinessCardModal({
       onClose={close}
       size="lg"
       footer={
-        <>
-          <Button type="button" variant="outline" onClick={close}>
-            취소
-          </Button>
-          <Button type="button" disabled={image === null} onClick={read}>
-            명함 읽기
-          </Button>
-        </>
+        <Button type="button" disabled={image === null} onClick={read}>
+          {failed ? '다시 시도' : '다음'}
+        </Button>
       }
     >
       <input

--- a/frontend/src/pages/Customers/components/BusinessLicenseModal/BusinessLicenseModal.tsx
+++ b/frontend/src/pages/Customers/components/BusinessLicenseModal/BusinessLicenseModal.tsx
@@ -97,6 +97,9 @@ export default function BusinessLicenseModal({ onClose, onDrafted }: Props) {
     if (!reading) onClose()
   }
 
+  // 읽다 실패한 뒤에도 파일은 그대로 있습니다. 같은 버튼이 다시 읽는 버튼이 됩니다.
+  const failed = file !== null && (error !== null || unavailable)
+
   // 읽는 동안에는 사용자가 손댈 것이 없습니다. 파일 줄과 미리보기, 눌리지 않는 버튼까지
   // 함께 두면 화면만 길어지므로, 어디까지 왔는지 하나만 남깁니다.
   if (reading && progress) {
@@ -114,14 +117,9 @@ export default function BusinessLicenseModal({ onClose, onDrafted }: Props) {
       onClose={close}
       size="lg"
       footer={
-        <>
-          <Button type="button" variant="outline" onClick={close}>
-            취소
-          </Button>
-          <Button type="button" disabled={file === null} onClick={read}>
-            다음
-          </Button>
-        </>
+        <Button type="button" disabled={file === null} onClick={read}>
+          {failed ? '다시 시도' : '다음'}
+        </Button>
       }
     >
       <input

--- a/frontend/src/pages/Customers/components/CustomerDrawer/CustomerDrawer.tsx
+++ b/frontend/src/pages/Customers/components/CustomerDrawer/CustomerDrawer.tsx
@@ -6,10 +6,12 @@ import ImageLightbox from '@/components/ImageLightbox'
 import Popover from '@/components/Popover'
 import useCompanyDeals from '@/hooks/useCompanyDeals'
 import useCustomerAttachments from '@/pages/Customers/useCustomerAttachments'
-import type { Customer, CustomerAttachment } from '@/types'
+import useCustomerCompany from '@/pages/Customers/useCustomerCompany'
+import { regionLabel } from '@/shared/regionCodes'
+import type { Customer, CustomerAttachment, CustomerCompanyResponse } from '@/types'
 import { sizeLabel } from '@/utils/attachment'
 import { fmtDay, parseISO } from '@/utils/date'
-import { formatPhone } from '@/utils/format'
+import { formatBusinessNo, formatPhone } from '@/utils/format'
 
 import CustomerDeals from './CustomerDeals'
 import styles from './CustomerDrawer.module.scss'
@@ -38,6 +40,13 @@ function Block({ title, children }: BlockProps) {
 }
 
 const shown = (value: string | null | undefined): string => value || '—'
+
+/** 회사 주소 한 줄. 등록 폼에서 보던 것과 같은 모양입니다. */
+function companyAddress(company: CustomerCompanyResponse | null): string {
+  if (company === null || !company.address) return '—'
+  const head = company.postcode ? `(${company.postcode}) ${company.address}` : company.address
+  return company.address_detail ? `${head} ${company.address_detail}` : head
+}
 
 const KIND_LABEL: Record<CustomerAttachment['kind'], string> = {
   business_card: '명함',
@@ -104,6 +113,8 @@ export default function CustomerDrawer({ customer, canDelete, onEdit, onDelete, 
   const { deals, loading, error, reload } = useCompanyDeals(customer.companyId)
   // 명함은 이 사람의 것이고, 사업자등록증은 이 회사의 것입니다. 서버가 함께 줍니다.
   const attachments = useCustomerAttachments(customer.id)
+  // 사업자 등록번호와 주소는 회사에 붙어 있습니다. 고객 응답에는 들어 있지 않습니다.
+  const company = useCustomerCompany(customer.companyId)
 
   // 담당자가 여럿이면 상세에서는 전부 보여 줍니다. 좁은 표와 달리 자리가 있습니다.
   const ownerNames =
@@ -117,6 +128,7 @@ export default function CustomerDrawer({ customer, canDelete, onEdit, onDelete, 
     ['담당자', ownerNames.join(', ')],
     ['상태', customer.status],
     ['유입 경로', customer.source],
+    ['방문', customer.visited ? '방문' : '미방문'],
     ['등록일', fmtDay(parseISO(customer.created))],
   ]
 
@@ -196,6 +208,19 @@ export default function CustomerDrawer({ customer, canDelete, onEdit, onDelete, 
           <Block title="연락처">
             <dl className={styles.facts}>
               <div>
+                <dt>휴대폰</dt>
+                <dd>
+                  <a className={`${styles.mail} tnum`} href={`tel:${customer.phone}`}>
+                    {formatPhone(customer.phone)}
+                  </a>
+                </dd>
+              </div>
+              {/* 팩스는 거는 번호가 아니라 링크로 두지 않습니다. */}
+              <div>
+                <dt>팩스</dt>
+                <dd className="tnum">{customer.fax ? formatPhone(customer.fax) : '—'}</dd>
+              </div>
+              <div>
                 <dt>이메일</dt>
                 <dd>
                   {customer.email ? (
@@ -205,14 +230,6 @@ export default function CustomerDrawer({ customer, canDelete, onEdit, onDelete, 
                   ) : (
                     <span className={styles.muted}>등록된 이메일 없음</span>
                   )}
-                </dd>
-              </div>
-              <div>
-                <dt>전화</dt>
-                <dd>
-                  <a className={`${styles.mail} tnum`} href={`tel:${customer.phone}`}>
-                    {formatPhone(customer.phone)}
-                  </a>
                 </dd>
               </div>
             </dl>
@@ -225,8 +242,17 @@ export default function CustomerDrawer({ customer, canDelete, onEdit, onDelete, 
                 <dd>{customer.org}</dd>
               </div>
               <div>
-                <dt>지역 코드</dt>
-                <dd>{shown(customer.regionCode)}</dd>
+                <dt>사업자번호</dt>
+                <dd className="tnum">{shown(formatBusinessNo(company?.business_no))}</dd>
+              </div>
+              <div>
+                <dt>주소</dt>
+                <dd>{companyAddress(company)}</dd>
+              </div>
+              <div>
+                <dt>지역</dt>
+                {/* 화면에 보이는 건 코드가 아니라 "서울"입니다. */}
+                <dd>{regionLabel(customer.regionCode ?? null)}</dd>
               </div>
             </dl>
           </Block>

--- a/frontend/src/pages/Customers/components/CustomerFormModal/CustomerFormModal.module.scss
+++ b/frontend/src/pages/Customers/components/CustomerFormModal/CustomerFormModal.module.scss
@@ -144,6 +144,51 @@
   font-size: 11px;
 }
 
+/*
+ * 문서에서 읽어 채웠다는 안내. 사람이 한 번 읽으면 되는 말이라 닫을 수 있고, 닫아도
+ * 라벨 옆의 확인 필요 표시는 남습니다. 확인해야 할 자리는 안내문이 아니라 칸에 붙어
+ * 있어야 합니다.
+ */
+.ocrNotice {
+  display: flex;
+  align-items: center;
+  gap: var(--s2);
+  flex: none;
+  padding: var(--s2) var(--s5);
+  border-bottom: 1px solid var(--line);
+  background: var(--orange-tint);
+  color: var(--orange-ink);
+  font-size: 12px;
+  line-height: 1.5;
+
+  p {
+    flex: 1;
+    margin: 0;
+  }
+}
+
+.ocrIcon {
+  flex: none;
+  width: 15px;
+  height: 15px;
+  color: var(--orange);
+}
+
+.ocrClose {
+  flex: none;
+  padding: 0 4px;
+  border: 0;
+  background: none;
+  color: var(--muted);
+  font-size: 15px;
+  line-height: 1.2;
+  cursor: pointer;
+
+  &:hover {
+    color: var(--ink);
+  }
+}
+
 .field {
   @include form-field;
 }
@@ -153,14 +198,37 @@
 }
 
 .label {
+  // 라벨과 확인 필요 뱃지가 한 줄에 섭니다.
+  display: flex;
+  align-items: center;
+  gap: var(--s2);
   color: var(--ink-2);
   font-size: 12px;
   font-weight: 600;
 
   b {
-    margin-left: 3px;
+    margin-left: -3px;
     color: var(--red);
   }
+
+  // 라벨보다 작게 두어 뱃지가 아니라 라벨이 먼저 읽힙니다.
+  span:not(.hint) {
+    padding: 2px 4px;
+    border-radius: 4px;
+    font-size: 8px;
+    line-height: 1.4;
+  }
+}
+
+// 칸 아래가 아니라 라벨 끝에 붙는 사용법 한 줄. 라벨과 달리 읽고 지나가는 글입니다.
+.hint {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 400;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .error {

--- a/frontend/src/pages/Customers/components/CustomerFormModal/CustomerFormModal.tsx
+++ b/frontend/src/pages/Customers/components/CustomerFormModal/CustomerFormModal.tsx
@@ -6,10 +6,11 @@ import { useCurrentUser } from '@/auth/sessionContext'
 import AddressField, { type AddressValue } from '@/components/AddressField'
 import Button from '@/components/Button'
 import CompanyAutocomplete, { type CompanySelection } from '@/components/CompanyAutocomplete'
-import { ChevronLeftIcon } from '@/components/icons'
+import { ChevronRightIcon, InfoIcon } from '@/components/icons'
 import MemberMultiSelect from '@/components/MemberMultiSelect'
 import Modal from '@/components/Modal'
 import Select from '@/components/Select'
+import StatusBadge from '@/components/StatusBadge'
 import { SOURCE_OPTIONS } from '@/pages/Customers/contact'
 import type {
   Customer,
@@ -69,11 +70,12 @@ const EMPTY = {
   title: '',
   email: '',
   phone: '',
+  fax: '',
   memo: '',
 }
 
 type Draft = typeof EMPTY
-type ErrorKey = keyof Draft | 'company' | 'businessNo' | 'assignees'
+type ErrorKey = keyof Draft | 'company' | 'businessNo' | 'address' | 'assignees'
 type Errors = Partial<Record<ErrorKey, string>>
 
 interface Form {
@@ -99,6 +101,40 @@ function validate({ draft, company, businessNo, assigneeIds }: Form): Errors {
 }
 
 const optional = (value: string): string | null => value.trim() || null
+
+/**
+ * 문서에서 읽어 채운 칸들. 사람이 눈으로 확인해야 하는 자리라 뱃지를 답니다.
+ * 사람이 직접 친 값과 구분되지 않으면 검수 없이 저장되고, 그건 OCR 오차가 그대로
+ * 고객 정보가 된다는 뜻입니다.
+ */
+function filledByDocument(
+  initial: Partial<Draft> | undefined,
+  company: CompanySelection | undefined,
+  businessNo: string | undefined,
+  address: AddressValue | undefined,
+): Set<ErrorKey> {
+  const filled = new Set<ErrorKey>()
+  for (const [key, value] of Object.entries(initial ?? {})) {
+    if (typeof value === 'string' && value.trim() !== '') filled.add(key as ErrorKey)
+  }
+  if (company !== undefined) filled.add('company')
+  if (businessNo !== undefined && businessNo.trim() !== '') filled.add('businessNo')
+  if (address !== undefined && address.address.trim() !== '') filled.add('address')
+  return filled
+}
+
+/**
+ * 문서에서 읽지 못한 필수 칸. 저장을 눌러 보기 전에 어디가 비었는지 먼저 보여 줍니다.
+ * 백엔드 명함 서비스가 보는 세 항목(name·company_name·phone)과 같습니다.
+ */
+function missingRequired(form: Form): Errors {
+  const found = validate(form)
+  const initial: Errors = {}
+  for (const key of ['company', 'name', 'phone'] as const) {
+    if (found[key] !== undefined) initial[key] = found[key]
+  }
+  return initial
+}
 
 const companyName = (company: CompanySelection): string =>
   company.kind === 'existing' ? company.company.name : company.name
@@ -173,6 +209,7 @@ function customerDraft(customer: Customer): Draft {
     title: customer.title,
     email: customer.email,
     phone: customer.phone,
+    fax: customer.fax,
     memo: customer.memo,
   }
 }
@@ -197,6 +234,15 @@ export default function CustomerFormModal({
   const sourceFile = archiveImage ?? archiveLicense
   // 원본이 있으면 검수 화면이다. 열어 둔 채로 시작하고, 입력 공간이 필요하면 접는다.
   const [sourceOpen, setSourceOpen] = useState(true)
+  const reviewing = sourceFile !== undefined
+  // 자동 입력 안내. 한 번 읽으면 자리만 차지하므로 닫을 수 있다.
+  const [noticeOpen, setNoticeOpen] = useState(true)
+  // 문서에서 채워진 칸. 사람이 고치면 확인이 끝난 것이라 그 칸만 빠진다.
+  const [fromDocument, setFromDocument] = useState<Set<ErrorKey>>(() =>
+    reviewing
+      ? filledByDocument(initial, initialCompany, initialBusinessNo, initialAddress)
+      : new Set(),
+  )
 
   const [draft, setDraft] = useState<Draft>(
     customer ? customerDraft(customer) : { ...EMPTY, ...initial },
@@ -224,7 +270,16 @@ export default function CustomerFormModal({
     const owners = customer.owners?.map((owner) => owner.id) ?? []
     return owners.length > 0 ? owners : [customer.ownerMemberId ?? memberId]
   })
-  const [errors, setErrors] = useState<Errors>({})
+  const [errors, setErrors] = useState<Errors>(() =>
+    reviewing && customer === undefined
+      ? missingRequired({
+          draft: { ...EMPTY, ...initial },
+          company: initialCompany ?? null,
+          businessNo: initialBusinessNo ?? '',
+          assigneeIds: [],
+        })
+      : {},
+  )
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
   /*
@@ -272,9 +327,20 @@ export default function CustomerFormModal({
     setSubmitError(null)
   }
 
+  /** 사람이 그 칸을 손댔습니다. 더는 확인이 필요한 값이 아닙니다. */
+  const confirmed = (key: ErrorKey) => {
+    setFromDocument((previous) => {
+      if (!previous.has(key)) return previous
+      const next = new Set(previous)
+      next.delete(key)
+      return next
+    })
+  }
+
   const set = (key: keyof Draft, value: string) => {
     setDraft((previous) => ({ ...previous, [key]: value }))
     clearError(key)
+    confirmed(key)
   }
 
   const pickCompany = (selection: CompanySelection | null) => {
@@ -293,6 +359,7 @@ export default function CustomerFormModal({
     }
     clearError('company')
     clearError('businessNo')
+    confirmed('company')
   }
 
   const submit = async () => {
@@ -316,6 +383,7 @@ export default function CustomerFormModal({
         job_title: optional(draft.title),
         email: optional(draft.email),
         phone: phoneDigits(draft.phone),
+        fax: phoneDigits(draft.fax) || null,
         source_code: sourceCode === '' ? null : sourceCode,
         memo: optional(draft.memo),
         visited,
@@ -433,6 +501,20 @@ export default function CustomerFormModal({
         </>
       }
     >
+      {reviewing && noticeOpen && (
+        <div className={styles.ocrNotice} role="status">
+          <InfoIcon className={styles.ocrIcon} />
+          <p>문서에서 정보를 자동으로 입력했습니다. 자동입력 표시가 붙은 항목을 확인해주세요.</p>
+          <button
+            type="button"
+            className={styles.ocrClose}
+            aria-label="안내 닫기"
+            onClick={() => setNoticeOpen(false)}
+          >
+            ×
+          </button>
+        </div>
+      )}
       <Split
         source={
           sourceFile && (
@@ -456,7 +538,13 @@ export default function CustomerFormModal({
           </div>
         )}
         <div className={styles.grid} aria-busy={submitting}>
-          <Field label="회사" required error={errors.company} htmlFor={false}>
+          <Field
+            label="회사"
+            required
+            error={errors.company}
+            check={fromDocument.has('company')}
+            htmlFor={false}
+          >
             <CompanyAutocomplete
               value={company}
               onChange={pickCompany}
@@ -466,9 +554,14 @@ export default function CustomerFormModal({
             />
           </Field>
 
-          <Field label="사업자 등록번호" error={errors.businessNo}>
+          <Field
+            label="사업자 등록번호"
+            error={errors.businessNo}
+            check={fromDocument.has('businessNo')}
+          >
             <input
               value={maskBusinessNo(businessNo)}
+              aria-invalid={errors.businessNo !== undefined}
               placeholder="123-45-67890"
               maxLength={12}
               // 이미 있는 회사는 그 회사의 값을 보여 주기만 합니다.
@@ -478,42 +571,55 @@ export default function CustomerFormModal({
               onChange={(event) => {
                 setBusinessNo(businessNoDigits(event.target.value))
                 clearError('businessNo')
+                confirmed('businessNo')
               }}
             />
           </Field>
 
           {/* 주소는 회사에 붙는 값입니다. 이미 있는 회사면 그 회사의 주소를 보여 주기만 합니다. */}
-          <Field label="주소" wide htmlFor={false}>
+          <Field
+            label="주소"
+            wide
+            check={fromDocument.has('address')}
+            hint="앞부분을 누르면 주소를 찾고, 뒤에 이어 쓰면 상세주소가 됩니다."
+            hintId="address-field-hint"
+            htmlFor={false}
+          >
             <AddressField
               value={address}
-              onChange={setAddress}
+              onChange={(next) => {
+                setAddress(next)
+                confirmed('address')
+              }}
               readOnly={company?.kind === 'existing'}
               // 등록증에서 읽어 온 주소가 있으면 회사를 고르기 전에도 다시 고를 수 있습니다.
               disabled={submitting || (company === null && address.address === '')}
             />
           </Field>
 
-          <Field label="이름" required error={errors.name}>
+          <Field label="이름" required error={errors.name} check={fromDocument.has('name')}>
             <input
               value={draft.name}
               maxLength={254}
+              aria-invalid={errors.name !== undefined}
               disabled={submitting}
               onChange={(event) => set('name', event.target.value)}
             />
           </Field>
 
-          <Field label="전화" required error={errors.phone}>
+          <Field label="휴대폰" required error={errors.phone} check={fromDocument.has('phone')}>
             <input
               type="tel"
               value={formatPhone(draft.phone)}
-              placeholder="02-000-0000"
+              placeholder="010-0000-0000"
               maxLength={50}
+              aria-invalid={errors.phone !== undefined}
               disabled={submitting}
               onChange={(event) => set('phone', phoneDigits(event.target.value))}
             />
           </Field>
 
-          <Field label="부서">
+          <Field label="부서" check={fromDocument.has('dept')}>
             <input
               value={draft.dept}
               placeholder="부서 이름"
@@ -523,7 +629,7 @@ export default function CustomerFormModal({
             />
           </Field>
 
-          <Field label="직함">
+          <Field label="직함" check={fromDocument.has('title')}>
             <input
               value={draft.title}
               placeholder="과장"
@@ -533,14 +639,26 @@ export default function CustomerFormModal({
             />
           </Field>
 
-          <Field label="이메일" error={errors.email}>
+          <Field label="이메일" error={errors.email} check={fromDocument.has('email')}>
             <input
               type="email"
               value={draft.email}
               placeholder="name@company.com"
               maxLength={254}
+              aria-invalid={errors.email !== undefined}
               disabled={submitting}
               onChange={(event) => set('email', event.target.value)}
+            />
+          </Field>
+
+          <Field label="팩스" check={fromDocument.has('fax')}>
+            <input
+              type="tel"
+              value={formatPhone(draft.fax)}
+              placeholder="02-000-0000"
+              maxLength={50}
+              disabled={submitting}
+              onChange={(event) => set('fax', phoneDigits(event.target.value))}
             />
           </Field>
 
@@ -649,7 +767,7 @@ function Split({ source, open, onReopen, children }: SplitProps) {
           <div className={styles.paneTop}>
             <button type="button" className={styles.reopen} onClick={onReopen}>
               원본 보기
-              <ChevronLeftIcon width={14} height={14} />
+              <ChevronRightIcon width={14} height={14} />
             </button>
           </div>
         )}
@@ -667,6 +785,12 @@ interface FieldProps {
   label: string
   required?: boolean
   error?: string
+  /** 문서에서 읽어 온 값. 사람이 확인할 때까지 라벨 옆에 표시합니다. */
+  check?: boolean
+  /** 칸을 어떻게 쓰는지 한 줄로. 칸 아래가 아니라 라벨 끝에 붙습니다. */
+  hint?: string
+  /** 입력이 aria-describedby 로 가리키는 힌트의 id. */
+  hintId?: string
   wide?: boolean
   /**
    * label 로 감쌀지. 검색해서 고르는 입력은 안에 버튼이 있어, label 을 누르면 버튼이
@@ -676,13 +800,29 @@ interface FieldProps {
   children: React.ReactNode
 }
 
-function Field({ label, required, error, wide, htmlFor = true, children }: FieldProps) {
+function Field({
+  label,
+  required,
+  error,
+  check,
+  hint,
+  hintId,
+  wide,
+  htmlFor = true,
+  children,
+}: FieldProps) {
   const Wrapper = htmlFor ? 'label' : 'div'
   return (
     <Wrapper className={`${styles.field} ${wide ? styles.isWide : ''}`}>
       <span className={styles.label}>
         {label}
         {required && <b aria-hidden="true">*</b>}
+        {check && <StatusBadge label="자동입력" tone="orange" />}
+        {hint && (
+          <span id={hintId} className={styles.hint}>
+            {hint}
+          </span>
+        )}
       </span>
       {children}
       {error && <span className={styles.error}>{error}</span>}

--- a/frontend/src/pages/Customers/components/ImportModal/ImportModal.tsx
+++ b/frontend/src/pages/Customers/components/ImportModal/ImportModal.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react'
 
 import { client } from '@/api/client'
 import { errorMessage } from '@/api/errorMessage'
+import Button from '@/components/Button'
 import { UploadIcon } from '@/components/icons'
 import Modal from '@/components/Modal'
 import type { CustomerContactBulkItem, CustomerContactBulkResult } from '@/types'
@@ -70,7 +71,7 @@ interface ImportModalProps {
 
 export default function ImportModal({ onClose, onImported }: ImportModalProps) {
   const fileRef = useRef<HTMLInputElement>(null)
-  const [filename, setFilename] = useState<string | null>(null)
+  const [file, setFile] = useState<File | null>(null)
   const [count, setCount] = useState(0)
   const [error, setError] = useState<string | null>(null)
   const [result, setResult] = useState<CustomerContactBulkResult | null>(null)
@@ -97,16 +98,15 @@ export default function ImportModal({ onClose, onImported }: ImportModalProps) {
   }
 
   /*
-   * 파일을 고르면 그대로 보냅니다. 보내기 전에 한 번 더 보여 줘도 사용자가 손볼 것은
+   * 고른 파일을 읽어 그대로 보냅니다. 보내기 전에 한 번 더 보여 줘도 사용자가 손볼 것은
    * 없고, 몇 명이 왜 빠졌는지는 등록한 뒤 결과에 남습니다.
    * 여기서 막는 것은 아예 보낼 수 없는 파일뿐입니다.
    */
-  const readFile = async (file: File) => {
-    if (parsing || sending) return
+  const readFile = async () => {
+    if (file === null || parsing || sending) return
 
     setParsing(true)
     setError(null)
-    setFilename(file.name)
     setCount(0)
     setResult(null)
 
@@ -172,13 +172,27 @@ export default function ImportModal({ onClose, onImported }: ImportModalProps) {
           ? '일부 등록 완료'
           : '등록 완료'
 
+  const picking = result === null && !parsing && !sending
+
   return (
-    <Modal title={heading} description="" onClose={close} size="lg">
+    <Modal
+      title={heading}
+      description=""
+      onClose={close}
+      size="lg"
+      footer={
+        picking && (
+          <Button type="button" disabled={file === null} onClick={() => void readFile()}>
+            {error === null ? '다음' : '다시 시도'}
+          </Button>
+        )
+      }
+    >
       {/*
         고르는 자리는 고를 때만 둡니다. 읽는 중에는 누를 수 없고 등록이 끝나면 같은 파일을
         다시 올릴 일이 없어, 남겨 두면 아직 할 일이 있는 것처럼 읽힙니다.
       */}
-      {result === null && !parsing && !sending && (
+      {picking && (
         <>
           <input
             ref={fileRef}
@@ -186,15 +200,18 @@ export default function ImportModal({ onClose, onImported }: ImportModalProps) {
             accept=".csv,text/csv"
             className="sr-only"
             onChange={(event) => {
-              const file = event.target.files?.[0]
-              if (file) void readFile(file)
+              const next = event.target.files?.[0]
+              if (next) {
+                setFile(next)
+                setError(null)
+              }
               // 같은 파일을 고쳐서 다시 고르면 change 가 뜨지 않습니다.
               event.target.value = ''
             }}
           />
           <button type="button" className={styles.drop} onClick={() => fileRef.current?.click()}>
             <UploadIcon width={22} height={22} strokeWidth={1.5} />
-            <strong>{filename ?? 'CSV 파일 선택'}</strong>
+            <strong>{file?.name ?? 'CSV 파일 선택'}</strong>
           </button>
           <button type="button" className={styles.template} onClick={downloadTemplate}>
             엑셀 템플릿 다운로드

--- a/frontend/src/pages/Customers/components/SourceDocumentViewer/SourceDocumentViewer.tsx
+++ b/frontend/src/pages/Customers/components/SourceDocumentViewer/SourceDocumentViewer.tsx
@@ -232,7 +232,7 @@ export default function SourceDocumentViewer({
           aria-label={fullScreen ? '원본 문서 닫기' : '원본 문서 접기'}
           onClick={onCollapse}
         >
-          {fullScreen ? <CloseIcon /> : <ChevronRightIcon />}
+          {fullScreen ? <CloseIcon /> : <ChevronLeftIcon />}
         </Button>
       </header>
 

--- a/frontend/src/pages/Customers/contact.ts
+++ b/frontend/src/pages/Customers/contact.ts
@@ -59,6 +59,7 @@ export function toCustomer(contact: CustomerContactResponse): Customer {
     title: contact.job_title ?? '',
     email: contact.email ?? '',
     phone: contact.phone,
+    fax: contact.fax ?? '',
     owner: contact.owner_display_name,
     source: toSourceLabel(contact.source_code),
     sourceCode: toSourceCode(contact.source_code),

--- a/frontend/src/pages/Customers/useCustomerCompany.ts
+++ b/frontend/src/pages/Customers/useCustomerCompany.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react'
+
+import { client } from '@/api/client'
+import type { CustomerCompanyResponse } from '@/types'
+
+/**
+ * 고객이 속한 회사. 사업자 등록번호와 주소는 사람이 아니라 회사에 붙어 있어
+ * 고객 목록 응답에는 들어 있지 않습니다.
+ *
+ * 못 받아 오면 null 입니다. 회사 정보가 없다고 상세를 못 여는 쪽이 더 나쁩니다.
+ */
+export default function useCustomerCompany(
+  companyId: string | undefined,
+): CustomerCompanyResponse | null {
+  const [company, setCompany] = useState<CustomerCompanyResponse | null>(null)
+
+  useEffect(() => {
+    setCompany(null)
+    if (companyId === undefined) return
+    const controller = new AbortController()
+    void client
+      .get<CustomerCompanyResponse>(`/customer-companies/${companyId}`, {
+        signal: controller.signal,
+      })
+      .then(({ data }) => {
+        if (!controller.signal.aborted) setCompany(data)
+      })
+      .catch(() => {
+        // 사업자번호·주소만 비고 나머지 상세는 그대로 열립니다.
+      })
+
+    return () => controller.abort()
+  }, [companyId])
+
+  return company
+}

--- a/frontend/src/styles/_mixins.scss
+++ b/frontend/src/styles/_mixins.scss
@@ -77,6 +77,12 @@
       border-color var(--t-fast) var(--ease-out),
       box-shadow var(--t-fast) var(--ease-out);
 
+    // 아직 채우지 않은 필수 칸. 문구를 읽기 전에 어느 칸인지 눈에 먼저 들어옵니다.
+    &[aria-invalid='true'] {
+      border-color: var(--red);
+    }
+
+    // 지금 치고 있는 칸은 파란 테두리가 이깁니다. 고치는 중에 빨간 칸을 볼 이유가 없습니다.
     &:focus {
       border-color: var(--blue);
       box-shadow: 0 0 0 3px var(--blue-ring);

--- a/frontend/src/types/customers.ts
+++ b/frontend/src/types/customers.ts
@@ -29,6 +29,8 @@ export interface Customer {
   title: string
   email: string
   phone: string
+  /** 팩스. 선택 항목이라 없을 수 있습니다. */
+  fax: string
   /** 담당 영업 */
   owner: string
   source: CustomerSource
@@ -67,6 +69,7 @@ export interface CustomerContactResponse {
   job_title: string | null
   email: string | null
   phone: string
+  fax: string | null
   /** 예전 데이터에는 아래 목록 밖의 코드도 있어 문자열을 그대로 받습니다. */
   status_code: CustomerStatusCode | string | null
   source_code: CustomerSourceCode | string | null
@@ -118,6 +121,7 @@ export interface CustomerContactCreateRequest {
   job_title: string | null
   email: string | null
   phone: string
+  fax: string | null
   status_code: CustomerStatusCode | null
   source_code: CustomerSourceCode | null
   memo: string | null

--- a/frontend/tests/addressLine.test.mjs
+++ b/frontend/tests/addressLine.test.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  addressHead,
+  caretPicksAddress,
+  formatAddress,
+  readAddressLine,
+} from '../src/components/AddressField/addressLine.ts'
+
+const picked = { postcode: '81020', address: '합성시 관계구 세일즈로 20', addressDetail: '' }
+const scanned = { postcode: '', address: '서울시 서초구 남부순환로 339길 23', addressDetail: '' }
+const empty = { postcode: '', address: '', addressDetail: '' }
+
+test('고른 주소는 우편번호를 괄호에 넣어 한 줄이 된다', () => {
+  assert.equal(formatAddress(picked), '(81020) 합성시 관계구 세일즈로 20')
+  assert.equal(formatAddress({ ...picked, addressDetail: '3층' }), '(81020) 합성시 관계구 세일즈로 20 3층')
+})
+
+test('문서에서 읽어 온 주소는 우편번호가 없어 주소만 선다', () => {
+  assert.equal(formatAddress(scanned), '서울시 서초구 남부순환로 339길 23')
+  assert.equal(formatAddress(empty), '')
+})
+
+test('줄 끝에 이어 친 만큼이 상세주소가 된다', () => {
+  const typed = `${formatAddress(picked)} 3층`
+  assert.deepEqual(readAddressLine(picked, typed), { ...picked, addressDetail: '3층' })
+})
+
+test('상세주소를 지워도 고른 주소는 남는다', () => {
+  const filled = { ...picked, addressDetail: '3층' }
+  assert.deepEqual(readAddressLine(filled, addressHead(filled)), { ...picked, addressDetail: '' })
+})
+
+test('고른 주소를 건드리면 값을 고치지 않고 다시 고르게 한다', () => {
+  assert.equal(readAddressLine(picked, '(81020) 합성시 관계'), null)
+  assert.equal(readAddressLine(picked, ''), null)
+  // 주소가 없으면 상세주소만 적을 데도 없다.
+  assert.equal(readAddressLine(empty, '3층'), null)
+})
+
+test('커서가 주소 안이면 다시 고르고, 줄 끝이면 상세주소를 적는다', () => {
+  const head = addressHead(picked).length
+  assert.equal(caretPicksAddress(picked, 0), true)
+  assert.equal(caretPicksAddress(picked, head - 1), true)
+  assert.equal(caretPicksAddress(picked, head), false)
+  assert.equal(caretPicksAddress(picked, head + 2), false)
+  // 아직 아무것도 없으면 어디를 눌러도 고르는 자리다.
+  assert.equal(caretPicksAddress(empty, 0), true)
+})


### PR DESCRIPTION
## 요약
고객 현황 등록·상세 흐름을 개선했습니다.

- OCR 인식 실패 시 필수값 입력을 유도하는 UI 추가
- 최종 등록 전 OCR 자동입력 정보 확인 안내 추가
- 휴대폰번호·팩스 입력 및 상세 표시 추가
- 고객 회사 주소·지역 표시와 주소 입력 흐름 개선

Refs #171

## 체크리스트
- [x] OCR 인식 실패시 필수값 입력 유도하는 UI 추가
- [x] 최종 등록 전 입력 OCR 정보 확인 문구 추가 (인식이 안 됐을 때 가이드)
- [x] 팩스와 휴대폰번호 입력란 추가

## 검증
- [x] Frontend lint
- [x] Frontend Prettier format check
- [x] Frontend tests (111 passed)
- [x] Frontend build
- [x] Backend ruff
- [ ] Backend pytest: 1,423 passed / 8 skipped / 1 failed (Supabase 통합 테스트 DNS 환경 문제)
- [ ] Backend CI 전체 의존성 설치: macOS x86_64에서 onnxruntime 1.29.0 호환 wheel 없음

## 화면
![고객 현황 관련 수정](https://github.com/user-attachments/assets/af9b0c77-cbed-477d-9299-1605d8415345)
![고객 현황 관련 수정](https://github.com/user-attachments/assets/66fd9ca4-c2cc-4475-acb7-cabdaea79927)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 고객 연락처에 선택 입력 가능한 팩스 번호를 추가했습니다.
  - 주소 입력을 한 줄 형식으로 개선하고, 주소에 따라 지역을 자동 설정합니다.
  - 고객 상세 화면에 사업자 정보, 지역, 휴대폰·팩스, 방문 여부를 표시합니다.
  - 문서 OCR 자동 입력 항목과 필수값 확인 안내를 제공합니다.
- **개선**
  - 사업자등록증·명함 OCR 실패 시 선택한 파일로 재시도할 수 있습니다.
  - 고객 일괄 가져오기는 파일 선택 후 확인 버튼을 눌러 진행하도록 변경했습니다.
  - 주소 및 필수 입력 오류를 더 명확하게 표시합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->