### PR TITLE
미팅 보고서 작성 UI 개선

### DIFF
--- a/frontend/src/components/AttachmentPanel/AttachmentPanel.module.scss
+++ b/frontend/src/components/AttachmentPanel/AttachmentPanel.module.scss
@@ -1,4 +1,5 @@
 .note {
+  margin-bottom: var(--s3);
   font-size: 12px;
   line-height: 1.6;
   color: var(--muted);
@@ -7,20 +8,28 @@
 .actions {
   display: flex;
   gap: var(--s2);
-  margin: var(--s3) 0;
   flex-wrap: wrap;
 }
 
+/*
+ * 파일을 넣는 자리는 버튼이 아니라 면입니다. 빈 칸에 작은 버튼 하나만 얹으면
+ * 남은 자리가 무엇에 쓰는 곳인지 말하지 않습니다 — 자리 전체가 그 말을 합니다.
+ */
 .action {
-  display: inline-flex;
+  display: flex;
+  flex: 1;
   align-items: center;
+  justify-content: center;
   gap: 6px;
-  padding: 8px var(--s3);
+  min-width: 0;
+  min-height: 72px;
+  padding: var(--s3);
   border: 1px dashed var(--line-2);
   border-radius: var(--r-sm);
   background: var(--surface);
   font-size: 13px;
   font-weight: 600;
+  color: var(--ink-2);
   cursor: pointer;
   transition:
     border-color var(--t-fast),
@@ -29,7 +38,22 @@
   &:hover {
     border-color: var(--blue);
     background: var(--blue-tint);
+    color: var(--blue);
   }
+
+  &:focus-visible {
+    outline: 2px solid var(--blue);
+    outline-offset: 2px;
+  }
+}
+
+/* 아직 넣은 것이 없으면 남은 높이를 다 씁니다. 목록이 생기면 제 키만 씁니다. */
+.actions:only-child {
+  flex: 1;
+}
+
+.actions + .list {
+  margin-top: var(--s3);
 }
 
 .list {

--- a/frontend/src/components/AttachmentPanel/AttachmentPanel.tsx
+++ b/frontend/src/components/AttachmentPanel/AttachmentPanel.tsx
@@ -171,8 +171,9 @@ export default function AttachmentPanel({
         </>
       )}
 
+      {/* 작성 화면에서는 빈 상태를 말하지 않습니다. 바로 위 '파일 추가'가 그 자리를 설명합니다. */}
       {attachments.length === 0 ? (
-        <p className={styles.empty}>{readOnly ? '첨부 없음' : '첨부한 자료가 없습니다.'}</p>
+        readOnly && <p className={styles.empty}>첨부 없음</p>
       ) : (
         <ul className={styles.list}>
           {attachments.map((item) => (

--- a/frontend/src/components/layout/AppShell/AppShell.module.scss
+++ b/frontend/src/components/layout/AppShell/AppShell.module.scss
@@ -32,7 +32,7 @@
 .content {
   max-width: var(--content-max);
   margin: 0 auto;
-  padding: var(--s6) var(--s6) var(--s8);
+  padding: var(--s6);
 
   @include md {
     padding: var(--s4) var(--s4) var(--s6);

--- a/frontend/src/pages/Daily/Daily.module.scss
+++ b/frontend/src/pages/Daily/Daily.module.scss
@@ -80,6 +80,7 @@
 .markDone,
 .markPending,
 .markDraft,
+.markRejected,
 .markMissing {
   width: 6px;
   height: 6px;
@@ -91,15 +92,19 @@
 }
 
 .markPending {
-  background: var(--blue);
+  background: var(--orange);
 }
 
 .markDraft {
-  background: var(--muted-2);
+  background: var(--blue);
+}
+
+.markRejected {
+  background: var(--red);
 }
 
 .markMissing {
-  background: var(--orange);
+  background: var(--muted-2);
 }
 
 .isOnBlue {

--- a/frontend/src/pages/Daily/Daily.tsx
+++ b/frontend/src/pages/Daily/Daily.tsx
@@ -159,7 +159,7 @@ export default function Daily() {
       if (row?.status === '확정') return styles.markDone
       if (row?.status === '검토 대기') return styles.markPending
       if (row?.status === '작성중' || row?.status === '수정중') return styles.markDraft
-      if (row?.status === '반려') return styles.markMissing
+      if (row?.status === '반려') return styles.markRejected
       // 주간·월간·미팅은 매일 내는 보고가 아니므로 미작성으로 보지 않습니다.
       if (period !== 'all' && period !== 'daily') return null
       const past = dateISO < TODAY_ISO
@@ -285,16 +285,19 @@ export default function Daily() {
         {!showMonth && (
           <p className={styles.legend}>
             <span>
-              <i className={styles.markDone} /> 확정
+              <i className={styles.markDraft} /> 작성중
             </span>
             <span>
               <i className={styles.markPending} /> 검토 대기
             </span>
             <span>
-              <i className={styles.markDraft} /> 작성중
+              <i className={styles.markDone} /> 확정
             </span>
             <span>
-              <i className={styles.markMissing} /> 미작성 · 반려
+              <i className={styles.markRejected} /> 반려
+            </span>
+            <span>
+              <i className={styles.markMissing} /> 미작성
             </span>
           </p>
         )}

--- a/frontend/src/pages/Daily/MeetingPick.module.scss
+++ b/frontend/src/pages/Daily/MeetingPick.module.scss
@@ -61,11 +61,20 @@
   }
 }
 
-.selectedDot {
-  width: 6px;
-  height: 6px;
+.markDot {
+  width: 5px;
+  height: 5px;
   border-radius: 50%;
   background: var(--blue);
+}
+
+// 점으로 다 세우지 못한 나머지 건수. 점보다 앞서 읽히면 안 되므로 흐리게 둡니다.
+.more {
+  margin-left: 1px;
+  font-size: 10px;
+  line-height: 1;
+  font-weight: 600;
+  color: var(--muted);
 }
 
 .filters {
@@ -116,10 +125,12 @@
   min-height: 360px;
 }
 
+// 일정 목록은 한 장의 카드입니다. 줄마다 테두리를 두르면 같은 하루가 조각나 보입니다.
 .timeline {
+  @include card;
+
   position: relative;
-  display: grid;
-  gap: var(--s3);
+  overflow: hidden;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -129,104 +140,73 @@
   position: relative;
 }
 
+// 시간은 줄의 기준점이라 제목 첫 줄에 맞춰 세웁니다.
 .time {
-  position: relative;
-  display: grid;
-  place-items: center;
-  align-self: stretch;
-  padding: var(--s4) var(--s2);
-  border-right: 1px solid var(--line);
+  align-self: start;
+  padding-top: 2px;
   color: var(--ink-2);
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 700;
-  text-align: center;
-}
-
-.dot {
-  position: absolute;
-  top: 50%;
-  right: -7px;
-  transform: translateY(-50%);
-  z-index: 1;
-  width: 14px;
-  height: 14px;
-  border: 3px solid var(--surface);
-  border-radius: 50%;
-  background: var(--muted-2);
-}
-
-.status검토대기 {
-  background: var(--blue);
-}
-.status확정 {
-  background: var(--green);
-}
-.status반려 {
-  background: var(--red);
 }
 
 .card {
   display: grid;
-  grid-template-columns: 90px minmax(0, 1fr) auto;
-  align-items: center;
+  grid-template-columns: max-content minmax(0, 1fr) auto;
+  align-items: start;
   justify-content: space-between;
-  gap: var(--s4);
+  gap: var(--s3);
   min-width: 0;
-  padding: var(--s4) var(--s5);
-  border: 1px solid var(--line);
-  border-radius: var(--r-lg);
-  background: var(--surface);
+  padding: var(--s6) var(--s5);
   color: inherit;
   text-decoration: none;
-  transition:
-    border-color var(--t-fast),
-    box-shadow var(--t-fast),
-    transform var(--t-fast);
+  transition: background var(--t-fast);
 
   &:hover {
-    border-color: rgba(0, 122, 255, 0.55);
-    box-shadow: var(--sh-1);
+    background: var(--fill-2);
   }
 
   &:active {
-    transform: translateY(1px);
+    background: var(--fill);
+  }
+
+  // 카드가 목록 테두리를 넘지 않도록 잘라 두어 포커스 링은 안쪽에 그립니다.
+  &:focus-visible {
+    outline-offset: -3px;
   }
 
   h2 {
-    font-size: 17px;
+    font-size: 16px;
     font-weight: 700;
     letter-spacing: -0.016em;
   }
 }
 
+// 병원 이름과 담당자는 한 줄로 읽습니다.
 .content {
   min-width: 0;
+
+  h2 {
+    display: inline;
+  }
 }
 
-.who,
-.brief {
-  margin-top: 3px;
+.who {
+  display: inline;
+  margin-left: 7px;
   color: var(--muted);
   font-size: 12px;
 }
 
 .title {
-  margin-top: var(--s2);
+  margin-top: 6px;
   font-size: 14px;
   font-weight: 600;
-}
-
-.brief {
-  display: -webkit-box;
-  overflow: hidden;
-  line-height: 1.5;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 1;
 }
 
 .action {
   display: inline-flex;
   align-items: center;
+  align-self: center;
   gap: 5px;
   flex: none;
   color: var(--blue);
@@ -269,32 +249,14 @@
     align-items: flex-start;
   }
 
-  .entry {
-    padding-left: 22px;
-  }
-
-  .time {
-    display: block;
-    min-height: 0;
-    padding: 0;
-    border-right: 0;
-    text-align: left;
-  }
-
-  .dot {
-    top: var(--s4);
-    right: auto;
-    left: -20px;
-    transform: none;
-  }
-
   .card {
     grid-template-columns: minmax(0, 1fr) auto;
-    padding: var(--s3);
+    padding: var(--s4);
   }
 
   .time {
     grid-column: 1 / -1;
+    padding-top: 0;
   }
 
   .content {

--- a/frontend/src/pages/Daily/MeetingPick.tsx
+++ b/frontend/src/pages/Daily/MeetingPick.tsx
@@ -166,9 +166,14 @@ export default function MeetingPick() {
             return (
               <>
                 {Array.from({ length: shown }, (_, index) => (
-                  <i key={index} className={styles.markDot} />
+                  <i key={index} aria-hidden="true" className={styles.markDot} />
                 ))}
-                {hidden > 0 && <span className={`${styles.more} tnum`}>+{hidden}</span>}
+                {hidden > 0 && (
+                  <span aria-hidden="true" className={`${styles.more} tnum`}>
+                    +{hidden}
+                  </span>
+                )}
+                <span className="sr-only">일정 {total}건</span>
               </>
             )
           }}

--- a/frontend/src/pages/Daily/MeetingPick.tsx
+++ b/frontend/src/pages/Daily/MeetingPick.tsx
@@ -12,14 +12,23 @@ import { useMeetingReportsOn } from '@/pages/Meetings/useMeetingReports'
 import { useAgendaState } from '@/shared/agenda'
 import { addDays, iso, startOfWeek, TODAY, TODAY_ISO, weekRangeLabel } from '@/utils/date'
 
-import { meetingLinkFor } from './sources'
+import { meetingLinkFor, type SourceMeta } from './sources'
 import DailyListLink from './components/DailyListLink'
 
 import styles from './MeetingPick.module.scss'
 
 const LIST_H = 360
-const FILTERS = ['전체', '검토 대기', '확정', '반려'] as const
+/** 표식 자리에 세울 수 있는 점 개수. 대시보드 주간 일정과 같습니다. */
+const MAX_MARKS = 5
+const FILTERS = ['전체', '미작성', '작성중', '확정'] as const
 type Filter = (typeof FILTERS)[number]
+
+/**
+ * 목록 상태를 필터 세 갈래로 접습니다. 미팅 보고서는 팀장 확인 없이 작성자가 끝내므로
+ * 제출('검토 대기')이 곧 확정이고, 반려는 다시 손봐야 하니 '작성중'입니다.
+ */
+const filterOf = (status: SourceMeta['status']): Filter =>
+  status === null ? '미작성' : status === '확정' || status === '검토 대기' ? '확정' : '작성중'
 
 const weekDays = (offset: number) => {
   const first = addDays(startOfWeek(TODAY), offset * 7)
@@ -47,13 +56,21 @@ export default function MeetingPick() {
     setWeekOffset((current) => (current === next ? current : next))
   }, [dateISO])
 
+  // 날짜 칸마다 그 날 일정이 몇 건인지 보여 주므로 하루가 아니라 보이는 주를 통째로
+  // 받습니다. 고를 수 없는 미래 날짜는 셀 것도 없어 오늘까지만 묻습니다.
+  const weekEnd = iso(days[6])
   const {
     items,
     loading: agendaLoading,
     error: agendaError,
     reload: reloadAgenda,
-  } = useAgendaState(dateISO, dateISO, true)
+  } = useAgendaState(iso(days[0]), weekEnd > TODAY_ISO ? TODAY_ISO : weekEnd, true)
   const agenda = items.filter((item) => item.date === dateISO)
+  const countByDate = useMemo(() => {
+    const map = new Map<string, number>()
+    for (const item of items) map.set(item.date, (map.get(item.date) ?? 0) + 1)
+    return map
+  }, [items])
   const {
     reports: meetings,
     loading: meetingLoading,
@@ -75,22 +92,13 @@ export default function MeetingPick() {
     () => agenda.map((item) => ({ item, link: meetingLinkFor(item.id, byAgenda.get(item.id)) })),
     [agenda, byAgenda],
   )
-  const counts = useMemo(
-    () =>
-      FILTERS.reduce<Record<Filter, number>>(
-        (result, value) => {
-          result[value] =
-            value === '전체' ? rows.length : rows.filter(({ link }) => link.status === value).length
-          return result
-        },
-        {} as Record<Filter, number>,
-      ),
-    [rows],
-  )
-  const visible = filter === '전체' ? rows : rows.filter(({ link }) => link.status === filter)
+  const visible =
+    filter === '전체' ? rows : rows.filter(({ link }) => filterOf(link.status) === filter)
 
   const changeDate = (next: string) => {
     if (next === '' || next > TODAY_ISO) return
+    // 날짜가 바뀌면 이전 날짜에서 고른 상태 필터는 의미가 없습니다.
+    setFilter('전체')
     const query = new URLSearchParams(params)
     query.set('date', next)
     setParams(query, { replace: true })
@@ -150,7 +158,20 @@ export default function MeetingPick() {
           selectedISO={dateISO}
           onSelect={onSelectDate}
           onOutOfRange={(next) => setWeekOffset(initialWeekOffset(next))}
-          renderMarks={(key) => (key === dateISO ? <i className={styles.selectedDot} /> : null)}
+          renderMarks={(key) => {
+            // 대시보드 주간 일정과 같은 읽기. 점 하나가 일정 하나이고, 넘치면 '+N'.
+            const total = countByDate.get(key) ?? 0
+            const shown = Math.min(total, total > MAX_MARKS ? MAX_MARKS - 1 : MAX_MARKS)
+            const hidden = total - shown
+            return (
+              <>
+                {Array.from({ length: shown }, (_, index) => (
+                  <i key={index} className={styles.markDot} />
+                ))}
+                {hidden > 0 && <span className={`${styles.more} tnum`}>+{hidden}</span>}
+              </>
+            )
+          }}
           label="미팅 보고서 날짜 선택"
           selectionStyle="outline"
           maxISO={TODAY_ISO}
@@ -168,7 +189,6 @@ export default function MeetingPick() {
             onClick={() => setFilter(value)}
           >
             {value}
-            <span className="tnum">{counts[value]}</span>
           </button>
         ))}
       </div>
@@ -217,12 +237,7 @@ export default function MeetingPick() {
                   to={link.to ?? dailyComposePath(dateISO, '일일')}
                   aria-label={`${item.hospital || item.title} ${link.label}`}
                 >
-                  <span className={`${styles.time} tnum`}>
-                    {item.time}
-                    <i
-                      className={`${styles.dot} ${link.status ? styles[`status${link.status.replace(' ', '')}`] : ''}`}
-                    />
-                  </span>
+                  <span className={`${styles.time} tnum`}>{item.time}</span>
                   <div className={styles.content}>
                     <h2>{item.hospital || item.title}</h2>
                     {(item.dept || item.contact) && (
@@ -231,7 +246,6 @@ export default function MeetingPick() {
                       </p>
                     )}
                     {item.hospital && <p className={styles.title}>{item.title}</p>}
-                    {item.brief && <p className={styles.brief}>{item.brief}</p>}
                   </div>
                   <span className={styles.action}>
                     {link.label}

--- a/frontend/src/pages/Meetings/Compose.module.scss
+++ b/frontend/src/pages/Meetings/Compose.module.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   // AppShell의 상단바와 content 위·아래 여백을 제외한 작성 화면 높이.
-  height: calc(100dvh - var(--topbar-h) - var(--s6) - var(--s8));
+  height: calc(100dvh - var(--topbar-h) - var(--s6) * 2);
 
   @include lg {
     display: block;
@@ -72,6 +72,27 @@
   }
 }
 
+/*
+ * 등록 단계. 아직 만든 것이 없으므로 결과 자리를 미리 비워 두지 않고 한 열만 씁니다.
+ * .layout 과 특정도를 맞춰 겹쳐 씁니다 — 파일이 붙는 순서에 좌우되지 않게 합니다.
+ */
+.layout.solo {
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: auto;
+
+  // 페이지가 스크롤합니다. 안쪽에 스크롤 상자를 하나 더 두면 두 번 굴려야 합니다.
+  .sideContent {
+    flex: none;
+    overflow: visible;
+  }
+}
+
+/* 한 열일 때는 좌우로 나눠 각각 스크롤시킬 이유가 없습니다. */
+.page.pageSolo {
+  display: block;
+  height: auto;
+}
+
 /* 왼쪽 = 참고 자료와 입력, 오른쪽 = 최종 보고서. */
 .layout {
   display: grid;
@@ -120,10 +141,14 @@
 
 .generateBar {
   flex: none;
+  display: flex;
+  gap: var(--s2);
+  justify-content: space-between;
 }
 
+/* 두 버튼은 제 글자만큼만 서고 양쪽 끝으로 갈립니다. */
 .generate {
-  width: 100%;
+  flex: none;
 }
 
 /*
@@ -131,16 +156,9 @@
  * 오른쪽 보고서만 그림자로 떠 있어서, 흰 면이 둘이어도 어느 쪽을 고치는 중인지
  * 한눈에 갈립니다. 참고판은 놓여 있고 문서는 들려 있습니다.
  */
+/* 참고 열은 그 자체로 면이 아닙니다 — 안의 두 판이 각자 면을 씁니다. */
 .reference {
   min-width: 0;
-  padding: var(--s4);
-  border: 1px solid var(--line);
-  border-radius: var(--r-lg);
-  background: var(--surface);
-
-  @include md {
-    padding: var(--s4);
-  }
 }
 
 /* 오른쪽 작업 열. 나오는 것(보고서)만 섭니다. */
@@ -223,28 +241,6 @@
  */
 .input {
   min-width: 0;
-}
-
-/* 패널의 머리. 탭이든 제목이든 같은 자리에 같은 높이로 섭니다. */
-.refHead {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--s3);
-  min-height: var(--control-h);
-  margin-bottom: var(--s3);
-}
-
-.refTitle {
-  font-size: 13px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-}
-
-.pill {
-  @include tag-pill;
-
-  font-size: 11px;
 }
 
 /*

--- a/frontend/src/pages/Meetings/Compose.tsx
+++ b/frontend/src/pages/Meetings/Compose.tsx
@@ -256,13 +256,14 @@ export default function Compose() {
   const deals = useCompanyDeals(item?.customerCompanyId)
   const [createDealOpen, setCreateDealOpen] = useState(false)
   const createDealKey = useRef('')
-  useEffect(() => {
-    setCreateDealOpen(false)
-    createDealKey.current = ''
-  }, [agendaId, item?.customerCompanyId])
   const [confirm, setConfirm] = useState<Confirm>(null)
   // 일정 상세는 대시보드·캘린더가 쓰는 드로어를 그대로 엽니다. AI 브리핑까지 그 안에 있습니다.
   const [detailOpen, setDetailOpen] = useState(false)
+  useEffect(() => {
+    setCreateDealOpen(false)
+    createDealKey.current = ''
+    setDetailOpen(false)
+  }, [agendaId, item?.customerCompanyId])
 
   if (agendaLoading || loading) {
     return (

--- a/frontend/src/pages/Meetings/Compose.tsx
+++ b/frontend/src/pages/Meetings/Compose.tsx
@@ -23,6 +23,7 @@ import {
 import Button, { buttonClass } from '@/components/Button'
 import { ChevronLeftIcon } from '@/components/icons'
 import Modal from '@/components/Modal'
+import RecordDrawer from '@/pages/Dashboard/components/RecordDrawer'
 import { SkeletonDetail } from '@/components/Skeleton'
 import { meetingPickPath, meetingReportPath, ROUTES } from '@/constants/routes'
 import { isOwnAgendaItem, useAgendaItem } from '@/shared/agenda'
@@ -92,6 +93,8 @@ export default function Compose() {
   const [submitting, setSubmitting] = useState(false)
   const [runError, setRunError] = useState<string | null>(null)
   const [runErrors, setRunErrors] = useState<Record<string, string>>({})
+  // 등록 단계에서는 왼쪽 한 열만 씁니다. 작성을 시작해야 보고서 열이 열립니다.
+  const [opened, setOpened] = useState(false)
   const agendaId = params.get('agenda') ?? ''
   useEffect(() => {
     setGenerating(false)
@@ -99,6 +102,7 @@ export default function Compose() {
     setSubmitting(false)
     setRunError(null)
     setRunErrors({})
+    setOpened(false)
     recoveredAgendaId.current = ''
     generationAttempt.current = undefined
     return () => {
@@ -176,6 +180,7 @@ export default function Compose() {
         dealIds = input.sales_deal_ids
         restoreGenerationInput(input)
         beginGeneration(dealIds)
+        setOpened(true)
         if (run.status_code === 'failed' || run.status_code === 'cancelled') {
           throw new Error(run.error_code ?? run.error_message ?? 'agent_run_failed')
         }
@@ -256,6 +261,8 @@ export default function Compose() {
     createDealKey.current = ''
   }, [agendaId, item?.customerCompanyId])
   const [confirm, setConfirm] = useState<Confirm>(null)
+  // 일정 상세는 대시보드·캘린더가 쓰는 드로어를 그대로 엽니다. AI 브리핑까지 그 안에 있습니다.
+  const [detailOpen, setDetailOpen] = useState(false)
 
   if (agendaLoading || loading) {
     return (
@@ -379,6 +386,9 @@ export default function Compose() {
     draft.draftsByDeal,
     result?.shared,
   )
+  // 보고서 열을 여는 조건. 작성을 시작했거나, 이미 결과·저장본이 있는 미팅입니다.
+  const showWork =
+    opened || generating || Boolean(result) || Boolean(savedReport) || hasDraftContent
   const generationInputError = reportInputError(meetingGenerationRequestOf(payloadForMeeting(), ''))
   const submitInputError = reportInputError({
     ...meetingRequestOf(payloadForMeeting()),
@@ -482,6 +492,7 @@ export default function Compose() {
   }
 
   const requestGeneration = () => {
+    setOpened(true)
     if (hasDraftContent) setConfirm({ kind: 'regenerate' })
     else void generateAll()
   }
@@ -525,7 +536,7 @@ export default function Compose() {
     draft.salesDealIds.some((dealId) => draft.draftsByDeal[dealId]?.phase === 'ready')
 
   return (
-    <section className={styles.page}>
+    <section className={showWork ? styles.page : `${styles.page} ${styles.pageSolo}`}>
       <h1 className="sr-only">
         {item.hospital} {item.title} 미팅 보고서 작성
       </h1>
@@ -539,14 +550,17 @@ export default function Compose() {
           일정 고르기
         </Link>
 
-        <Button
-          variant="outline"
-          type="button"
-          disabled={!printable}
-          onClick={() => window.print()}
-        >
-          PDF 다운로드
-        </Button>
+        {/* 아직 만든 보고서가 없는 등록 단계에서는 내려받을 것이 없습니다. */}
+        {showWork && (
+          <Button
+            variant="outline"
+            type="button"
+            disabled={!printable}
+            onClick={() => window.print()}
+          >
+            PDF 다운로드
+          </Button>
+        )}
       </div>
 
       {lockedDealIds.length > 0 && (
@@ -572,17 +586,13 @@ export default function Compose() {
         </div>
       )}
 
-      <div className={styles.layout}>
+      <div className={showWork ? styles.layout : `${styles.layout} ${styles.solo}`}>
         <div className={styles.side}>
           <div className={styles.sideContent}>
             <aside className={styles.reference}>
-              <div className={styles.refHead}>
-                <h2 className={styles.refTitle}>미팅 정보</h2>
-                {item.stage && <span className={styles.pill}>{item.stage}</span>}
-              </div>
-
               <MeetingInfoPanel
                 item={{ ...item, date: meetingDate, time: meetingTime }}
+                onOpenDetail={() => setDetailOpen(true)}
                 deals={deals.deals}
                 dealsLoading={deals.loading}
                 dealsError={deals.error}
@@ -622,13 +632,20 @@ export default function Compose() {
                   생성할 수 없습니다.
                 </p>
               )}
-              <p className={styles.generationNote}>
-                미팅 공통 기록을 만들며, 관련 딜을 선택하면 딜별 보고서도 함께 처리합니다. 작성한
-                내용이 있으면 새 후보로 바꾸기 전에 확인합니다.
-              </p>
             </div>
           </div>
           <div className={styles.generateBar} aria-busy={generating || recovering}>
+            {/* AI 없이 쓰는 길. 보고서 열이 이미 열렸다면 이 자리에 둘 이유가 없습니다. */}
+            {!showWork && (
+              <Button
+                type="button"
+                variant="outline"
+                disabled={busy || !canEdit}
+                onClick={() => setOpened(true)}
+              >
+                직접 작성
+              </Button>
+            )}
             <Button
               type="button"
               className={styles.generate}
@@ -643,87 +660,89 @@ export default function Compose() {
                 recovering
               }
             >
-              {generating || recovering
-                ? '미팅 전체 분석·보고서 작성 중…'
-                : '미팅 전체 분석·보고서 작성'}
+              {generating || recovering ? 'AI 보고서 작성 중…' : 'AI 보고서 작성'}
             </Button>
           </div>
         </div>
 
-        <section className={styles.work} aria-label="미팅 보고서">
-          <div className={styles.saveBar} aria-busy={submitting || draft.attachmentsPending}>
-            <div className={styles.saveCopy}>
-              <strong>미팅 보고서</strong>
-              <p>미팅일 {fmtDot(parseISO(meetingDate))} · 작성 완료 후에도 이 날짜로 저장됩니다.</p>
-              <p>
-                {draft.salesDealIds.length > 0
-                  ? `공통 기록과 딜 ${draft.salesDealIds.length}건을 한 문서로 저장합니다.`
-                  : '딜 미지정 미팅 기록을 한 문서로 저장합니다.'}
-              </p>
+        {showWork && (
+          <section className={styles.work} aria-label="미팅 보고서">
+            <div className={styles.saveBar} aria-busy={submitting || draft.attachmentsPending}>
+              <div className={styles.saveCopy}>
+                <strong>미팅 보고서</strong>
+                <p>
+                  미팅일 {fmtDot(parseISO(meetingDate))} · 작성 완료 후에도 이 날짜로 저장됩니다.
+                </p>
+                <p>
+                  {draft.salesDealIds.length > 0
+                    ? `공통 기록과 딜 ${draft.salesDealIds.length}건을 한 문서로 저장합니다.`
+                    : '딜 미지정 미팅 기록을 한 문서로 저장합니다.'}
+                </p>
+              </div>
+              <Button
+                type="button"
+                className={styles.saveAllButton}
+                aria-label="미팅 보고서 작성 완료"
+                disabled={
+                  busy ||
+                  draft.attachmentsPending ||
+                  !canEdit ||
+                  editableDealIds.length !== draft.salesDealIds.length ||
+                  Boolean(submitInputError) ||
+                  missingBody
+                }
+                onClick={() => void submitAll()}
+              >
+                {submitting ? '완료 중…' : '미팅 보고서 작성 완료'}
+              </Button>
             </div>
-            <Button
-              type="button"
-              className={styles.saveAllButton}
-              aria-label="미팅 보고서 작성 완료"
-              disabled={
-                busy ||
-                draft.attachmentsPending ||
-                !canEdit ||
-                editableDealIds.length !== draft.salesDealIds.length ||
-                Boolean(submitInputError) ||
-                missingBody
-              }
-              onClick={() => void submitAll()}
-            >
-              {submitting ? '완료 중…' : '미팅 보고서 작성 완료'}
-            </Button>
-          </div>
-          <div className={styles.reports}>
-            {(draft.salesDealIds.length === 0 ||
-              result ||
-              draft.processingProgress ||
-              generating) && (
-              <MeetingSharedPanel
-                shared={result?.shared ?? null}
-                progress={draft.processingProgress}
-                generating={generating || recovering}
-                disabled={busy}
-                showCommon={draft.salesDealIds.length === 0}
-                onChange={canEdit ? draft.setShared : undefined}
-              />
-            )}
-            {draft.salesDealIds.length > 0 &&
-              draft.salesDealIds.map((dealId) => {
-                const state = draft.draftsByDeal[dealId]
-                if (!state) return null
-                const deal = deals.deals.find((one) => one.id === dealId)
-                const savedSection = savedByDeal.get(dealId)
-                const product = deal?.product ?? savedSection?.product
+            <div className={styles.reports}>
+              {(draft.salesDealIds.length === 0 ||
+                result ||
+                draft.processingProgress ||
+                generating) && (
+                <MeetingSharedPanel
+                  shared={result?.shared ?? null}
+                  progress={draft.processingProgress}
+                  generating={generating || recovering}
+                  disabled={busy}
+                  showCommon={draft.salesDealIds.length === 0}
+                  onChange={canEdit ? draft.setShared : undefined}
+                />
+              )}
+              {draft.salesDealIds.length > 0 &&
+                draft.salesDealIds.map((dealId) => {
+                  const state = draft.draftsByDeal[dealId]
+                  if (!state) return null
+                  const deal = deals.deals.find((one) => one.id === dealId)
+                  const savedSection = savedByDeal.get(dealId)
+                  const product = deal?.product ?? savedSection?.product
 
-                return (
-                  <DealReportCard
-                    key={dealId}
-                    dealId={dealId}
-                    deal={deal}
-                    savedDeal={savedSection?.salesDeal}
-                    draft={state}
-                    progress={draft.processingProgress}
-                    when={`${when}${product ? ` · ${product}` : ''}`}
-                    saving={pending}
-                    generating={generating || recovering}
-                    canGenerate={
-                      draft.canGenerate && generatable && !generationInputError && !createDealOpen
-                    }
-                    readOnly={!canEditDeal(dealId) || createDealOpen}
-                    onTitleChange={(value) => draft.setTitle(dealId, value)}
-                    onChange={(body) => draft.applyDocument(dealId, body)}
-                    onStartManual={() => draft.startManual(dealId)}
-                    onGenerate={requestGeneration}
-                  />
-                )
-              })}
-          </div>
-        </section>
+                  return (
+                    <DealReportCard
+                      key={dealId}
+                      dealId={dealId}
+                      deal={deal}
+                      savedDeal={savedSection?.salesDeal}
+                      draft={state}
+                      progress={draft.processingProgress}
+                      when={`${when}${product ? ` · ${product}` : ''}`}
+                      saving={pending}
+                      generating={generating || recovering}
+                      canGenerate={
+                        draft.canGenerate && generatable && !generationInputError && !createDealOpen
+                      }
+                      readOnly={!canEditDeal(dealId) || createDealOpen}
+                      onTitleChange={(value) => draft.setTitle(dealId, value)}
+                      onChange={(body) => draft.applyDocument(dealId, body)}
+                      onStartManual={() => draft.startManual(dealId)}
+                      onGenerate={requestGeneration}
+                    />
+                  )
+                })}
+            </div>
+          </section>
+        )}
       </div>
 
       {confirm?.kind === 'regenerate' && (
@@ -751,6 +770,7 @@ export default function Compose() {
           <p>현재 편집 중인 내용은 아직 미팅 보고서로 저장되지 않았습니다.</p>
         </Modal>
       )}
+      {detailOpen && <RecordDrawer item={item} onClose={() => setDetailOpen(false)} />}
       {createDealOpen && item.customerCompanyId && (
         <MeetingDealForm
           activityKey={item.id}

--- a/frontend/src/pages/Meetings/components/DealPicker/DealPicker.module.scss
+++ b/frontend/src/pages/Meetings/components/DealPicker/DealPicker.module.scss
@@ -6,7 +6,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--s1);
-  max-height: 260px;
+  max-height: 220px;
   overflow-y: auto;
 }
 
@@ -46,6 +46,7 @@
 
 .body {
   display: flex;
+  flex: 1;
   flex-direction: column;
   gap: var(--s1);
   min-width: 0;
@@ -55,6 +56,7 @@
   display: flex;
   align-items: center;
   gap: var(--s2);
+  min-width: 0;
 }
 
 .no {
@@ -63,13 +65,19 @@
   letter-spacing: -0.01em;
 }
 
+/* 두 줄짜리 행입니다. 딜명이 길어도 줄을 늘리지 않고 잘라 목록 높이를 고르게 둡니다. */
 .title {
   color: var(--ink-2);
   font-size: 12px;
   line-height: 1.5;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .amount {
+  flex: none;
+  margin-left: auto;
   color: var(--muted);
   font-size: 12px;
 }

--- a/frontend/src/pages/Meetings/components/DealPicker/DealPicker.tsx
+++ b/frontend/src/pages/Meetings/components/DealPicker/DealPicker.tsx
@@ -56,9 +56,15 @@ export default function DealPicker({
     return <p className={styles.empty}>이 회사에 연결된 영업 현황이 없습니다.</p>
   }
 
+  // 고른 딜을 목록 맨 위로 올립니다. 목록이 스크롤되면 무엇을 골랐는지가 아래로 밀려납니다.
+  // sort 는 안정 정렬이라 고르지 않은 딜의 원래 순서는 그대로입니다.
+  const ordered = [...deals].sort(
+    (a, b) => Number(selected.includes(b.id)) - Number(selected.includes(a.id)),
+  )
+
   return (
     <ul className={styles.list}>
-      {deals.map((deal) => (
+      {ordered.map((deal) => (
         <li key={deal.id}>
           <label className={styles.row}>
             <input
@@ -71,13 +77,14 @@ export default function DealPicker({
             />
 
             <span className={styles.body}>
+              {/* 식별자 줄. 금액은 오른쪽 끝에 세워 여러 딜의 숫자가 한 열로 읽힙니다. */}
               <span className={styles.head}>
                 <span className={styles.no}>{deal.no}</span>
                 <StageChip tone={deal.stageTone}>{deal.stageName}</StageChip>
+                <span className={['tnum', styles.amount].join(' ')}>{won(deal.amount)}</span>
               </span>
               {/* 제목이 비어 있는 딜이 있습니다. 그때는 제품이 그 자리를 대신합니다. */}
               <span className={styles.title}>{deal.title.trim() || deal.product}</span>
-              <span className={['tnum', styles.amount].join(' ')}>{won(deal.amount)}</span>
             </span>
           </label>
           {fixed.includes(deal.id) && (

--- a/frontend/src/pages/Meetings/components/MeetingInfoPanel/MeetingInfoPanel.module.scss
+++ b/frontend/src/pages/Meetings/components/MeetingInfoPanel/MeetingInfoPanel.module.scss
@@ -1,27 +1,63 @@
-.root {
-  display: flex;
-  flex-direction: column;
-  gap: var(--s3);
-}
-
 /*
- * 참고 열은 카드로도 실선으로도 나누지 않습니다. 제목과 여백이 그 일을 합니다.
- * 좁은 열에 가로선을 겹쳐 그으면 한 화면이 여러 조각으로 잘려 보입니다.
+ * 미팅 정보와 관련 딜은 한 판입니다. 안에서만 좌우로 갈리고, 그 사이를 세로선 하나가 지납니다.
+ * 미디어쿼리가 아니라 이 판의 폭으로만 갈립니다 — 보고서 열이 열려 좁아지면
+ * 위아래로 쌓이고 세로선은 그 자리에서 사라집니다.
  */
-.block {
-  padding-bottom: var(--s2);
-  border-bottom: 1px solid var(--line);
+.root {
+  container-type: inline-size;
+  min-width: 0;
+  padding: var(--s4);
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+  background: var(--surface);
 }
 
-.blockHead {
-  display: inline-flex;
-  width: calc(100% - var(--s5));
-  vertical-align: top;
-  align-items: center;
-  justify-content: space-between;
+.cols {
+  display: grid;
+  gap: var(--s4);
+}
+
+.block {
+  display: grid;
   gap: var(--s3);
-  font-size: 13px;
-  font-weight: 600;
+  align-content: start;
+  min-width: 0;
+}
+
+/* 두 판이 나란히 설 만큼 넓을 때만 좌우로 가르고 그 사이에 선을 놓습니다. */
+@container (min-width: 560px) {
+  .cols {
+    grid-template-columns: 1fr 1fr;
+    gap: 0;
+  }
+
+  .block:first-child {
+    padding-right: var(--s4);
+  }
+
+  .block + .block {
+    padding-left: var(--s4);
+    border-left: 1px solid var(--line);
+  }
+}
+
+/* 판의 머리. 제목과 상태가 왼쪽에 붙고 그 판의 조작 하나가 오른쪽 끝에 섭니다. */
+.head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--s2);
+  min-height: var(--control-h);
+
+  h2 {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+}
+
+.headAction {
+  margin-left: auto;
 }
 
 .context {
@@ -31,46 +67,32 @@
   line-height: 1.5;
   overflow-wrap: anywhere;
 
+  strong {
+    font-size: 15px;
+    font-weight: 650;
+    letter-spacing: -0.01em;
+  }
+
   span {
     color: var(--ink-2);
   }
-}
-
-.disclosure {
-  summary {
-    color: var(--blue);
-    font-size: 12px;
-    line-height: 1.6;
-    cursor: pointer;
-  }
-
-  &[open] > summary {
-    margin-bottom: var(--s3);
-  }
-}
-
-.context + .disclosure {
-  margin-top: var(--s2);
-}
-
-.selectedNames {
-  display: block;
-  margin-top: var(--s1);
-  color: var(--ink-2);
-  font-size: 12px;
-  font-weight: 400;
-  overflow-wrap: anywhere;
 }
 
 .count {
   color: var(--blue);
   font-size: 12px;
   font-weight: 600;
+  white-space: nowrap;
+}
+
+.pill {
+  @include tag-pill;
+
+  font-size: 11px;
 }
 
 /* 미팅 브리핑. 사실 목록 아래에 한 문단으로 깝니다. */
 .brief {
-  margin-top: var(--s3);
   color: var(--ink-2);
   font-size: 12px;
   line-height: 1.7;

--- a/frontend/src/pages/Meetings/components/MeetingInfoPanel/MeetingInfoPanel.tsx
+++ b/frontend/src/pages/Meetings/components/MeetingInfoPanel/MeetingInfoPanel.tsx
@@ -1,4 +1,4 @@
-// 미팅 맥락과 선택한 딜은 항상 보여 주고, 추가 정보와 선택 목록만 펼칩니다.
+// 미팅 맥락과 연결할 딜을 나란한 두 판으로 펼쳐 둡니다. 판마다 제 머리와 제 조작을 답니다.
 import type { SalesDeal } from '@/pages/Deals/useSalesDeals'
 import type { AgendaItem } from '@/types'
 import Button from '@/components/Button'
@@ -20,6 +20,7 @@ interface Props {
   fixedDealIds?: string[]
   onToggleDeal: (id: string) => void
   onCreateDeal?: () => void
+  onOpenDetail: () => void
   disabled: boolean
 }
 
@@ -33,62 +34,68 @@ export default function MeetingInfoPanel({
   fixedDealIds,
   onToggleDeal,
   onCreateDeal,
+  onOpenDetail,
   disabled,
 }: Props) {
-  const selectedNames = selectedDealIds.map((id) => {
-    const deal = deals.find((one) => one.id === id)
-    return deal ? deal.title.trim() || deal.product || deal.no : '선택한 딜'
-  })
-
   return (
     <div className={styles.root}>
-      <section className={styles.block}>
-        <div className={styles.context}>
-          <strong>{item.hospital || '회사 미지정'}</strong>
-          <span>
-            {item.contact || '담당자 미지정'} · 미팅일 {fmtDot(parseISO(item.date))} {item.time}
-          </span>
-        </div>
-        <details className={styles.disclosure}>
-          <summary>추가 정보</summary>
+      <div className={styles.cols}>
+        <section className={styles.block}>
+          <div className={styles.head}>
+            <h2>미팅 정보</h2>
+            {item.stage && <span className={styles.pill}>{item.stage}</span>}
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className={styles.headAction}
+              onClick={onOpenDetail}
+            >
+              자세히 보기
+            </Button>
+          </div>
+          <div className={styles.context}>
+            <strong>{item.hospital || '회사 미지정'}</strong>
+            <span>
+              {item.contact || '담당자 미지정'} · 미팅일 {fmtDot(parseISO(item.date))} {item.time}
+            </span>
+          </div>
           <MeetingFacts dept={item.dept} contact={item.contact} place={item.place} />
           {item.brief && <p className={styles.brief}>{item.brief}</p>}
-        </details>
-      </section>
+        </section>
 
-      <details className={styles.disclosure}>
-        <summary>
-          <span className={styles.blockHead}>
-            <span>관련 딜 선택</span>
+        <section className={styles.block}>
+          <div className={styles.head}>
+            <h2>관련 딜</h2>
             <span className={styles.count}>
               {selectedDealIds.length}건 선택
               {dealsLoading ? ' · 조회 중' : dealsError ? ' · 조회 오류' : ''}
             </span>
-          </span>
-          <span className={styles.selectedNames}>{selectedNames.join(' · ') || '딜 미지정'}</span>
-        </summary>
-        <DealPicker
-          deals={deals}
-          loading={dealsLoading}
-          error={dealsError}
-          onRetry={onReloadDeals}
-          selected={selectedDealIds}
-          fixed={fixedDealIds}
-          onToggle={onToggleDeal}
-          disabled={disabled}
-        />
-        {onCreateDeal && (
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={disabled || dealsLoading || !item.customerCompanyId}
-            onClick={onCreateDeal}
-          >
-            새 딜 생성
-          </Button>
-        )}
-      </details>
+            {onCreateDeal && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className={styles.headAction}
+                disabled={disabled || dealsLoading || !item.customerCompanyId}
+                onClick={onCreateDeal}
+              >
+                새 딜 생성
+              </Button>
+            )}
+          </div>
+          <DealPicker
+            deals={deals}
+            loading={dealsLoading}
+            error={dealsError}
+            onRetry={onReloadDeals}
+            selected={selectedDealIds}
+            fixed={fixedDealIds}
+            onToggle={onToggleDeal}
+            disabled={disabled}
+          />
+        </section>
+      </div>
     </div>
   )
 }

--- a/frontend/src/pages/Meetings/components/MeetingInputPanel/MeetingInputPanel.module.scss
+++ b/frontend/src/pages/Meetings/components/MeetingInputPanel/MeetingInputPanel.module.scss
@@ -10,82 +10,81 @@
   border: 1px solid var(--line);
   border-radius: var(--r-lg);
   background: var(--surface);
-
-  @include md {
-    padding: var(--s4);
-  }
 }
 
 .blockHead {
   display: flex;
   align-items: center;
-  gap: var(--s3);
+  flex-wrap: wrap;
+  gap: var(--s1);
   margin-bottom: var(--s3);
 
-  h2,
-  .blockTitle {
+  h2 {
     font-size: 13px;
     font-weight: 600;
     letter-spacing: -0.01em;
   }
 }
 
-.references {
-  summary {
-    cursor: pointer;
-  }
-
-  .blockHead {
-    display: inline-flex;
-    width: calc(100% - var(--s5));
-    vertical-align: top;
-    flex-wrap: wrap;
-    margin-bottom: var(--s1);
-  }
+/*
+ * 원문 세 갈래. 녹음·이미지는 좌우로 반씩 나눠 서고 직접 입력이 그 아래 한 줄을 통으로 씁니다.
+ * 보고서가 열려 왼쪽 열이 좁아지면 컨테이너 폭만으로 저절로 한 줄씩 쌓입니다. 분기는 두지 않습니다.
+ */
+.sources {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s3);
+  /* 한 줄에 선 카드는 키를 맞춥니다 — 기본 stretch. 줄이 갈리면 줄마다 따로 맞습니다. */
 }
 
-.sourceInput {
-  & + .sourceInput {
-    border-top: 1px solid var(--line);
+/* 카드 안의 작은 면. 떠 있는 면은 오른쪽 보고서 하나뿐이라 그림자는 두지 않습니다. */
+.source {
+  display: flex;
+  flex: 1 1 200px;
+  flex-direction: column;
+  min-width: 0;
+  padding: var(--s3);
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  background: var(--surface);
+}
+
+/*
+ * 머리 아래에 오는 AttachmentPanel 의 뿌리. 남은 높이를 받아 안의 놓는 자리에 그대로 넘깁니다.
+ * 직접 입력 칸은 div 가 아니라 textarea 라 여기에 걸리지 않습니다.
+ */
+.source > div + div {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}
+
+/*
+ * 직접 입력은 글을 담는 자리라 녹음·이미지의 두 배를 씁니다 — 넓을 때 1:1:2.
+ * 기준 폭이 커서, 셋이 다 서기 좁아지면 이것부터 줄바꿈해 녹음·이미지 아래로 내려갑니다.
+ * .source 뒤에 두어야 같은 특정도의 flex 를 덮어씁니다.
+ */
+.wide {
+  flex: 2 1 400px;
+}
+
+.sourceHead {
+  display: flex;
+  align-items: center;
+  gap: var(--s2);
+  min-height: 28px;
+  margin-bottom: var(--s2);
+
+  strong {
+    color: var(--ink);
+    font-size: 13px;
+    font-weight: 600;
   }
 
-  > summary {
-    display: flex;
-    align-items: center;
-    gap: var(--s2);
-    min-height: 36px;
-    padding: var(--s2) 0;
-    list-style: none;
-    cursor: pointer;
-
-    &::-webkit-details-marker {
-      display: none;
-    }
-
-    strong {
-      color: var(--ink);
-      font-size: 13px;
-      font-weight: 600;
-    }
-
-    svg {
-      flex: none;
-      color: var(--muted);
-    }
-
-    &:focus-visible {
-      outline: 3px solid var(--blue-ring);
-      outline-offset: 2px;
-      border-radius: var(--r-xs);
-    }
-  }
-
-  &[open] > summary {
-    margin-bottom: var(--s2);
-
-    .caret {
-      transform: rotate(0);
-    }
+  svg {
+    flex: none;
+    color: var(--muted);
   }
 }
 
@@ -96,33 +95,62 @@
   white-space: nowrap;
 }
 
-.caret {
-  transform: rotate(-90deg);
+/*
+ * 설명은 물어볼 때만 나옵니다. 여닫는 상태를 두지 않고 hover 와 포커스로만 폅니다 —
+ * 마우스로 눌러도 버튼에 포커스가 들어와 같이 열립니다.
+ */
+.hint {
+  position: relative;
+  display: inline-flex;
 }
 
-.referenceAction {
-  margin-left: auto;
-  color: var(--blue);
-  font-size: 12px;
-}
-
-.note {
-  display: block;
+.hintBtn {
+  display: inline-flex;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: none;
   color: var(--muted);
+  cursor: pointer;
+
+  &:hover {
+    color: var(--ink-2);
+  }
+
+  &:focus-visible {
+    color: var(--ink-2);
+    outline: 2px solid var(--blue);
+    outline-offset: 2px;
+  }
+}
+
+.tip {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 3;
+  width: max-content;
+  max-width: 240px;
+  padding: var(--s2) var(--s3);
+  border-radius: var(--r-sm);
+  background: var(--ink);
+  color: var(--surface);
   font-size: 12px;
+  font-weight: 400;
   line-height: 1.6;
+  visibility: hidden;
+  pointer-events: none;
 }
 
-.required,
-.optional {
-  @include tag-pill;
-
-  font-size: 11px;
+.hint:hover .tip,
+.hintBtn:focus + .tip {
+  visibility: visible;
 }
 
+/* 필수는 별표 하나로 말합니다. 알약을 붙이면 제목보다 알약이 먼저 읽힙니다. */
 .required {
-  color: var(--blue);
-  background: var(--blue-tint);
+  margin-left: 2px;
+  color: var(--red-ink);
 }
 
 .transcript {
@@ -149,7 +177,7 @@
 }
 
 .error {
-  margin-top: var(--s2);
+  margin-top: var(--s3);
   color: var(--red);
   font-size: 12px;
   line-height: 1.6;

--- a/frontend/src/pages/Meetings/components/MeetingInputPanel/MeetingInputPanel.tsx
+++ b/frontend/src/pages/Meetings/components/MeetingInputPanel/MeetingInputPanel.tsx
@@ -1,6 +1,7 @@
 // 미팅의 실제 기록과 보고서에만 쓰는 참고자료를 목적별로 나눕니다.
+// 셋 다 펼친 채로 둡니다 — 무엇을 넣어야 하는지가 여닫이 뒤에 숨지 않습니다.
 import AttachmentPanel from '@/components/AttachmentPanel'
-import { ChevronDownIcon, DocumentsIcon, EditIcon, PhoneIcon } from '@/components/icons'
+import { DocumentsIcon, EditIcon, InfoIcon, PhoneIcon } from '@/components/icons'
 import type { AttachmentKind, AttachmentPurpose, ReportAttachment } from '@/types'
 import { meetingAttachmentPurposeOf } from '@/utils/attachment'
 
@@ -20,6 +21,23 @@ interface Props {
   transcript: string
   onTranscriptChange: (value: string) => void
   disabled: boolean
+}
+
+/**
+ * 무엇을 넣는 자리인지에 대한 설명. 본문처럼 깔아 두면 정작 넣을 것을 밀어내서
+ * 물어볼 때만 나오게 둡니다. 여닫는 상태는 두지 않고 hover·포커스로만 폅니다.
+ */
+function InfoHint({ text }: { text: string }) {
+  return (
+    <span className={styles.hint}>
+      <button type="button" className={styles.hintBtn} aria-label={text}>
+        <InfoIcon width={14} height={14} />
+      </button>
+      <span className={styles.tip} role="tooltip">
+        {text}
+      </span>
+    </span>
+  )
 }
 
 export default function MeetingInputPanel({
@@ -43,77 +61,86 @@ export default function MeetingInputPanel({
     <div className={styles.root}>
       <section className={styles.block}>
         <div className={styles.blockHead}>
-          <h2>미팅 원문</h2>
-          <span className={styles.required}>필수</span>
+          <h2>
+            미팅 원문
+            <span className={styles.required} aria-hidden="true">
+              *
+            </span>
+            <span className="sr-only">필수</span>
+          </h2>
+          <InfoHint text="보고서의 근거가 되는 원본 기록입니다. 녹음·이미지·PDF·직접 입력 중 하나만 넣어도 됩니다." />
         </div>
 
-        <details className={styles.sourceInput}>
-          <summary>
-            <PhoneIcon width={16} height={16} />
-            <strong>STT · 녹음</strong>
-            <span className={styles.inputStatus}>{audioSources.length}개</span>
-            <ChevronDownIcon className={styles.caret} width={14} height={14} />
-          </summary>
-          <AttachmentPanel
-            attachments={audioSources}
-            readOnly={disabled}
-            note=""
-            acceptedKinds={['audio']}
-            onAttach={(files, kinds) => onAttach(files, 'meeting_source', kinds)}
-            onRemove={onRemoveAttachment}
-            onExtractChange={onExtractChange}
-          />
-        </details>
+        <div className={styles.sources}>
+          <div className={styles.source}>
+            <div className={styles.sourceHead}>
+              <PhoneIcon width={16} height={16} />
+              <strong>녹음</strong>
+              <span className={styles.inputStatus}>{audioSources.length}개</span>
+            </div>
+            <AttachmentPanel
+              attachments={audioSources}
+              readOnly={disabled}
+              note=""
+              acceptedKinds={['audio']}
+              onAttach={(files, kinds) => onAttach(files, 'meeting_source', kinds)}
+              onRemove={onRemoveAttachment}
+              onExtractChange={onExtractChange}
+            />
+          </div>
 
-        <details className={styles.sourceInput}>
-          <summary>
-            <DocumentsIcon width={16} height={16} />
-            <strong>OCR · 이미지·PDF</strong>
-            <span className={styles.inputStatus}>{documentSources.length}개</span>
-            <ChevronDownIcon className={styles.caret} width={14} height={14} />
-          </summary>
-          <AttachmentPanel
-            attachments={documentSources}
-            readOnly={disabled}
-            note=""
-            acceptedKinds={['image', 'pdf']}
-            onAttach={(files, kinds) => onAttach(files, 'meeting_source', kinds)}
-            onRemove={onRemoveAttachment}
-            onExtractChange={onExtractChange}
-          />
-        </details>
+          <div className={styles.source}>
+            <div className={styles.sourceHead}>
+              <DocumentsIcon width={16} height={16} />
+              <strong>이미지·PDF</strong>
+              <span className={styles.inputStatus}>{documentSources.length}개</span>
+            </div>
+            <AttachmentPanel
+              attachments={documentSources}
+              readOnly={disabled}
+              note=""
+              acceptedKinds={['image', 'pdf']}
+              onAttach={(files, kinds) => onAttach(files, 'meeting_source', kinds)}
+              onRemove={onRemoveAttachment}
+              onExtractChange={onExtractChange}
+            />
+          </div>
 
-        <details className={styles.sourceInput}>
-          <summary>
-            <EditIcon width={16} height={16} />
-            <strong>직접 입력</strong>
-            <span className={styles.inputStatus}>{transcript.trim() ? '입력됨' : '내용 없음'}</span>
-            <ChevronDownIcon className={styles.caret} width={14} height={14} />
-          </summary>
-          <label className="sr-only" htmlFor="transcript">
-            직접 입력
-          </label>
-          <textarea
-            id="transcript"
-            className={styles.transcript}
-            rows={5}
-            value={transcript}
-            disabled={disabled}
-            placeholder="직접 기록한 미팅 내용을 추가하세요."
-            onChange={(event) => onTranscriptChange(event.target.value)}
-          />
-        </details>
+          <div className={`${styles.source} ${styles.wide}`}>
+            <div className={styles.sourceHead}>
+              <EditIcon width={16} height={16} />
+              <strong>직접 입력</strong>
+              <span className={styles.inputStatus}>
+                {transcript.trim() ? '입력됨' : '내용 없음'}
+              </span>
+            </div>
+            <label className="sr-only" htmlFor="transcript">
+              직접 입력
+            </label>
+            <textarea
+              id="transcript"
+              className={styles.transcript}
+              rows={5}
+              value={transcript}
+              disabled={disabled}
+              placeholder="직접 기록한 미팅 내용을 추가하세요."
+              onChange={(event) => onTranscriptChange(event.target.value)}
+            />
+          </div>
+        </div>
+
+        {attachmentError && (
+          <p className={styles.error} role="alert">
+            {attachmentError}
+          </p>
+        )}
       </section>
 
-      <details className={`${styles.block} ${styles.references}`}>
-        <summary>
-          <span className={styles.blockHead}>
-            <span className={styles.blockTitle}>보고서 참고자료</span>
-            <span className={styles.optional}>선택 · {references.length}개</span>
-            <span className={styles.referenceAction}>첨부·보기</span>
-          </span>
-          <span className={styles.note}>배경자료로만 쓰며 미팅 발언으로 사용하지 않습니다.</span>
-        </summary>
+      <section className={styles.block}>
+        <div className={styles.blockHead}>
+          <h2>보고서 참고자료</h2>
+          <InfoHint text="선택 입력입니다. 배경자료로만 쓰며 미팅 발언으로 사용하지 않습니다." />
+        </div>
         <AttachmentPanel
           attachments={references}
           readOnly={disabled}
@@ -121,13 +148,7 @@ export default function MeetingInputPanel({
           onAttach={(files) => onAttach(files, 'reference')}
           onRemove={onRemoveAttachment}
         />
-      </details>
-
-      {attachmentError && (
-        <p className={styles.error} role="alert">
-          {attachmentError}
-        </p>
-      )}
+      </section>
     </div>
   )
 }


### PR DESCRIPTION
## 변경 요약

- 미팅 보고서 리스트와 작성 화면의 시각 구조를 정리했습니다.
- 처음 작성할 때는 입력 영역을 넓게 보여 주고, 내용이 생기면 필요한 크기로 줄어드는 흐름으로 조정했습니다.
- 딜 선택·미팅 정보·첨부 패널의 간격과 상태 표현을 작성 흐름에 맞게 다듬었습니다.

## 화면 미리보기 (WIP)

![미팅 보고서 리스트](https://github.com/user-attachments/assets/f22ae3dc-f8b9-4a89-876c-5006bb7c472d)

![미팅 보고서 작성 초기 화면](https://github.com/user-attachments/assets/afed2555-f26e-4f06-aa8e-70181ab902da)

![미팅 보고서 내용 작성 화면](https://github.com/user-attachments/assets/a65a3151-4c18-414f-8832-e3f3787e4a37)

## 검증

- `npm run lint` 통과
- `npm run format:check` 통과
- `npm test` 통과 (111개)
- `npm run build` 통과

## 영향 및 주의 사항

- 미팅 보고서 목록 및 작성 화면의 프런트엔드 UI에만 영향을 줍니다.
- 디자인은 아직 WIP이며, 현재 방향을 기반으로 후속 디자인 작업을 이어갈 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 미팅 보고서 작성 화면을 등록 단계와 작성 단계로 구분하고, 필요할 때 보고서 영역을 열 수 있습니다.
  * 미팅 정보와 관련 딜을 나란히 확인하고, 상세 정보와 새 딜 생성 기능을 이용할 수 있습니다.
  * 녹음·이미지·PDF·직접 입력 자료를 한 화면에서 확인할 수 있습니다.
  * 주간 일정에 날짜별 일정 수와 보고서 상태가 표시됩니다.

* **개선 사항**
  * 첨부파일, 딜 선택 목록, 미팅 입력 패널의 레이아웃과 반응형 표시를 개선했습니다.
  * 보고서 상태별 색상과 범례를 명확히 구분했습니다.
  * 긴 딜 이름은 보기 좋게 줄여 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->