### PR TITLE
미팅 보고서 작성·상세 화면을 재구성합니다

### DIFF
--- a/frontend/src/api/errorMessage.ts
+++ b/frontend/src/api/errorMessage.ts
@@ -59,27 +59,33 @@ const MESSAGE_BY_DETAIL: Record<string, string> = {
   ocr_unavailable: '문자 인식 서버에 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.',
   llm_not_configured: 'AI 처리 설정이 완료되지 않았습니다. 서버 설정을 확인해 주세요.',
   ...Object.fromEntries(
-    ['agent_run_timeout', 'report_generation_timeout', 'meeting_content_timeout'].map((code) => [
+    [
+      'agent_run_timeout',
+      'report_generation_timeout',
+      'meeting_content_timeout',
+      'report_agent_timeout',
+    ].map((code) => [
       code,
-      'AI 처리가 제한시간 안에 끝나지 않았습니다. 입력은 유지됩니다. 다시 시도해 주세요.',
+      'AI 보고서 작성이 제한시간 안에 끝나지 않았습니다. 다시 시도해 주세요.',
     ]),
   ),
   ...Object.fromEntries(
+    ['agent_run_failed', 'agent_run_unexpected_error', 'report_generation_failed'].map((code) => [
+      code,
+      'AI 보고서 작성이 중간에 멈췄습니다. 다시 시도해 주세요.',
+    ]),
+  ),
+  meeting_content_failed: 'AI가 미팅 원문을 읽지 못했습니다. 원문을 확인한 뒤 다시 시도해 주세요.',
+  // 응답은 왔지만 보고서 형식이 아닌 경우입니다. 원인이 달라 다시 시도의 성격도 다릅니다.
+  ...Object.fromEntries(
     [
-      'agent_run_failed',
-      'agent_run_unexpected_error',
-      'report_generation_failed',
-      'meeting_content_failed',
       'report_output_invalid',
       'llm_output_schema_mismatch',
       'llm_response_not_object',
       'llm_response_not_json',
-      'empty_llm_output',
-    ].map((code) => [
-      code,
-      'AI 보고서를 완성하지 못했습니다. 입력은 유지됩니다. 다시 시도해 주세요.',
-    ]),
+    ].map((code) => [code, 'AI 응답을 보고서 형식으로 읽지 못했습니다. 다시 시도해 주세요.']),
   ),
+  empty_llm_output: 'AI가 보고서 내용을 만들지 못했습니다. 원문을 보완한 뒤 다시 시도해 주세요.',
   ...Object.fromEntries(
     [401, 403].map((status) => [
       `llm_provider_error:${status}`,
@@ -164,7 +170,7 @@ const MESSAGE_BY_DETAIL: Record<string, string> = {
   meeting_notes_empty: '기록된 공통·미지정 내용은 비워서 저장할 수 없습니다.',
   meeting_notes_without_evidence: '근거가 없는 공통·미지정 항목에는 메모를 추가할 수 없습니다.',
   report_agent_output_invalid:
-    'AI가 보고서 초안을 정상적으로 구성하지 못했습니다. 입력한 내용은 유지됩니다. 다시 시도해 주세요.',
+    'AI가 보고서 초안을 정상적으로 구성하지 못했습니다. 다시 시도해 주세요.',
   meeting_analysis_failed: '미팅 분석을 완료하지 못했습니다. 다시 시도해 주세요.',
   report_attachment_extraction_failed:
     '첨부 파일에서 내용을 읽지 못했습니다. 파일을 확인한 뒤 다시 올려 주세요.',
@@ -236,9 +242,11 @@ export function messageForCode(code: string, fallback: string): string {
 }
 
 export function reportGenerationMessage(code: string): string {
+  // 모르는 코드는 문구로 바꿀 수 없습니다. 원인을 잃지 않게 원문을 함께 보여 줍니다.
+  const reason = code.trim().slice(0, 120)
   return messageForCode(
     code,
-    'AI 보고서 작성을 완료하지 못했습니다. 입력한 내용은 유지됩니다. 다시 시도해 주세요.',
+    `AI 보고서 작성을 완료하지 못했습니다. 다시 시도해 주세요.${reason ? ` (${reason})` : ''}`,
   )
 }
 

--- a/frontend/src/components/Button/Button.tsx
+++ b/frontend/src/components/Button/Button.tsx
@@ -1,8 +1,8 @@
-import type { ButtonHTMLAttributes, ReactNode } from 'react'
+import type { ComponentPropsWithRef, ReactNode } from 'react'
 
 import { buttonClass, type ButtonSize, type ButtonVariant } from './buttonClass'
 
-interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+interface ButtonProps extends ComponentPropsWithRef<'button'> {
   children: ReactNode
   variant?: ButtonVariant
   size?: ButtonSize

--- a/frontend/src/components/StatusBadge/StatusBadge.module.scss
+++ b/frontend/src/components/StatusBadge/StatusBadge.module.scss
@@ -3,6 +3,7 @@
 
   // 같은 줄에 서는 담당자 이름표와 키를 맞춥니다.
   height: 22px;
+  gap: 4px;
   padding: 0 8px;
   font-size: 11px;
   white-space: nowrap;

--- a/frontend/src/components/StatusBadge/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge/StatusBadge.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react'
+
 import styles from './StatusBadge.module.scss'
 
 /** 배지 색. neutral 은 tag-pill 기본색으로, 아직 아무 일도 일어나지 않은 상태에 씁니다. */
@@ -6,6 +8,8 @@ export type StatusTone = 'neutral' | 'blue' | 'orange' | 'green' | 'red'
 interface Props {
   label: string
   tone?: StatusTone
+  /** 글자 앞에 서는 표시. 상태를 한 번 더 말해야 하는 머리 띠에서만 씁니다. */
+  icon?: ReactNode
 }
 
 const TONE: Record<StatusTone, string> = {
@@ -16,10 +20,11 @@ const TONE: Record<StatusTone, string> = {
   red: 'isRed',
 }
 
-export default function StatusBadge({ label, tone = 'neutral' }: Props) {
+export default function StatusBadge({ label, tone = 'neutral', icon }: Props) {
   const toneClass = TONE[tone]
   return (
     <span className={toneClass ? `${styles.badge} ${styles[toneClass]}` : styles.badge}>
+      {icon}
       {label}
     </span>
   )

--- a/frontend/src/pages/Daily/MeetingPick.module.scss
+++ b/frontend/src/pages/Daily/MeetingPick.module.scss
@@ -1,10 +1,5 @@
-.page {
-  max-width: 1080px;
-  margin: 0 auto;
-}
-
 .back {
-  margin-bottom: var(--s3);
+  margin-bottom: var(--s4);
 }
 
 .calendar {

--- a/frontend/src/pages/Daily/MeetingPick.tsx
+++ b/frontend/src/pages/Daily/MeetingPick.tsx
@@ -121,7 +121,7 @@ export default function MeetingPick() {
   const canShowNextWeek = iso(weekDays(weekOffset + 1)[0]) <= TODAY_ISO
 
   return (
-    <section className={styles.page} aria-busy={loading}>
+    <section aria-busy={loading}>
       <h1 className="sr-only">미팅 보고서 작성</h1>
 
       <DailyListLink back tab="meeting" className={styles.back} />

--- a/frontend/src/pages/Daily/components/DailyListLink/DailyListLink.module.scss
+++ b/frontend/src/pages/Daily/components/DailyListLink/DailyListLink.module.scss
@@ -3,8 +3,14 @@
   padding-right: var(--s3);
 }
 
-/* 되돌아가기 모양에서는 화살표가 앞으로 오므로 줄이는 쪽도 뒤집습니다. */
+/* 되돌아가는 길은 버튼이 아니라 파란 글자 한 줄입니다. */
 .back {
-  padding-right: var(--s4);
-  padding-left: var(--s3);
+  @include back-link;
+}
+
+/* 머리 띠 안에서는 버튼이 아니라 이 문서가 어디에서 왔는지 가리키는 줄입니다. */
+.crumb {
+  @include back-link;
+
+  font-size: 12px;
 }

--- a/frontend/src/pages/Daily/components/DailyListLink/DailyListLink.tsx
+++ b/frontend/src/pages/Daily/components/DailyListLink/DailyListLink.tsx
@@ -6,7 +6,7 @@
 import { Link } from 'react-router'
 
 import { buttonClass } from '@/components/Button'
-import { ChevronLeftIcon, ChevronRightIcon } from '@/components/icons'
+import { ChevronLeftIcon, ChevronRightIcon, DailyReportIcon } from '@/components/icons'
 
 import { dailyListPath, type Period } from '../../periods'
 
@@ -19,19 +19,38 @@ interface Props {
   className?: string
   /** 본문 위 왼쪽에 서서 되돌아가는 길로 읽힐 때. 화살표가 글자 앞으로 갑니다. */
   back?: boolean
+  /** 머리 띠 안에 들어갈 때. 버튼이 아니라 어디에서 왔는지를 가리키는 한 줄입니다. */
+  crumb?: boolean
 }
 
-export default function DailyListLink({ tab, className, back = false }: Props) {
-  const own = back ? `${styles.root} ${styles.back}` : styles.root
+export default function DailyListLink({ tab, className, back = false, crumb = false }: Props) {
+  // 되돌아가는 길과 머리 띠의 자취는 같은 줄 모양입니다. 앞에 서는 표식만 다릅니다.
+  // 되돌아가는 길은 화살표로 방향을, 자취는 아이콘으로 어느 화면인지를 가리킵니다.
+  if (crumb || back) {
+    const own = crumb ? styles.crumb : styles.back
+
+    return (
+      <Link className={className ? `${own} ${className}` : own} to={dailyListPath(tab)}>
+        {crumb ? (
+          <DailyReportIcon width={15} height={15} />
+        ) : (
+          <ChevronLeftIcon width={15} height={15} />
+        )}
+        업무보고
+      </Link>
+    )
+  }
 
   return (
     <Link
-      className={buttonClass({ variant: 'outline' }, className ? `${own} ${className}` : own)}
+      className={buttonClass(
+        { variant: 'outline' },
+        className ? `${styles.root} ${className}` : styles.root,
+      )}
       to={dailyListPath(tab)}
     >
-      {back && <ChevronLeftIcon width={15} height={15} />}
       업무보고
-      {!back && <ChevronRightIcon width={15} height={15} />}
+      <ChevronRightIcon width={15} height={15} />
     </Link>
   )
 }

--- a/frontend/src/pages/Meetings/Compose.module.scss
+++ b/frontend/src/pages/Meetings/Compose.module.scss
@@ -11,19 +11,60 @@
 }
 
 /* 머리말 한 줄. 왼쪽은 나가는 길, 오른쪽은 PDF 입니다. 상세 화면과 같은 자리입니다. */
+/* 제목 없이 조작부만 서는 줄이라 판을 깔지 않고 바탕 위에 그대로 둡니다. */
 .head {
   flex: none;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--s2);
-  margin-bottom: var(--s3);
+  gap: var(--s3);
+  margin-bottom: var(--s4);
+
+  /*
+   * 넓은 화면은 .page 가 화면 높이에 맞춰져 머리말이 늘 보입니다.
+   * 페이지가 통째로 구르는 좁은 화면에서만 톱바 아래에 붙여 둡니다.
+   */
+  @include lg {
+    position: sticky;
+    top: calc(var(--topbar-h) + var(--s2));
+    z-index: 1;
+    // 판이 없으므로 아래로 지나가는 내용이 비쳐 보이지 않게 바탕색을 직접 깝니다.
+    padding-block: var(--s2);
+    background: var(--paper);
+  }
 }
 
-/* 화살표가 글자 앞에 서므로 줄이는 여백도 왼쪽입니다. */
+/* 머리말 가운데 자리. 알림이 없으면 빈 칸으로 남아 좌우 버튼 자리를 지킵니다. */
+.headNotice {
+  flex: 1;
+  min-width: 0;
+
+  > * + * {
+    margin-top: var(--s2);
+  }
+}
+
+/* 실패는 아니지만 놓치면 내용이 날아갑니다. 오류와 같은 무게로 둡니다. */
+.headNote {
+  flex: none;
+  color: var(--red-ink);
+  font-size: 13px;
+
+  &::before {
+    content: '* ';
+  }
+}
+
+/* 되돌아가기 반대편. 작성 버튼이 끝에 옵니다. */
+.headActions {
+  display: flex;
+  align-items: center;
+  gap: var(--s2);
+}
+
+/* 되돌아가는 길은 버튼이 아니라 파란 글자 한 줄입니다. */
 .back {
-  padding-right: var(--s4);
-  padding-left: var(--s3);
+  @include back-link;
 }
 
 .locked {
@@ -44,12 +85,15 @@
 
 .mutationError {
   flex: none;
-  margin-bottom: var(--s3);
-  padding: var(--s3) var(--s4);
-  border-radius: var(--r-md);
-  background: var(--red-tint);
   color: var(--red-ink);
   font-size: 13px;
+
+  p,
+  li {
+    &::before {
+      content: '* ';
+    }
+  }
 }
 
 .generationNote {
@@ -111,6 +155,25 @@
   }
 }
 
+/*
+ * 왼쪽 열을 통째로 접은 상태. 보고서가 남은 폭을 모두 가져가고 왼쪽에는 다시 펴는 손잡이만 남습니다.
+ * .layout / .layout.solo 와 특정도를 맞춰 겹쳐 씁니다 — 파일이 붙는 순서에 좌우되지 않게 합니다.
+ */
+.layout.sideCollapsed {
+  grid-template-columns: auto minmax(0, 1fr);
+}
+
+/* 접기 손잡이. 왼쪽 열 머리에 붙어 제 글자만큼만 섭니다. */
+.sideToggle {
+  flex: none;
+  align-self: start;
+}
+
+/* 접힌 내용은 지우지 않고 감춥니다 — 첨부 원문을 펼쳐 둔 상태가 살아 있어야 합니다. */
+.collapsed.collapsed {
+  display: none;
+}
+
 /* 왼쪽 열. 위는 참고 자료, 아래는 입력판입니다. */
 .side {
   display: flex;
@@ -139,14 +202,8 @@
   }
 }
 
-.generateBar {
-  flex: none;
-  display: flex;
-  gap: var(--s2);
-  justify-content: space-between;
-}
-
-/* 두 버튼은 제 글자만큼만 서고 양쪽 끝으로 갈립니다. */
+/* 보고서 끝에 붙는 내려받기 줄. 오른쪽 끝에 섭니다. */
+/* 버튼은 제 글자만큼만 섭니다. 글자가 바뀌어도 폭만 따라 바뀝니다. */
 .generate {
   flex: none;
 }
@@ -188,50 +245,25 @@
 /* 여러 딜 카드의 저장 지점은 이 한 곳입니다. 긴 보고서를 내려 읽어도 상단에 남습니다. */
 .saveBar {
   flex: none;
-  position: sticky;
-  top: calc(var(--topbar-h) + var(--s3));
-  z-index: 2;
+  display: flex;
+  min-width: 0;
+  padding-top: var(--s3);
+}
+
+.saveActions {
+  flex: 1;
   display: flex;
   align-items: center;
-  gap: var(--s3);
-  min-width: 0;
-  padding: var(--s3);
-  border: 1px solid var(--line);
-  border-radius: var(--r-md);
-  background: var(--surface);
-  box-shadow: var(--sh-2);
-
-  @include sm {
-    flex-wrap: wrap;
-    top: 64px;
-  }
+  justify-content: space-between;
+  gap: var(--s2);
 }
 
-.saveCopy {
-  min-width: 0;
-  flex: 1;
-
-  strong {
-    display: block;
-    margin-bottom: 2px;
-    color: var(--ink);
-    font-size: 13px;
-    font-weight: 650;
-  }
-
-  p {
-    color: var(--muted);
-    font-size: 12px;
-    line-height: 1.5;
-    overflow-wrap: anywhere;
-  }
-}
-
+.pdfButton,
 .saveAllButton {
   flex: none;
 
   @include sm {
-    width: 100%;
+    flex: 1;
   }
 }
 
@@ -256,6 +288,7 @@
   .saveBar.saveBar,
   .generateBar.generateBar,
   .reference.reference,
+  .sideToggle.sideToggle,
   .input.input {
     display: none;
   }

--- a/frontend/src/pages/Meetings/Compose.tsx
+++ b/frontend/src/pages/Meetings/Compose.tsx
@@ -272,6 +272,7 @@ export default function Compose() {
     setCreateDealOpen(false)
     createDealKey.current = ''
     setDetailOpen(false)
+    setConfirm(null)
   }, [agendaId, item?.customerCompanyId])
 
   if (agendaLoading || loading) {
@@ -406,7 +407,9 @@ export default function Compose() {
     const state = draft.draftsByDeal[dealId]
     const losesContent =
       draft.salesDealIds.includes(dealId) &&
-      (state?.reportId !== undefined || !isMeetingBodyBlank(state?.values ?? {}))
+      (state?.reportId !== undefined ||
+        state?.touched === true ||
+        !isMeetingBodyBlank(state?.values ?? {}))
     if (losesContent) setConfirm({ kind: 'deselect', dealId })
     else draft.toggleSalesDeal(dealId)
   }

--- a/frontend/src/pages/Meetings/Compose.tsx
+++ b/frontend/src/pages/Meetings/Compose.tsx
@@ -20,8 +20,8 @@ import {
   waitForMeetingAnalysis,
   waitForMeetingProcessing,
 } from '@/api/reportAgent'
-import Button, { buttonClass } from '@/components/Button'
-import { ChevronLeftIcon } from '@/components/icons'
+import Button from '@/components/Button'
+import { ChevronLeftIcon, ChevronRightIcon, RefreshIcon } from '@/components/icons'
 import Modal from '@/components/Modal'
 import RecordDrawer from '@/pages/Dashboard/components/RecordDrawer'
 import { SkeletonDetail } from '@/components/Skeleton'
@@ -36,7 +36,6 @@ import type {
   MeetingProcessingOutput,
   ReportGenerationInput,
 } from '@/types'
-import { fmtDot, parseISO } from '@/utils/date'
 import { attachmentPayloadsOf, meetingAttachmentPurposeOf } from '@/utils/attachment'
 
 import DealReportCard from './components/DealReportCard'
@@ -56,7 +55,7 @@ import useMeetingReports, {
 
 import styles from './Compose.module.scss'
 
-type Confirm = { kind: 'regenerate' } | null
+type Confirm = { kind: 'regenerate' } | { kind: 'deselect'; dealId: string } | null
 
 function meetingInputOf(
   run: AgentRunResponse<MeetingProcessingOutput>,
@@ -93,6 +92,8 @@ export default function Compose() {
   const [submitting, setSubmitting] = useState(false)
   const [runError, setRunError] = useState<string | null>(null)
   const [runErrors, setRunErrors] = useState<Record<string, string>>({})
+  // 저장 전에 페이지를 다시 연 경우. 마지막 실행 결과를 되살렸다는 안내입니다.
+  const [restored, setRestored] = useState(false)
   // 등록 단계에서는 왼쪽 한 열만 씁니다. 작성을 시작해야 보고서 열이 열립니다.
   const [opened, setOpened] = useState(false)
   const agendaId = params.get('agenda') ?? ''
@@ -102,6 +103,7 @@ export default function Compose() {
     setSubmitting(false)
     setRunError(null)
     setRunErrors({})
+    setRestored(false)
     setOpened(false)
     recoveredAgendaId.current = ''
     generationAttempt.current = undefined
@@ -189,7 +191,8 @@ export default function Compose() {
         if (controller.signal.aborted) return
         acceptGenerated(completed.id, completed.output_snapshot)
         startAnalysisWatch(completed)
-        setRunErrors(completed.output_snapshot.errors)
+        // 지난 실행의 실패는 딜 카드가 따로 알립니다. 여기서는 되살렸다는 사실만 알립니다.
+        setRestored(Boolean(completed.output_snapshot.reports))
       } catch (reason: unknown) {
         if (!controller.signal.aborted) {
           const parentRunId =
@@ -200,7 +203,9 @@ export default function Compose() {
                 : undefined
           if (parentRunId) startAnalysisWatchForParent(parentRunId)
           generationFailed(dealIds, reason)
-          setRunError(errorMessage(reason, '진행 중인 보고서를 복구하지 못했습니다.'))
+          setRunError(
+            errorMessage(reason, 'AI 보고서 작성을 완료하지 못했습니다. 다시 시도해 주세요.'),
+          )
         }
       } finally {
         if (recoveryAbort.current === controller) {
@@ -242,7 +247,9 @@ export default function Compose() {
           !missingInput &&
           (!isAxiosError(reason) || reason.response?.status !== 404)
         ) {
-          setRunError(errorMessage(reason, '진행 중인 보고서 상태를 확인하지 못했습니다.'))
+          setRunError(
+            errorMessage(reason, 'AI 보고서 작성을 완료하지 못했습니다. 다시 시도해 주세요.'),
+          )
         }
       })
       .finally(() => {
@@ -259,6 +266,8 @@ export default function Compose() {
   const [confirm, setConfirm] = useState<Confirm>(null)
   // 일정 상세는 대시보드·캘린더가 쓰는 드로어를 그대로 엽니다. AI 브리핑까지 그 안에 있습니다.
   const [detailOpen, setDetailOpen] = useState(false)
+  // 보고서를 읽을 때는 왼쪽 입력부를 통째로 접어 본문에 폭을 넘깁니다. 기억하지는 않습니다.
+  const [sideCollapsed, setSideCollapsed] = useState(false)
   useEffect(() => {
     setCreateDealOpen(false)
     createDealKey.current = ''
@@ -315,13 +324,9 @@ export default function Compose() {
         isAuthorEditableReportStatus(savedReport.apiStatus)))
   const canEditDeal = (_dealId: string) => canEdit
   const lockedDealIds = savedReport?.review === 'approved' ? [...draft.salesDealIds] : []
-  const fixedDealIds = draft.salesDealIds.filter(
-    (dealId) => draft.draftsByDeal[dealId]?.reportId !== undefined,
-  )
   const busy = pending || generating || recovering || submitting || createDealOpen
   const meetingDate = savedReport?.date ?? draft.reportDate ?? item.date
   const meetingTime = savedReport?.time ?? item.time
-  const when = `미팅일 ${fmtDot(parseISO(meetingDate))} ${meetingTime}`
 
   const dealRef = (dealId: string): MeetingDealRef => {
     const deal = deals.deals.find((one) => one.id === dealId)
@@ -396,6 +401,16 @@ export default function Compose() {
     attachments: attachmentPayloadsOf(draft.attachments),
   })
 
+  // 선택을 풀면 그 딜의 보고서가 화면에서 빠집니다. 내용이 있을 때만 한 번 묻습니다.
+  const toggleDeal = (dealId: string) => {
+    const state = draft.draftsByDeal[dealId]
+    const losesContent =
+      draft.salesDealIds.includes(dealId) &&
+      (state?.reportId !== undefined || !isMeetingBodyBlank(state?.values ?? {}))
+    if (losesContent) setConfirm({ kind: 'deselect', dealId })
+    else draft.toggleSalesDeal(dealId)
+  }
+
   const generateAll = async () => {
     if (
       busy ||
@@ -419,6 +434,7 @@ export default function Compose() {
     beginGeneration(targets)
     setRunError(null)
     setRunErrors({})
+    setRestored(false)
     let analysisParentRunId: string | undefined
     try {
       const request = meetingGenerationRequestOf(payload, attempt.key)
@@ -482,7 +498,9 @@ export default function Compose() {
           )
         }
         generationFailed(targets, reason)
-        setRunError(errorMessage(reason, '미팅 처리를 완료하지 못했습니다.'))
+        setRunError(
+          errorMessage(reason, 'AI 보고서 작성을 완료하지 못했습니다. 다시 시도해 주세요.'),
+        )
       }
     } finally {
       if (generationAbort.current === controller) {
@@ -543,25 +561,65 @@ export default function Compose() {
       </h1>
 
       <div className={styles.head}>
-        <Link
-          className={buttonClass({ variant: 'outline' }, styles.back)}
-          to={meetingPickPath(item.date)}
-        >
+        <Link className={styles.back} to={meetingPickPath(item.date)}>
           <ChevronLeftIcon width={15} height={15} />
-          일정 고르기
+          미팅 리스트
         </Link>
 
-        {/* 아직 만든 보고서가 없는 등록 단계에서는 내려받을 것이 없습니다. */}
-        {showWork && (
+        <div className={styles.headNotice}>
+          {restored && !runError && (
+            <p className={styles.headNote}>
+              자동 임시 저장된 내용입니다. 미팅 보고서 작성 완료를 눌러야 저장됩니다.
+            </p>
+          )}
+          {(submitInputError || runError || saveError) && (
+            <p className={styles.mutationError} role="alert">
+              {submitInputError
+                ? reportGenerationMessage(submitInputError)
+                : (runError ?? saveError)}
+            </p>
+          )}
+          {Object.keys(runErrors).length > 0 && (
+            <div className={styles.mutationError} role="alert">
+              <ul>
+                {Object.entries(runErrors).map(([step, message]) => (
+                  <li key={step}>{reportGenerationMessage(message)}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+
+        <div className={styles.headActions}>
+          {/* 작성 시작 지점입니다. 이미 본문이 있으면 같은 버튼이 다시 생성으로 바뀝니다. */}
           <Button
-            variant="outline"
             type="button"
-            disabled={!printable}
-            onClick={() => window.print()}
+            variant={hasDraftContent ? 'outline' : 'primary'}
+            className={styles.generate}
+            aria-busy={generating || recovering}
+            onClick={requestGeneration}
+            disabled={
+              busy ||
+              !canEdit ||
+              !draft.canGenerate ||
+              Boolean(generationInputError) ||
+              !generatable ||
+              generating ||
+              recovering
+            }
           >
-            PDF 다운로드
+            {generating || recovering ? (
+              'AI 보고서 작성 중…'
+            ) : hasDraftContent ? (
+              <>
+                <RefreshIcon width={16} height={16} />
+                AI 보고서 다시 생성
+              </>
+            ) : (
+              'AI 보고서 작성'
+            )}
           </Button>
-        )}
+        </div>
       </div>
 
       {lockedDealIds.length > 0 && (
@@ -571,36 +629,50 @@ export default function Compose() {
         </p>
       )}
 
-      {(submitInputError || runError || saveError) && (
-        <p className={styles.mutationError} role="alert">
-          {submitInputError ? reportGenerationMessage(submitInputError) : (runError ?? saveError)}
-        </p>
-      )}
-      {Object.keys(runErrors).length > 0 && (
-        <div className={styles.mutationError} role="alert">
-          <p>일부 처리가 완료되지 않았습니다. 기존 작성 내용은 유지됩니다.</p>
-          <ul>
-            {Object.entries(runErrors).map(([step, message]) => (
-              <li key={step}>{reportGenerationMessage(message)}</li>
-            ))}
-          </ul>
-        </div>
-      )}
-
-      <div className={showWork ? styles.layout : `${styles.layout} ${styles.solo}`}>
+      <div
+        className={
+          showWork
+            ? sideCollapsed
+              ? `${styles.layout} ${styles.sideCollapsed}`
+              : styles.layout
+            : `${styles.layout} ${styles.solo}`
+        }
+      >
         <div className={styles.side}>
-          <div className={styles.sideContent}>
+          {/* 접기 손잡이는 미팅 정보 판의 머리에 있습니다. 접히면 그 판까지 사라지므로
+              다시 펴는 손잡이만 왼쪽 레일에 남깁니다. */}
+          {showWork && sideCollapsed && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              iconOnly
+              className={styles.sideToggle}
+              aria-expanded={false}
+              aria-controls="compose-side"
+              aria-label="미팅 정보·원문 펼치기"
+              onClick={() => setSideCollapsed(false)}
+            >
+              <ChevronRightIcon width={15} height={15} />
+            </Button>
+          )}
+          <div
+            id="compose-side"
+            className={
+              sideCollapsed ? `${styles.sideContent} ${styles.collapsed}` : styles.sideContent
+            }
+          >
             <aside className={styles.reference}>
               <MeetingInfoPanel
                 item={{ ...item, date: meetingDate, time: meetingTime }}
                 onOpenDetail={() => setDetailOpen(true)}
+                onCollapse={showWork ? () => setSideCollapsed(true) : undefined}
                 deals={deals.deals}
                 dealsLoading={deals.loading}
                 dealsError={deals.error}
                 onReloadDeals={deals.reload}
                 selectedDealIds={draft.salesDealIds}
-                fixedDealIds={fixedDealIds}
-                onToggleDeal={draft.toggleSalesDeal}
+                onToggleDeal={toggleDeal}
                 onCreateDeal={() => {
                   if (busy || !canEdit || !item.customerCompanyId || deals.loading) return
                   createDealKey.current = `${item.id}:${item.customerCompanyId}`
@@ -635,68 +707,10 @@ export default function Compose() {
               )}
             </div>
           </div>
-          <div className={styles.generateBar} aria-busy={generating || recovering}>
-            {/* AI 없이 쓰는 길. 보고서 열이 이미 열렸다면 이 자리에 둘 이유가 없습니다. */}
-            {!showWork && (
-              <Button
-                type="button"
-                variant="outline"
-                disabled={busy || !canEdit}
-                onClick={() => setOpened(true)}
-              >
-                직접 작성
-              </Button>
-            )}
-            <Button
-              type="button"
-              className={styles.generate}
-              onClick={requestGeneration}
-              disabled={
-                busy ||
-                !canEdit ||
-                !draft.canGenerate ||
-                Boolean(generationInputError) ||
-                !generatable ||
-                generating ||
-                recovering
-              }
-            >
-              {generating || recovering ? 'AI 보고서 작성 중…' : 'AI 보고서 작성'}
-            </Button>
-          </div>
         </div>
 
         {showWork && (
           <section className={styles.work} aria-label="미팅 보고서">
-            <div className={styles.saveBar} aria-busy={submitting || draft.attachmentsPending}>
-              <div className={styles.saveCopy}>
-                <strong>미팅 보고서</strong>
-                <p>
-                  미팅일 {fmtDot(parseISO(meetingDate))} · 작성 완료 후에도 이 날짜로 저장됩니다.
-                </p>
-                <p>
-                  {draft.salesDealIds.length > 0
-                    ? `공통 기록과 딜 ${draft.salesDealIds.length}건을 한 문서로 저장합니다.`
-                    : '딜 미지정 미팅 기록을 한 문서로 저장합니다.'}
-                </p>
-              </div>
-              <Button
-                type="button"
-                className={styles.saveAllButton}
-                aria-label="미팅 보고서 작성 완료"
-                disabled={
-                  busy ||
-                  draft.attachmentsPending ||
-                  !canEdit ||
-                  editableDealIds.length !== draft.salesDealIds.length ||
-                  Boolean(submitInputError) ||
-                  missingBody
-                }
-                onClick={() => void submitAll()}
-              >
-                {submitting ? '완료 중…' : '미팅 보고서 작성 완료'}
-              </Button>
-            </div>
             <div className={styles.reports}>
               {(draft.salesDealIds.length === 0 ||
                 result ||
@@ -717,7 +731,6 @@ export default function Compose() {
                   if (!state) return null
                   const deal = deals.deals.find((one) => one.id === dealId)
                   const savedSection = savedByDeal.get(dealId)
-                  const product = deal?.product ?? savedSection?.product
 
                   return (
                     <DealReportCard
@@ -727,7 +740,6 @@ export default function Compose() {
                       savedDeal={savedSection?.salesDeal}
                       draft={state}
                       progress={draft.processingProgress}
-                      when={`${when}${product ? ` · ${product}` : ''}`}
                       saving={pending}
                       generating={generating || recovering}
                       canGenerate={
@@ -741,6 +753,35 @@ export default function Compose() {
                     />
                   )
                 })}
+            </div>
+            <div className={styles.saveBar} aria-busy={submitting || draft.attachmentsPending}>
+              <div className={styles.saveActions}>
+                <Button
+                  variant="outline"
+                  type="button"
+                  className={styles.pdfButton}
+                  disabled={!printable}
+                  onClick={() => window.print()}
+                >
+                  PDF 다운로드
+                </Button>
+                <Button
+                  type="button"
+                  className={styles.saveAllButton}
+                  aria-label="미팅 보고서 작성 완료"
+                  disabled={
+                    busy ||
+                    draft.attachmentsPending ||
+                    !canEdit ||
+                    editableDealIds.length !== draft.salesDealIds.length ||
+                    Boolean(submitInputError) ||
+                    missingBody
+                  }
+                  onClick={() => void submitAll()}
+                >
+                  {submitting ? '완료 중…' : '미팅 보고서 작성 완료'}
+                </Button>
+              </div>
             </div>
           </section>
         )}
@@ -769,6 +810,35 @@ export default function Compose() {
           }
         >
           <p>현재 편집 중인 내용은 아직 미팅 보고서로 저장되지 않았습니다.</p>
+        </Modal>
+      )}
+      {confirm?.kind === 'deselect' && (
+        <Modal
+          title="이 딜을 보고서에서 뺄까요?"
+          description="선택을 풀면 이 딜의 보고서가 목록에서 사라집니다."
+          onClose={() => setConfirm(null)}
+          footer={
+            <>
+              <Button variant="outline" type="button" onClick={() => setConfirm(null)}>
+                취소
+              </Button>
+              <Button
+                type="button"
+                onClick={() => {
+                  const { dealId } = confirm
+                  setConfirm(null)
+                  draft.toggleSalesDeal(dealId)
+                }}
+              >
+                해제
+              </Button>
+            </>
+          }
+        >
+          <p>
+            다시 선택하면 작성한 내용이 그대로 돌아옵니다. 뺀 채로 저장하면 이미 저장된 딜 보고서는
+            삭제됩니다.
+          </p>
         </Modal>
       )}
       {detailOpen && <RecordDrawer item={item} onClose={() => setDetailOpen(false)} />}

--- a/frontend/src/pages/Meetings/Detail.module.scss
+++ b/frontend/src/pages/Meetings/Detail.module.scss
@@ -1,58 +1,96 @@
-/*
- * 머리말이 맡는 것은 이동뿐입니다. 이 문서에 하는 일(수정·PDF)은 전부 시트
- * 아래에 있습니다. 양 끝이 잡혀 있어야 띠로 보이므로 왼쪽에 정체, 오른쪽에
- * 갈 곳을 두고 아래를 실선으로 닫습니다. 카드 안쪽 여백과 글머리가 어긋나
- * 보이던 것도 이 선이 층을 갈라 주면서 정리됩니다.
- */
-.head {
+/* 머리 띠. 면과 물결은 작성 화면과 같은 것(page-banner)을 씁니다. */
+.banner {
+  @include page-banner;
+
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
-  gap: var(--s4);
+  gap: var(--s5);
   flex-wrap: wrap;
   margin-bottom: var(--s5);
-  padding-bottom: var(--s4);
-  border-bottom: 1px solid var(--line);
 }
 
 .heading {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
   min-width: 0;
-}
+  flex-direction: column;
+  gap: var(--s2);
 
-/* 머리말 위, 본문 왼쪽 끝에 섭니다. */
-.toDaily {
-  margin-bottom: var(--s3);
+  /* 글 앞에 선 파란 선 한 줄. 머리 띠의 어느 쪽이 본문인지 눈이 먼저 잡습니다. */
+  padding-left: var(--s4);
+  border-left: 3px solid var(--blue);
+
+  /* 좁은 폭에서는 머리 띠가 곧 한 열이라 세로선이 가리킬 바깥쪽이 없습니다. */
+  @include md {
+    padding-left: 0;
+    border-left: 0;
+  }
 }
 
 /* 회사 이름과 상태는 한 덩어리입니다. 이 기록이 무엇이고 지금 어디까지 왔는지. */
 .title {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: var(--s3);
   flex-wrap: wrap;
-  font-size: 18px;
+  font-size: 20px;
   font-weight: 700;
-  letter-spacing: -0.016em;
+  letter-spacing: -0.018em;
 }
 
 .meta {
   display: flex;
   align-items: center;
-  gap: var(--s2);
+  gap: var(--s3);
+  flex-wrap: wrap;
   color: var(--muted);
   font-size: 12px;
+}
+
+/* 앞의 아이콘이 무엇에 대한 값인지 말합니다. 그래서 '미팅일' 같은 말머리를 뺐습니다. */
+.metaItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+
+  svg {
+    flex: none;
+    color: var(--muted-2);
+  }
+}
+
+/* 가운뎃점 대신 선 한 줄. 항목마다 아이콘이 서 있어 점은 묻힙니다. */
+.bar {
+  width: 1px;
+  height: 12px;
+  background: var(--line-2);
+}
+
+/* 좁은 폭에서는 날짜가 한 줄을 다 쓰고, 작성자와 건수가 그 아래로 함께 내려갑니다. */
+@include md {
+  .meta {
+    row-gap: 0;
+  }
+
+  /* 줄바꿈 자리이자 두 줄 사이 간격입니다(행 간격을 0으로 두어 한 번만 벌어집니다). */
+  .breakBar {
+    width: 100%;
+    height: var(--s1);
+    background: none;
+  }
 }
 
 .when {
   font-variant-numeric: tabular-nums;
 }
 
-/* 테두리색(--line)은 글자로 쓰기엔 너무 옅어 가운뎃점이 사라집니다. */
-.dot {
-  color: var(--muted-2);
+/* 머리 띠 오른쪽 끝. 정체 덩어리가 폭을 다 쓰고 남은 자리에 섭니다. */
+.actions {
+  display: flex;
+  align-items: center;
+  gap: var(--s2);
+  flex: none;
+  margin-left: auto;
 }
 
 /* 확인이 끝난 보고서. 수정 버튼 자리에 왜 없는지를 대신 둡니다. */
@@ -70,10 +108,95 @@
   align-items: start;
 
   // 작성 화면과 같은 비율·같은 간격입니다. 두 화면을 오갈 때 문서가 제자리에 있어야 합니다.
+  // 한 열로 접히면 미팅 정보가 제목 바로 다음입니다(접어 둘 수 있습니다).
   @include lg {
     grid-template-columns: minmax(0, 1fr);
-    grid-template-areas: 'sheet' 'materials';
+    grid-template-areas: 'materials' 'sheet';
     gap: var(--s4);
+  }
+}
+
+/*
+ * 자료 열을 접은 상태. 보고서가 폭을 다 가져갑니다. 한 열로 접히는 폭에서는
+ * 나란히 볼 일이 없으므로 접기 자체를 쓰지 않습니다(손잡이도 감춥니다).
+ * .layout 과 특정도를 맞춰 겹쳐 씁니다 — 파일이 붙는 순서에 좌우되지 않게 합니다.
+ */
+.layout.materialsCollapsed {
+  grid-template-columns: auto minmax(0, 1fr);
+
+  @include lg {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas: 'materials' 'sheet';
+  }
+}
+
+.collapsed.collapsed {
+  display: none;
+
+  @include lg {
+    display: block;
+
+    .materialsBody {
+      display: none;
+    }
+
+    .materialHead {
+      margin-bottom: 0;
+    }
+
+    .mobileToggle svg {
+      transform: none;
+    }
+  }
+}
+
+/* 좁은 폭에서만 서는 여닫이 머리. 넓은 폭에서는 왼쪽 열의 접기 손잡이가 그 일을 합니다. */
+.mobileToggle {
+  display: none;
+
+  @include lg {
+    display: inline-flex;
+    align-items: center;
+    margin-left: auto;
+    padding: 0;
+    border: 0;
+    background: none;
+    color: var(--ink-2);
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+
+    &:focus-visible {
+      outline: 3px solid var(--blue-ring);
+      outline-offset: 4px;
+      border-radius: var(--r-sm);
+    }
+
+    svg {
+      flex: none;
+      color: var(--muted);
+      transform: rotate(180deg);
+    }
+  }
+}
+
+/* 다시 펴는 손잡이. 접힌 자료 열의 자리에 제 글자만큼만 서서 어디를 펴는지 알립니다. */
+.materialsToggle {
+  grid-area: materials;
+  align-self: start;
+
+  @include lg {
+    display: none;
+  }
+}
+
+/* 접기 손잡이는 판의 머리 오른쪽 끝. 한 열로 접히면 접을 이유가 없어 사라집니다. */
+.collapseAction {
+  flex: none;
+  margin-left: auto;
+
+  @include lg {
+    display: none;
   }
 }
 
@@ -90,29 +213,11 @@
   border-radius: var(--r-lg);
   background: var(--surface);
 
-  /*
-   * 보고서를 끝까지 내려도 자료는 제자리에 남습니다. 대조해 가며 읽는 것이
-   * 이 화면의 일이기 때문입니다. 한 열로 접히면 나란히 볼 일이 없으므로
-   * 아래에서 도로 풉니다.
-   *
-   * 길이는 미팅 내용 쪽에서 잡습니다. 여기 max-height 는 첨부가 아주 많을 때를
-   * 위한 뒷받침이라, 평소에는 걸리지 않습니다.
-   */
-  position: sticky;
-  top: var(--s5);
-  max-height: calc(100vh - var(--s7));
-  overflow-y: auto;
-
+  /* 길이는 잘라 두지 않고 페이지와 함께 흐릅니다. 보고서만 볼 때는 통째로 접습니다. */
   section + section {
     margin-top: var(--s5);
     padding-top: var(--s5);
     border-top: 1px solid var(--line);
-  }
-
-  @include lg {
-    position: static;
-    max-height: none;
-    overflow: visible;
   }
 
   @include md {
@@ -120,14 +225,21 @@
   }
 }
 
+/* 판의 머리. 제목이 왼쪽에 붙고 그 판의 조작이 오른쪽으로 이어집니다. */
 .materialHead {
   display: flex;
-  align-items: baseline;
+  align-items: center;
+  flex-wrap: wrap;
   gap: var(--s2);
   margin-bottom: var(--s3);
   color: var(--ink-2);
   font-size: 12px;
   font-weight: 600;
+
+  h2 {
+    font-size: inherit;
+    font-weight: inherit;
+  }
 }
 
 /* 보고서 열: 종이 한 장과 그 아래 조작부. */
@@ -145,10 +257,6 @@
   gap: var(--s5);
 }
 
-.assessment {
-  flex: none;
-}
-
 .sectionError {
   margin-top: var(--s3);
   color: var(--danger);
@@ -164,32 +272,7 @@
   text-align: center;
 }
 
-/*
- * 작성 화면은 시트 아래 같은 자리에 제출 버튼을 둡니다. 두 화면을 오갈 때
- * 주된 버튼이 같은 곳에 있습니다. 다만 여기서는 따라붙지 않습니다 —
- * 다 읽은 뒤에 하는 일이라 끝에서 만나면 됩니다.
- */
-.docActions {
-  display: flex;
-  align-items: center;
-  gap: var(--s2);
-  margin-top: var(--s4);
-
-  @include sm {
-    flex-wrap: wrap;
-  }
-}
-
-/* 주된 것은 오른쪽 끝. 작성 화면의 제출 버튼과 같은 자리입니다. */
-.trailing {
-  margin-left: auto;
-
-  @include sm {
-    margin-left: 0;
-  }
-}
-
-/* 작성 화면의 딜 카드와 같은 머리·본문 구조입니다. */
+/* 작성 화면의 딜 카드와 같은 머리·본문 구조입니다. 머리는 DealCardHeader 가 맡습니다. */
 .card {
   min-width: 0;
   overflow: hidden;
@@ -199,87 +282,21 @@
   box-shadow: var(--sh-2);
 }
 
-.cardHead {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  min-height: 78px;
-  align-items: center;
-  gap: var(--s3);
-  padding: var(--s4) var(--s5);
-  border-bottom: 1px solid var(--line);
-
-  @include sm {
-    grid-template-columns: minmax(0, 1fr);
-
-    .assessment {
-      justify-self: start;
-    }
-  }
-}
-
-.dealIdentity {
-  display: flex;
-  min-width: 0;
-  flex-direction: column;
-  gap: var(--s1);
-  border-radius: var(--r-sm);
-  color: inherit;
-  text-decoration: none;
-
-  &:hover .dealLine {
-    color: var(--blue);
-    text-decoration: underline;
-    text-underline-offset: 3px;
-  }
-
-  &:focus-visible {
-    outline: 3px solid var(--blue-ring);
-    outline-offset: 3px;
-  }
-}
-
-.dealLine {
-  color: var(--blue);
-  font-size: 15px;
-  letter-spacing: -0.015em;
-}
-
-.dealTitle {
-  overflow: hidden;
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 500;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .cardBody {
   padding: var(--s5);
+  border-top: 1px solid var(--line);
 
   @include md {
     padding: var(--s4);
   }
 }
 
-.titleBlock {
-  display: flex;
-  flex-direction: column;
-  gap: var(--s2);
-  margin-bottom: var(--s6);
-}
-
 /* 작성 화면에서는 고쳐 쓰는 칸이지만 여기서는 그냥 머리글입니다. */
 .docTitle {
+  margin-bottom: var(--s6);
   font-size: 22px;
   font-weight: 700;
   letter-spacing: -0.02em;
-}
-
-.docWhen {
-  align-self: flex-end;
-  color: var(--muted);
-  font-size: 13px;
-  font-variant-numeric: tabular-nums;
 }
 
 .reportBody {
@@ -309,22 +326,12 @@
   line-height: 1.7;
 }
 
-/*
- * 미팅 내용만 길이가 정해져 있지 않습니다. 그대로 두면 자료 판이 보고서보다
- * 훨씬 길어져, 결과물이 곁다리처럼 보입니다. 스크롤은 길어지는 이 한 곳에만 둡니다.
- */
+/* 미팅 내용은 잘라 두지 않습니다. 길면 자료 열째로 접어 두면 됩니다. */
 .transcript {
-  max-height: 340px;
-  overflow-y: auto;
   color: var(--ink-2);
   font-size: 13px;
   line-height: 1.8;
   white-space: pre-wrap;
-
-  @include lg {
-    max-height: none;
-    overflow: visible;
-  }
 }
 
 .missing {
@@ -347,15 +354,27 @@
  */
 @media print {
   .materials.materials,
-  .docActions.docActions,
-  .toDaily.toDaily {
+  .materialsToggle.materialsToggle,
+  .actions.actions {
     display: none;
   }
 
-  /* 종이에서는 머리말이 문서의 머리글입니다. 화면용 구분선은 남기지 않습니다. */
-  .head.head {
-    padding-bottom: 0;
-    border-bottom: 0;
+  /* 종이에서는 머리 띠가 문서의 머리글입니다. 면도 물결도 남기지 않습니다. */
+  .banner.banner {
+    margin-bottom: var(--s5);
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  .banner.banner::after {
+    display: none;
+  }
+
+  /* 종이에서 목록으로 돌아가는 길은 쓸 수 없습니다. */
+  .heading.heading a {
+    display: none;
   }
 
   .layout.layout {
@@ -369,12 +388,8 @@
     break-inside: avoid;
   }
 
-  .cardHead.cardHead {
-    min-height: 0;
-    padding: 0 0 var(--s3);
-  }
-
   .cardBody.cardBody {
+    display: block;
     padding: var(--s3) 0 0;
   }
 

--- a/frontend/src/pages/Meetings/Detail.tsx
+++ b/frontend/src/pages/Meetings/Detail.tsx
@@ -1,21 +1,35 @@
 // 제출한 미팅 기록을 읽는 화면입니다. 작성 화면과 같은 컴포넌트를 읽기 모드로 씁니다.
+import { useId, useState } from 'react'
 import { Link, useParams } from 'react-router'
 
 import { useCurrentUser } from '@/auth/sessionContext'
 import AttachmentPanel from '@/components/AttachmentPanel'
 import Button, { buttonClass } from '@/components/Button'
-import { EditIcon } from '@/components/icons'
+import {
+  CalendarIcon,
+  CheckIcon,
+  ChevronDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  DownloadIcon,
+  EditIcon,
+  SheetIcon,
+  TeamIcon,
+} from '@/components/icons'
 import ReportBody from '@/components/ReportBody'
 import { SkeletonDetail } from '@/components/Skeleton'
 import StatusBadge, { type StatusTone } from '@/components/StatusBadge'
-import { dealDetailPath, meetingComposePath, ROUTES } from '@/constants/routes'
+import { meetingComposePath, ROUTES } from '@/constants/routes'
+import RecordDrawer from '@/pages/Dashboard/components/RecordDrawer'
 import DailyListLink from '@/pages/Daily/components/DailyListLink'
+import { useAgendaItem } from '@/shared/agenda'
 import { useReportDetail } from '@/shared/reportQuery'
 import { isAuthorEditableReportStatus } from '@/shared/reports'
-import { fmtDay, fmtDot, parseISO } from '@/utils/date'
+import { fmtDay, parseISO } from '@/utils/date'
 import { meetingAttachmentPurposeOf } from '@/utils/attachment'
 import type { MeetingDealSection } from '@/types'
 
+import DealCardHeader from './components/DealCardHeader'
 import MeetingFacts from './components/MeetingFacts'
 import MeetingSharedPanel from './components/MeetingSharedPanel'
 import { isInsufficientDealPrediction } from './generatedDraft'
@@ -53,6 +67,54 @@ function assessmentBadge(section: MeetingDealSection): {
       }
 }
 
+/*
+ * 딜 한 건의 보고서. 작성 화면의 딜 카드와 같은 머리를 씁니다.
+ */
+function DealSectionCard({
+  section,
+  fallbackTitle,
+}: {
+  section: MeetingDealSection
+  fallbackTitle: string
+}) {
+  const titleId = useId()
+
+  return (
+    <article className={styles.card} aria-labelledby={titleId}>
+      <DealCardHeader
+        dealId={section.salesDealId}
+        label={section.salesDeal.label}
+        note={section.salesDeal.note}
+        badge={assessmentBadge(section)}
+      />
+
+      <div className={styles.cardBody}>
+        {/* 미팅일은 머리 띠에, 제품은 딜 머리에 이미 있습니다. 여기는 제목만입니다. */}
+        <h2 className={styles.docTitle} id={titleId}>
+          {section.title || fallbackTitle}
+        </h2>
+
+        {section.values.body?.trim() ? (
+          <ReportBody className={styles.reportBody} body={section.values.body} />
+        ) : (
+          <p className={styles.emptyBody}>작성된 내용이 없습니다.</p>
+        )}
+        {section.evidence && <p className={styles.evidence}>{section.evidence}</p>}
+        {section.analysisError && !isInsufficientDealPrediction(section.analysisError) && (
+          <p className={styles.sectionError} role="status">
+            ML 분석: {section.analysisError}
+          </p>
+        )}
+        {section.reportError && (
+          <p className={styles.sectionError} role="status">
+            보고서 생성: {section.reportError}
+          </p>
+        )}
+      </div>
+    </article>
+  )
+}
+
 export default function Detail() {
   const { reportId } = useParams()
   const { item, loading, error, reload } = useReportDetail(
@@ -64,6 +126,11 @@ export default function Detail() {
   // 보고서는 쓴 사람만 고칩니다. 팀장이 팀원의 보고서를 열어도 고치는 길은 서지 않습니다.
   const { memberId } = useCurrentUser()
   const isMine = report?.ownerMemberId === memberId
+  // 작성 화면과 같은 손잡이입니다. 보고서만 넓게 읽고 싶을 때 자료 열을 접습니다.
+  const [materialsCollapsed, setMaterialsCollapsed] = useState(false)
+  // 자세히 보기는 작성 화면과 같은 드로어입니다. 일정 원본은 보고서에 없어 따로 받아 옵니다.
+  const [detailOpen, setDetailOpen] = useState(false)
+  const agenda = useAgendaItem(report?.agendaId ?? '')
 
   if (loading)
     return (
@@ -97,6 +164,7 @@ export default function Detail() {
   }
 
   const editable = isAuthorEditableReportStatus(report.apiStatus)
+  const meetingDay = parseISO(report.date)
 
   return (
     <section>
@@ -104,41 +172,67 @@ export default function Detail() {
         {report.hospital} {report.title} 미팅 보고서
       </h1>
 
-      {/* 미팅 기록에서 나가므로 목록도 미팅 보고서 탭으로 엽니다. */}
-      <DailyListLink back tab="meeting" className={styles.toDaily} />
-
       {/*
-        머리말은 어느 회사의 언제 기록인지와 지금 어디까지 왔는지만 말합니다.
-        미팅 제목은 오른쪽 보고서의 머리글이 이미 크게 달고 있어 여기서 뺐습니다.
+        머리 띠 하나가 어디에서 왔는지, 어느 회사의 언제 기록인지, 지금 어디까지
+        왔는지, 그리고 이 문서로 할 수 있는 일을 함께 답니다. 미팅 제목은 오른쪽
+        보고서의 머리글이 이미 크게 달고 있어 여기서는 회사 옆에 붙여만 둡니다.
       */}
-      <header className={styles.head}>
+      <header className={styles.banner}>
         <div className={styles.heading}>
+          {/* 미팅 기록에서 나가므로 목록도 미팅 보고서 탭으로 엽니다. */}
+          <DailyListLink crumb tab="meeting" />
+
           <p className={styles.title}>
             {report.hospital}
             {report.title && <span>{report.title}</span>}
             <StatusBadge
               label={meetingStatusLabel(report.apiStatus ?? 'draft')}
               tone={MEETING_STATUS_TONE[meetingStatusLabel(report.apiStatus ?? 'draft')]}
+              icon={<CheckIcon width={12} height={12} />}
             />
           </p>
 
           <p className={styles.meta}>
-            <span className={styles.when}>
-              미팅일 {fmtDay(parseISO(report.date))} {report.time}
+            <span className={styles.metaItem}>
+              <CalendarIcon width={14} height={14} />
+              <span className={styles.when}>
+                {meetingDay.getFullYear()}년 {fmtDay(meetingDay)} {report.time}
+              </span>
             </span>
-            <span className={styles.dot} aria-hidden="true">
-              ·
+            <span className={`${styles.bar} ${styles.breakBar}`} aria-hidden="true" />
+            <span className={styles.metaItem}>
+              <TeamIcon width={14} height={14} />
+              작성자 {report.owner}
             </span>
-            <span>작성자 {report.owner}</span>
-            <span className={styles.dot} aria-hidden="true">
-              ·
-            </span>
-            <span>
+            <span className={styles.bar} aria-hidden="true" />
+            <span className={styles.metaItem}>
+              <SheetIcon width={14} height={14} />
               {report.dealSections.length > 0
-                ? `딜 ${report.dealSections.length}건`
+                ? `총 ${report.dealSections.length}건`
                 : '관련 딜 없음'}
             </span>
           </p>
+        </div>
+
+        <div className={styles.actions}>
+          {/* 잠그는 것은 서버입니다(approved 는 더 이상 고칠 수 없습니다). */}
+          {!editable ? (
+            <span className={styles.sealed}>작성이 완료되어 수정할 수 없습니다</span>
+          ) : isMine ? (
+            <Link
+              className={buttonClass({ variant: 'outline' })}
+              to={meetingComposePath(report.agendaId)}
+            >
+              <EditIcon width={15} height={15} />
+              수정하기
+            </Link>
+          ) : null}
+
+          {/* 작성 화면과 같은 버튼입니다. 인쇄가 곧 PDF 입니다. */}
+          <Button type="button" onClick={() => window.print()}>
+            <DownloadIcon width={15} height={15} />
+            PDF 다운로드
+          </Button>
         </div>
       </header>
 
@@ -147,133 +241,129 @@ export default function Detail() {
         DOM 순서는 건드리지 않습니다. 좁은 화면에서 한 열로 접힐 때 긴 미팅 내용
         아래에 보고서가 묻히면 안 되고, 키보드 순서도 두 폭에서 같아야 합니다.
       */}
-      <div className={styles.layout}>
+      <div
+        className={
+          materialsCollapsed ? `${styles.layout} ${styles.materialsCollapsed}` : styles.layout
+        }
+      >
         <div className={styles.report}>
           <MeetingSharedPanel shared={report.meetingShared ?? null} />
           {report.dealSections.length === 0 ? (
             !report.meetingShared && <p className={styles.emptySections}>작성된 내용이 없습니다.</p>
           ) : (
             <div className={styles.dealSections}>
-              {report.dealSections.map((section, index) => {
-                const badge = assessmentBadge(section)
-                const titleId = `deal-report-${section.salesDealId}-${index}`
-                return (
-                  <article className={styles.card} key={titleId} aria-labelledby={titleId}>
-                    <header className={styles.cardHead}>
-                      <Link
-                        className={styles.dealIdentity}
-                        to={dealDetailPath(section.salesDealId)}
-                      >
-                        <strong className={styles.dealLine}>{section.salesDeal.label}</strong>
-                        {section.salesDeal.note && (
-                          <span className={styles.dealTitle}>{section.salesDeal.note}</span>
-                        )}
-                      </Link>
-                      <span className={styles.assessment} title={badge.title}>
-                        <StatusBadge label={badge.label} tone={badge.tone} />
-                      </span>
-                    </header>
-
-                    <div className={styles.cardBody}>
-                      <div className={styles.titleBlock}>
-                        <h2 className={styles.docTitle} id={titleId}>
-                          {section.title || report.title}
-                        </h2>
-                        <p className={styles.docWhen}>
-                          미팅일 {fmtDot(parseISO(report.date))} {report.time}
-                          {section.product && ` · ${section.product}`}
-                        </p>
-                      </div>
-
-                      {section.values.body?.trim() ? (
-                        <ReportBody className={styles.reportBody} body={section.values.body} />
-                      ) : (
-                        <p className={styles.emptyBody}>작성된 내용이 없습니다.</p>
-                      )}
-                      {section.evidence && <p className={styles.evidence}>{section.evidence}</p>}
-                      {section.analysisError &&
-                        !isInsufficientDealPrediction(section.analysisError) && (
-                          <p className={styles.sectionError} role="status">
-                            ML 분석: {section.analysisError}
-                          </p>
-                        )}
-                      {section.reportError && (
-                        <p className={styles.sectionError} role="status">
-                          보고서 생성: {section.reportError}
-                        </p>
-                      )}
-                    </div>
-                  </article>
-                )
-              })}
+              {report.dealSections.map((section, index) => (
+                <DealSectionCard
+                  key={`deal-report-${section.salesDealId}-${index}`}
+                  section={section}
+                  fallbackTitle={report.title}
+                />
+              ))}
             </div>
           )}
-
-          {/*
-            고치는 것은 다 읽은 다음의 일입니다. 머리말에서 먼저 소리치지 않고
-            보고서 끝에서 기다립니다. 작성 화면도 제출 버튼이 시트 아래에 있습니다.
-          */}
-          <div className={styles.docActions}>
-            {/* 작성 화면과 같은 자리, 같은 버튼입니다. 인쇄가 곧 PDF 입니다. */}
-            <Button variant="outline" type="button" onClick={() => window.print()}>
-              PDF 다운로드
-            </Button>
-
-            {/* 잠그는 것은 서버입니다(approved 는 더 이상 고칠 수 없습니다).
-                팀장 검토를 받는 문서가 아니므로 문구에서 팀장을 뺐습니다. */}
-            {!editable ? (
-              <span className={`${styles.sealed} ${styles.trailing}`}>
-                작성이 완료되어 수정할 수 없습니다
-              </span>
-            ) : isMine ? (
-              <Link
-                className={buttonClass({}, styles.trailing)}
-                to={meetingComposePath(report.agendaId)}
-              >
-                <EditIcon width={15} height={15} />
-                수정하기
-              </Link>
-            ) : null}
-          </div>
         </div>
 
         {/* 보고서를 쓸 때 낸 것들. 짧은 것부터 두고, 길이가 정해지지 않은 미팅 내용이 끝입니다. */}
-        <aside className={styles.materials}>
-          <section>
-            <h2 className={styles.materialHead}>미팅 정보</h2>
-            <MeetingFacts dept={report.dept} contact={report.contact} place={report.place} />
-          </section>
+        <aside
+          id="detail-materials"
+          className={
+            materialsCollapsed ? `${styles.materials} ${styles.collapsed}` : styles.materials
+          }
+        >
+          {/* 판의 머리는 접어도 남습니다. 한 열로 접히는 폭에서는 여기가 여닫이입니다. */}
+          <div className={styles.materialHead}>
+            <h2>미팅 정보</h2>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={!agenda.item}
+              onClick={() => setDetailOpen(true)}
+            >
+              자세히 보기
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              iconOnly
+              className={styles.collapseAction}
+              aria-expanded
+              aria-controls="detail-materials"
+              aria-label="미팅 자료 접기"
+              onClick={() => setMaterialsCollapsed(true)}
+            >
+              <ChevronLeftIcon width={15} height={15} />
+            </Button>
+            <button
+              type="button"
+              className={styles.mobileToggle}
+              aria-expanded={!materialsCollapsed}
+              aria-controls="detail-materials-body"
+              aria-label={materialsCollapsed ? '미팅 자료 펼치기' : '미팅 자료 접기'}
+              onClick={() => setMaterialsCollapsed((collapsed) => !collapsed)}
+            >
+              <ChevronDownIcon width={16} height={16} aria-hidden="true" />
+            </button>
+          </div>
 
-          {(
-            [
-              ['미팅 원문 파일', 'meeting_source'],
-              ['참고자료', 'reference'],
-            ] as const
-          ).map(([label, purpose]) => {
-            const attachments = report.attachments.filter(
-              (attachment) => meetingAttachmentPurposeOf(attachment) === purpose,
-            )
-            return (
-              <section key={purpose}>
-                <h2 className={styles.materialHead}>
-                  {label}
-                  {attachments.length > 0 && (
-                    <span className={styles.count}>{attachments.length}건</span>
-                  )}
-                </h2>
-                <AttachmentPanel attachments={attachments} reportId={report.id} readOnly />
-              </section>
-            )
-          })}
-
-          {report.transcript && (
+          <div id="detail-materials-body" className={styles.materialsBody}>
             <section>
-              <h2 className={styles.materialHead}>미팅 내용</h2>
-              <p className={styles.transcript}>{report.transcript}</p>
+              <MeetingFacts dept={report.dept} contact={report.contact} place={report.place} />
             </section>
-          )}
+
+            {(
+              [
+                ['미팅 원문 파일', 'meeting_source'],
+                ['참고자료', 'reference'],
+              ] as const
+            ).map(([label, purpose]) => {
+              const attachments = report.attachments.filter(
+                (attachment) => meetingAttachmentPurposeOf(attachment) === purpose,
+              )
+              return (
+                <section key={purpose}>
+                  <h2 className={styles.materialHead}>
+                    {label}
+                    {attachments.length > 0 && (
+                      <span className={styles.count}>{attachments.length}건</span>
+                    )}
+                  </h2>
+                  <AttachmentPanel attachments={attachments} reportId={report.id} readOnly />
+                </section>
+              )
+            })}
+
+            {report.transcript && (
+              <section>
+                <h2 className={styles.materialHead}>미팅 내용</h2>
+                <p className={styles.transcript}>{report.transcript}</p>
+              </section>
+            )}
+          </div>
         </aside>
+
+        {/* 접으면 판째로 사라지므로 펼치는 손잡이만 화면 왼쪽 아래에 남습니다. */}
+        {materialsCollapsed && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            iconOnly
+            className={styles.materialsToggle}
+            aria-expanded={false}
+            aria-controls="detail-materials"
+            aria-label="미팅 자료 펼치기"
+            onClick={() => setMaterialsCollapsed(false)}
+          >
+            <ChevronRightIcon width={15} height={15} />
+          </Button>
+        )}
       </div>
+
+      {detailOpen && agenda.item && (
+        <RecordDrawer item={agenda.item} onClose={() => setDetailOpen(false)} />
+      )}
     </section>
   )
 }

--- a/frontend/src/pages/Meetings/Detail.tsx
+++ b/frontend/src/pages/Meetings/Detail.tsx
@@ -1,5 +1,5 @@
 // 제출한 미팅 기록을 읽는 화면입니다. 작성 화면과 같은 컴포넌트를 읽기 모드로 씁니다.
-import { useId, useState } from 'react'
+import { useEffect, useId, useRef, useState } from 'react'
 import { Link, useParams } from 'react-router'
 
 import { useCurrentUser } from '@/auth/sessionContext'
@@ -128,6 +128,14 @@ export default function Detail() {
   const isMine = report?.ownerMemberId === memberId
   // 작성 화면과 같은 손잡이입니다. 보고서만 넓게 읽고 싶을 때 자료 열을 접습니다.
   const [materialsCollapsed, setMaterialsCollapsed] = useState(false)
+  // 접으면 누른 손잡이가 화면에서 사라집니다. 남는 쪽 손잡이로 초점을 넘겨 줍니다.
+  const collapseRef = useRef<HTMLButtonElement>(null)
+  const expandRef = useRef<HTMLButtonElement>(null)
+  const toggledRef = useRef(false)
+  useEffect(() => {
+    if (!toggledRef.current) return
+    ;(materialsCollapsed ? expandRef : collapseRef).current?.focus()
+  }, [materialsCollapsed])
   // 자세히 보기는 작성 화면과 같은 드로어입니다. 일정 원본은 보고서에 없어 따로 받아 옵니다.
   const [detailOpen, setDetailOpen] = useState(false)
   const agenda = useAgendaItem(report?.agendaId ?? '')
@@ -287,11 +295,15 @@ export default function Detail() {
               variant="outline"
               size="sm"
               iconOnly
+              ref={collapseRef}
               className={styles.collapseAction}
               aria-expanded
               aria-controls="detail-materials"
               aria-label="미팅 자료 접기"
-              onClick={() => setMaterialsCollapsed(true)}
+              onClick={() => {
+                toggledRef.current = true
+                setMaterialsCollapsed(true)
+              }}
             >
               <ChevronLeftIcon width={15} height={15} />
             </Button>
@@ -350,11 +362,15 @@ export default function Detail() {
             variant="outline"
             size="sm"
             iconOnly
+            ref={expandRef}
             className={styles.materialsToggle}
             aria-expanded={false}
             aria-controls="detail-materials"
             aria-label="미팅 자료 펼치기"
-            onClick={() => setMaterialsCollapsed(false)}
+            onClick={() => {
+              toggledRef.current = true
+              setMaterialsCollapsed(false)
+            }}
           >
             <ChevronRightIcon width={15} height={15} />
           </Button>

--- a/frontend/src/pages/Meetings/components/DealCardHeader/DealCardHeader.module.scss
+++ b/frontend/src/pages/Meetings/components/DealCardHeader/DealCardHeader.module.scss
@@ -1,0 +1,79 @@
+/* 딜 번호 왼쪽 끝을 본문 padding(--s5)에 맞춥니다. 머리와 본문이 한 축입니다. */
+.header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  width: 100%;
+  min-height: 78px;
+  align-items: center;
+  gap: var(--s3);
+  padding: var(--s3) var(--s5);
+  background: var(--surface);
+  color: var(--ink);
+}
+
+.identity {
+  min-width: 0;
+  border-radius: var(--r-sm);
+  color: inherit;
+  text-decoration: none;
+
+  &:hover .dealLine {
+    color: var(--blue);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+
+  &:focus-visible {
+    outline: 3px solid var(--blue-ring);
+    outline-offset: 3px;
+  }
+}
+
+.dealText {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--s1);
+}
+
+.dealLine {
+  color: var(--blue);
+  font-size: 15px;
+  letter-spacing: -0.015em;
+}
+
+.dealTitle {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.result {
+  display: flex;
+  flex: none;
+  align-items: center;
+}
+
+/* 좁은 폭에서는 배지를 딜 이름 아래 줄로 내립니다. */
+@include sm {
+  .header {
+    grid-template-columns: minmax(0, 1fr);
+    gap: var(--s2);
+    padding: var(--s3);
+  }
+
+  .result {
+    grid-column: 1;
+    grid-row: 2;
+    justify-self: start;
+  }
+}
+
+@media print {
+  .header {
+    min-height: 0;
+    padding: 0 0 var(--s3);
+  }
+}

--- a/frontend/src/pages/Meetings/components/DealCardHeader/DealCardHeader.tsx
+++ b/frontend/src/pages/Meetings/components/DealCardHeader/DealCardHeader.tsx
@@ -1,0 +1,48 @@
+// 딜 보고서 카드의 머리. 작성 화면과 완료 화면이 같은 것을 씁니다.
+//
+// 딜 번호는 아래 본문 제목과 같은 세로축에서 시작하고, 판정 배지는 줄 끝에 섭니다.
+import { Link } from 'react-router'
+
+import StatusBadge, { type StatusTone } from '@/components/StatusBadge'
+import { dealDetailPath } from '@/constants/routes'
+
+import styles from './DealCardHeader.module.scss'
+
+export interface DealBadge {
+  label: string
+  tone: StatusTone
+  title?: string
+}
+
+interface Props {
+  dealId: string
+  /** 딜 번호. SL-V2-020-03 처럼 사람이 부르는 이름입니다. */
+  label: string
+  note?: string
+  badge: DealBadge
+  /** 작성 중에는 쓰던 것을 잃지 않게 새 탭으로 엽니다. */
+  newTab?: boolean
+}
+
+export default function DealCardHeader({ dealId, label, note, badge, newTab = false }: Props) {
+  return (
+    <header className={styles.header}>
+      <Link
+        className={styles.identity}
+        to={dealDetailPath(dealId)}
+        target={newTab ? '_blank' : undefined}
+        rel={newTab ? 'noreferrer' : undefined}
+        aria-label={`${label} 딜 상세${newTab ? ' 새 탭에서' : ''} 열기`}
+      >
+        <span className={styles.dealText}>
+          <strong className={styles.dealLine}>{label}</strong>
+          {note && <span className={styles.dealTitle}>{note}</span>}
+        </span>
+      </Link>
+
+      <span className={styles.result} title={badge.title}>
+        <StatusBadge label={badge.label} tone={badge.tone} />
+      </span>
+    </header>
+  )
+}

--- a/frontend/src/pages/Meetings/components/DealCardHeader/index.ts
+++ b/frontend/src/pages/Meetings/components/DealCardHeader/index.ts
@@ -1,0 +1,2 @@
+export { default } from './DealCardHeader'
+export type { DealBadge } from './DealCardHeader'

--- a/frontend/src/pages/Meetings/components/DealPicker/DealPicker.module.scss
+++ b/frontend/src/pages/Meetings/components/DealPicker/DealPicker.module.scss
@@ -19,15 +19,28 @@
   cursor: pointer;
 
   &:hover {
-    background: var(--fill);
+    background: var(--fill-2);
   }
 
+  /*
+   * 고른 줄 배경에 단계 톤 tint 를 쓰지 않습니다. --blue-tint 로 두면 파랑 단계 태그의
+   * 배경과 값이 같아 그 줄에서만 태그가 pill 이 아닌 글자로 보입니다. 중립 회색에
+   * 파란 좌측 바로 표시하면 여섯 톤 어느 것과도 겹치지 않습니다.
+   */
   &:has(input:checked) {
-    background: var(--blue-tint);
+    background: var(--fill);
+    box-shadow: inset 2px 0 0 var(--blue);
   }
 
+  /* 선택된 줄에도 포커스 링이 보이도록 좌측 바와 함께 겹쳐 둡니다. */
   &:has(input:focus-visible) {
     box-shadow: 0 0 0 3px var(--blue-ring);
+  }
+
+  &:has(input:checked):has(input:focus-visible) {
+    box-shadow:
+      inset 2px 0 0 var(--blue),
+      0 0 0 3px var(--blue-ring);
   }
 
   &:has(input:disabled) {

--- a/frontend/src/pages/Meetings/components/DealPicker/DealPicker.tsx
+++ b/frontend/src/pages/Meetings/components/DealPicker/DealPicker.tsx
@@ -2,8 +2,6 @@
 //
 // 한 자리에서 여러 딜을 이야기하는 일이 흔해 체크박스로 둡니다. 고른 딜은 보고서에
 // 저장되고, 그대로 AI 가 읽는 작성 근거가 됩니다.
-import { useId } from 'react'
-
 import Button from '@/components/Button'
 import { SkeletonBlocks } from '@/components/Skeleton'
 import StageChip from '@/components/StageChip'
@@ -19,8 +17,6 @@ interface Props {
   onRetry: () => void
   /** 고른 딜의 id */
   selected: string[]
-  /** 보고서 행이 이미 생긴 딜은 연결을 바꿀 수 없어 선택을 풀 수 없습니다. */
-  fixed?: string[]
   onToggle: (id: string) => void
   disabled: boolean
 }
@@ -31,12 +27,9 @@ export default function DealPicker({
   error,
   onRetry,
   selected,
-  fixed = [],
   onToggle,
   disabled,
 }: Props) {
-  const fixedHintId = useId()
-
   if (loading) {
     return <SkeletonBlocks label="영업 현황을 불러오는 중입니다." count={3} height={52} />
   }
@@ -71,8 +64,7 @@ export default function DealPicker({
               type="checkbox"
               className={styles.check}
               checked={selected.includes(deal.id)}
-              disabled={disabled || fixed.includes(deal.id)}
-              aria-describedby={fixed.includes(deal.id) ? `${fixedHintId}-${deal.id}` : undefined}
+              disabled={disabled}
               onChange={() => onToggle(deal.id)}
             />
 
@@ -87,11 +79,6 @@ export default function DealPicker({
               <span className={styles.title}>{deal.title.trim() || deal.product}</span>
             </span>
           </label>
-          {fixed.includes(deal.id) && (
-            <p id={`${fixedHintId}-${deal.id}`} className={styles.empty}>
-              저장된 보고서가 있어 선택을 해제할 수 없습니다.
-            </p>
-          )}
         </li>
       ))}
     </ul>

--- a/frontend/src/pages/Meetings/components/DealReportCard/DealReportCard.module.scss
+++ b/frontend/src/pages/Meetings/components/DealReportCard/DealReportCard.module.scss
@@ -1,3 +1,4 @@
+/* 머리는 DealCardHeader 가 맡습니다. 여기는 면과 본문만 봅니다. */
 .card {
   display: flex;
   flex: none;
@@ -10,144 +11,11 @@
   box-shadow: var(--sh-2);
 }
 
-.header {
-  display: grid;
-  grid-template-columns: 44px minmax(0, 1fr) auto;
-  width: 100%;
-  min-height: 78px;
-  align-items: center;
-  gap: var(--s3);
-  padding: var(--s3) var(--s5) var(--s3) var(--s3);
-  background: var(--surface);
-  color: var(--ink);
-}
-
-.disclosure {
-  display: grid;
-  width: 44px;
-  height: 44px;
-  place-items: center;
-  border: 0;
-  border-radius: var(--r-sm);
-  background: transparent;
-  color: var(--muted);
-  cursor: pointer;
-  transition:
-    background var(--t-fast),
-    transform 100ms ease-out;
-
-  &:hover {
-    background: var(--fill);
-  }
-
-  &:focus-visible {
-    position: relative;
-    z-index: 1;
-    outline: 3px solid var(--blue-ring);
-    outline-offset: 1px;
-  }
-
-  &:active {
-    transform: scale(0.96);
-  }
-}
-
-.dealLine,
-.result {
-  display: flex;
-  align-items: center;
-}
-
-.identity {
-  min-width: 0;
-  border-radius: var(--r-sm);
-  color: inherit;
-  text-decoration: none;
-
-  &:hover strong {
-    color: var(--blue);
-    text-decoration: underline;
-    text-underline-offset: 3px;
-  }
-
-  &:focus-visible {
-    outline: 3px solid var(--blue-ring);
-    outline-offset: 3px;
-  }
-}
-
-.caret {
-  flex: none;
-  transform: rotate(-90deg);
-  transition: transform var(--t-fast) var(--ease-out);
-}
-
-.isOpen .caret {
-  transform: rotate(0deg);
-}
-
-.isOpen .disclosure {
-  color: var(--blue);
-}
-
-.dealText {
-  display: flex;
-  min-width: 0;
-  flex-direction: column;
-  gap: var(--s1);
-}
-
-.dealLine {
-  gap: var(--s2);
-
-  strong {
-    color: var(--blue);
-    font-size: 15px;
-    letter-spacing: -0.015em;
-  }
-}
-
-.dealTitle {
-  overflow: hidden;
-  color: var(--muted);
-  font-size: 12px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.result {
-  flex: none;
-}
-
 .body {
   display: flex;
   flex: 1;
   flex-direction: column;
   border-top: 1px solid var(--line);
-}
-
-.isClosed {
-  display: none;
-}
-
-@include sm {
-  .header {
-    grid-template-columns: 44px minmax(0, 1fr);
-    min-height: 78px;
-    padding: var(--s3);
-  }
-
-  .result {
-    grid-column: 2;
-    justify-self: start;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .disclosure,
-  .caret {
-    transition: none;
-  }
 }
 
 @media print {
@@ -160,18 +28,7 @@
     break-inside: avoid;
   }
 
-  .header {
-    grid-template-columns: minmax(0, 1fr) auto;
-    min-height: 0;
-    padding: 0 0 var(--s3);
-  }
-
-  .disclosure {
-    display: none;
-  }
-
-  .body,
-  .isClosed {
+  .body {
     display: block;
     border-top: 1px solid var(--line);
   }

--- a/frontend/src/pages/Meetings/components/DealReportCard/DealReportCard.tsx
+++ b/frontend/src/pages/Meetings/components/DealReportCard/DealReportCard.tsx
@@ -1,15 +1,11 @@
-import { useId, useState } from 'react'
-import { Link } from 'react-router'
-
-import { ChevronDownIcon } from '@/components/icons'
-import StatusBadge, { type StatusTone } from '@/components/StatusBadge'
-import { dealDetailPath } from '@/constants/routes'
+import { type StatusTone } from '@/components/StatusBadge'
 import type { SalesDeal } from '@/pages/Deals/useSalesDeals'
 import { isAuthorEditableReportStatus } from '@/shared/reports'
 import type { MeetingDealRef, MeetingProgress } from '@/types'
 
 import { isInsufficientDealPrediction } from '../../generatedDraft'
 import type { DealDraftState } from '../../useMeetingDraft'
+import DealCardHeader from '../DealCardHeader'
 import ReportSheet from '../ReportSheet'
 
 import styles from './DealReportCard.module.scss'
@@ -20,7 +16,6 @@ interface Props {
   savedDeal?: MeetingDealRef
   draft: DealDraftState
   progress?: MeetingProgress | null
-  when: string
   saving: boolean
   generating: boolean
   canGenerate: boolean
@@ -67,7 +62,6 @@ export default function DealReportCard({
   savedDeal,
   draft,
   progress,
-  when,
   saving,
   generating,
   canGenerate,
@@ -77,8 +71,6 @@ export default function DealReportCard({
   onStartManual,
   onGenerate,
 }: Props) {
-  const [open, setOpen] = useState(true)
-  const bodyId = useId()
   const badge = assessmentBadge(draft)
   const dealLabel = deal?.no ?? savedDeal?.label ?? dealId
   const dealTitle = deal ? deal.title.trim() || deal.product : savedDeal?.note
@@ -87,47 +79,16 @@ export default function DealReportCard({
   const generationDisabled = !isAuthorEditableReportStatus(draft.statusCode) || !canGenerate
 
   return (
-    <article className={`${styles.card} ${open ? styles.isOpen : ''}`}>
-      <header className={`${styles.header} ${open ? styles.isOpen : ''}`}>
-        <button
-          type="button"
-          className={styles.disclosure}
-          aria-label={`${dealLabel} 보고서 ${open ? '접기' : '펼치기'}`}
-          aria-expanded={open}
-          aria-controls={bodyId}
-          onClick={() => setOpen((value) => !value)}
-        >
-          <ChevronDownIcon className={styles.caret} width={17} height={17} />
-        </button>
+    <article className={styles.card}>
+      <DealCardHeader newTab dealId={dealId} label={dealLabel} note={dealTitle} badge={badge} />
 
-        <Link
-          className={styles.identity}
-          to={dealDetailPath(dealId)}
-          target="_blank"
-          rel="noreferrer"
-          aria-label={`${dealLabel} 딜 상세 새 탭에서 열기`}
-        >
-          <span className={styles.dealText}>
-            <span className={styles.dealLine}>
-              <strong>{dealLabel}</strong>
-            </span>
-            {dealTitle && <span className={styles.dealTitle}>{dealTitle}</span>}
-          </span>
-        </Link>
-
-        <span className={styles.result} title={badge.title}>
-          <StatusBadge label={badge.label} tone={badge.tone} />
-        </span>
-      </header>
-
-      <div id={bodyId} className={`${styles.body} ${open ? '' : styles.isClosed}`}>
+      <div className={styles.body}>
         <ReportSheet
           embedded
           phase={draft.phase}
           titleId={`report-title-${dealId}`}
           title={draft.title}
           onTitleChange={onTitleChange}
-          when={when}
           body={draft.values.body ?? ''}
           docKey={draft.docKey}
           onChange={onChange}
@@ -142,8 +103,6 @@ export default function DealReportCard({
           locked={locked}
           saving={saving || generating}
           onStartManual={onStartManual}
-          onRegenerate={onGenerate}
-          regenerateLabel="미팅 전체 다시 생성"
         />
       </div>
     </article>

--- a/frontend/src/pages/Meetings/components/MeetingInfoPanel/MeetingInfoPanel.module.scss
+++ b/frontend/src/pages/Meetings/components/MeetingInfoPanel/MeetingInfoPanel.module.scss
@@ -85,12 +85,6 @@
   white-space: nowrap;
 }
 
-.pill {
-  @include tag-pill;
-
-  font-size: 11px;
-}
-
 /* 미팅 브리핑. 사실 목록 아래에 한 문단으로 깝니다. */
 .brief {
   color: var(--ink-2);

--- a/frontend/src/pages/Meetings/components/MeetingInfoPanel/MeetingInfoPanel.tsx
+++ b/frontend/src/pages/Meetings/components/MeetingInfoPanel/MeetingInfoPanel.tsx
@@ -2,6 +2,7 @@
 import type { SalesDeal } from '@/pages/Deals/useSalesDeals'
 import type { AgendaItem } from '@/types'
 import Button from '@/components/Button'
+import { ChevronLeftIcon } from '@/components/icons'
 import { fmtDot, parseISO } from '@/utils/date'
 
 import DealPicker from '../DealPicker'
@@ -17,10 +18,11 @@ interface Props {
   dealsError: string | null
   onReloadDeals: () => void
   selectedDealIds: string[]
-  fixedDealIds?: string[]
   onToggleDeal: (id: string) => void
   onCreateDeal?: () => void
   onOpenDetail: () => void
+  /** 왼쪽 열을 접는 손잡이. 접을 곳(보고서 열)이 있을 때만 넘어옵니다. */
+  onCollapse?: () => void
   disabled: boolean
 }
 
@@ -31,10 +33,10 @@ export default function MeetingInfoPanel({
   dealsError,
   onReloadDeals,
   selectedDealIds,
-  fixedDealIds,
   onToggleDeal,
   onCreateDeal,
   onOpenDetail,
+  onCollapse,
   disabled,
 }: Props) {
   return (
@@ -43,16 +45,32 @@ export default function MeetingInfoPanel({
         <section className={styles.block}>
           <div className={styles.head}>
             <h2>미팅 정보</h2>
-            {item.stage && <span className={styles.pill}>{item.stage}</span>}
+            {/* 접기 손잡이가 오른쪽 끝을 쓰면 자세히 보기는 제목 옆에 섭니다.
+                손잡이가 없는 한 열짜리 화면에서는 자세히 보기가 그 자리를 그대로 씁니다. */}
             <Button
               type="button"
               variant="outline"
               size="sm"
-              className={styles.headAction}
+              className={onCollapse ? undefined : styles.headAction}
               onClick={onOpenDetail}
             >
               자세히 보기
             </Button>
+            {onCollapse && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                iconOnly
+                className={styles.headAction}
+                aria-expanded
+                aria-controls="compose-side"
+                aria-label="미팅 정보·원문 접기"
+                onClick={onCollapse}
+              >
+                <ChevronLeftIcon width={15} height={15} />
+              </Button>
+            )}
           </div>
           <div className={styles.context}>
             <strong>{item.hospital || '회사 미지정'}</strong>
@@ -90,7 +108,6 @@ export default function MeetingInfoPanel({
             error={dealsError}
             onRetry={onReloadDeals}
             selected={selectedDealIds}
-            fixed={fixedDealIds}
             onToggle={onToggleDeal}
             disabled={disabled}
           />

--- a/frontend/src/pages/Meetings/components/MeetingSharedPanel.module.scss
+++ b/frontend/src/pages/Meetings/components/MeetingSharedPanel.module.scss
@@ -1,10 +1,15 @@
+/*
+ * 공통 기록은 아래 딜 보고서와 한 문서로 읽혀야 합니다. 그래서 껍데기·머리 띠·
+ * 본문 타이포를 Detail 의 딜 카드(.card/.cardBody/.reportBody)와 같게 맞춥니다.
+ */
 .panel {
   flex: none;
   min-width: 0;
-  padding: var(--s5);
+  overflow: hidden;
   border: 1px solid var(--line);
   border-radius: var(--r-lg);
   background: var(--surface);
+  box-shadow: var(--sh-2);
 }
 
 // 딜 보고서 위의 두 보조 기록은 넓은 작성 화면에서만 나란히 읽는다.
@@ -12,12 +17,9 @@
   .supporting {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: var(--s3) var(--s4);
-    padding: var(--s4);
 
     .heading {
       grid-column: 1 / -1;
-      margin-bottom: 0;
 
       h2 {
         font-size: 13px;
@@ -26,22 +28,28 @@
 
     .section {
       min-width: 0;
-      margin-top: 0;
+      padding: var(--s4);
+    }
+
+    .section + .section {
+      border-left: 1px solid var(--line);
     }
   }
 }
 
+/* 머리 띠. 딜 카드 머리와 같은 자리에서 시작합니다. */
 .heading {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
   flex-wrap: wrap;
   gap: var(--s2);
-  margin-bottom: var(--s3);
+  padding: var(--s4) var(--s5);
 
   h2 {
     font-size: 15px;
     font-weight: 600;
+    letter-spacing: -0.015em;
   }
   span {
     color: var(--muted);
@@ -56,7 +64,8 @@
 }
 
 .section {
-  margin-top: var(--s4);
+  padding: var(--s5);
+  border-top: 1px solid var(--line);
 
   > label,
   > h3 {
@@ -86,19 +95,29 @@
       background: var(--surface-2);
     }
   }
+
+  @include md {
+    padding: var(--s4);
+  }
 }
 
+/* 읽는 화면의 본문. 딜 카드 본문과 같은 크기·행간이어야 한 문서로 읽힙니다. */
 .text,
 .printText {
-  font-size: 13px;
-  line-height: 1.8;
-  white-space: pre-wrap;
+  color: var(--ink-2);
+  font-size: 14px;
+  line-height: 1.75;
   overflow-wrap: anywhere;
 }
 
+.empty {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+/* 쓰는 동안에만 '확인 필요' 입니다. 읽는 화면에서는 이 클래스가 붙지 않습니다. */
 .needsReview {
-  padding-left: var(--s3);
-  border-left: 2px solid var(--orange);
+  background: var(--surface-2);
 
   > label,
   > h3,
@@ -115,20 +134,24 @@
   .supporting {
     display: block;
 
-    .section {
-      margin-top: var(--s4);
+    .section + .section {
+      border-left: 0;
     }
-  }
-
-  .needsReview {
-    padding-left: 0;
-    border: 0;
   }
 
   .panel {
     margin-bottom: var(--s5);
-    padding: 0;
     border: 0;
+    border-radius: 0;
+    box-shadow: none;
+  }
+  .heading {
+    padding: 0 0 var(--s3);
+  }
+  .section {
+    padding: var(--s4) 0 0;
+    border-top: 0;
+    background: none;
   }
   .note,
   .section textarea {

--- a/frontend/src/pages/Meetings/components/MeetingSharedPanel.tsx
+++ b/frontend/src/pages/Meetings/components/MeetingSharedPanel.tsx
@@ -1,5 +1,6 @@
 import { useId } from 'react'
 
+import ReportBody from '@/components/ReportBody'
 import type { MeetingProgress, MeetingSharedNotes } from '@/types'
 
 import styles from './MeetingSharedPanel.module.scss'
@@ -47,7 +48,7 @@ export default function MeetingSharedPanel({
     >
       <div className={styles.heading}>
         <h2>미팅 공통 기록</h2>
-        <span>미팅 공통 내용과 확인이 필요한 기록</span>
+        {onChange && <span>미팅 공통 내용과 확인이 필요한 기록</span>}
       </div>
       {generating && previews.length === 0 && (
         <div className={styles.section}>
@@ -76,8 +77,13 @@ export default function MeetingSharedPanel({
             change: (value: string) => onChange?.(value, unassignedBody),
           },
           {
+            /*
+             * 어느 딜에도 붙지 않은 기록입니다. 쓰는 동안에는 '어느 딜 얘기인지
+             * 보세요' 라는 할 일이지만, 제출한 보고서를 읽을 때는 더 확인할 것이
+             * 없습니다. 그래서 읽는 화면에서는 사실만 말하고 주황도 걷습니다.
+             */
             key: 'unassigned',
-            title: '딜 미지정 · 확인 필요',
+            title: onChange ? '딜 미지정 · 확인 필요' : '딜 미지정 기록',
             report: shared?.unassigned_report,
             value: unassignedBody,
             change: (value: string) => onChange?.(commonBody, value),
@@ -86,7 +92,9 @@ export default function MeetingSharedPanel({
           .filter((part) => part.report || (showCommon && part.key === 'common'))
           .map((part) => (
             <div
-              className={`${styles.section} ${part.key === 'unassigned' ? styles.needsReview : ''}`}
+              className={`${styles.section} ${
+                onChange && part.key === 'unassigned' ? styles.needsReview : ''
+              }`}
               key={part.key}
             >
               {onChange ? (
@@ -100,12 +108,22 @@ export default function MeetingSharedPanel({
                     placeholder="기록된 내용이 없습니다."
                     onChange={(event) => part.change(event.target.value)}
                   />
-                  <p className={styles.printText}>{part.value || '기록된 내용 없음'}</p>
+                  {part.value.trim() ? (
+                    <ReportBody className={styles.printText} body={part.value} />
+                  ) : (
+                    <p className={`${styles.printText} ${styles.empty}`}>기록된 내용 없음</p>
+                  )}
                 </>
               ) : (
                 <>
-                  <h3>{part.title}</h3>
-                  <p className={styles.text}>{part.value}</p>
+                  {/* 판 머리가 이미 '미팅 공통 기록' 입니다. 그 아래 같은 말을 또
+                      붙이지 않고, 갈래가 다른 미지정 기록에만 이름을 답니다. */}
+                  {part.key === 'unassigned' && <h3>{part.title}</h3>}
+                  {part.value.trim() ? (
+                    <ReportBody className={styles.text} body={part.value} />
+                  ) : (
+                    <p className={styles.empty}>기록된 내용 없음</p>
+                  )}
                 </>
               )}
             </div>

--- a/frontend/src/pages/Meetings/components/ReportSheet/ReportSheet.module.scss
+++ b/frontend/src/pages/Meetings/components/ReportSheet/ReportSheet.module.scss
@@ -13,12 +13,6 @@
     border-radius: 0;
     box-shadow: none;
   }
-
-  .actions {
-    position: static;
-    padding: var(--s3) var(--s5) var(--s4);
-    background: none;
-  }
 }
 
 /*
@@ -50,49 +44,46 @@
 }
 
 /*
- * 문서의 머리글이지만 고쳐 쓰는 칸이기도 합니다. 테두리를 지워 두면 고칠 수 있는
- * 줄인지 알 수 없어, 평소에도 옅은 테두리를 남깁니다. 확정본에서는 다시 머리글로
- * 돌아갑니다 — 그때는 고칠 수 없으니 칸처럼 보이면 안 됩니다.
+ * 문서의 머리글이지만 고쳐 쓰는 칸이기도 합니다. 평소에는 확정본과 같은 머리글로
+ * 두고, 고칠 수 있다는 것은 손이 올라갔을 때 배경 한 겹으로 말합니다 — 늘 칸처럼
+ * 보이면 두 화면에서 같은 제목이 다른 무게로 읽힙니다.
+ * 왼쪽 여백을 음수로 당겨 글자 시작점을 본문과 같은 축에 둡니다.
  */
 .title {
-  width: 100%;
+  width: calc(100% + var(--s3) * 2);
+  margin-inline: calc(var(--s3) * -1);
   padding: var(--s2) var(--s3);
-  border: 1px solid var(--line-2);
+  border: 1px solid transparent;
   border-radius: var(--r-sm);
-  background: var(--surface);
+  background: none;
   color: var(--ink);
   font: inherit;
   font-size: 22px;
   font-weight: 700;
   letter-spacing: -0.02em;
   outline: none;
+  transition: background var(--t-fast);
 
   &::placeholder {
     color: var(--muted-2);
   }
 
   &:hover:not(:disabled) {
-    border-color: var(--muted-2);
+    background: var(--fill);
   }
 
   &:focus {
     border-color: var(--blue);
+    background: var(--surface);
     box-shadow: 0 0 0 3px var(--blue-ring);
   }
 
   &:disabled {
+    width: 100%;
+    margin-inline: 0;
     padding-left: 0;
-    border-color: transparent;
-    background: none;
     color: var(--ink);
   }
-}
-
-.when {
-  align-self: flex-end;
-  color: var(--muted);
-  font-size: 13px;
-  font-variant-numeric: tabular-nums;
 }
 
 /*
@@ -133,31 +124,11 @@
 }
 
 /* 후보 재생성처럼 이 카드에만 해당하는 보조 조작입니다. */
-.actions {
-  position: sticky;
-  bottom: 0;
-  z-index: 1;
-  display: flex;
-  align-items: center;
-  gap: var(--s2);
-  margin-top: var(--s4);
-  padding: var(--s3) 0;
-  background: linear-gradient(to top, var(--paper) 72%, transparent);
-
-  @include sm {
-    flex-wrap: wrap;
-  }
-}
-
 /* 인쇄에는 조작부가 남지 않습니다. 시트도 종이 위 종이가 되지 않게 폅니다. */
 @media print {
   .root,
   .sheet.sheet {
     display: block;
-  }
-
-  .actions.actions {
-    display: none;
   }
 
   .sheet.sheet {
@@ -169,6 +140,8 @@
 
   /* 종이 위에는 입력칸이 없습니다. 제목은 머리글로만 찍힙니다. */
   .title.title {
+    width: 100%;
+    margin-inline: 0;
     padding-left: 0;
     border-color: transparent;
     background: none;

--- a/frontend/src/pages/Meetings/components/ReportSheet/ReportSheet.tsx
+++ b/frontend/src/pages/Meetings/components/ReportSheet/ReportSheet.tsx
@@ -19,8 +19,6 @@ interface Props {
   titleId?: string
   title: string
   onTitleChange: (value: string) => void
-  /** 미팅한 날. 제목 아래에 한 줄로 놓습니다. */
-  when: string
   body: string
   /** 편집기를 다시 세워야 할 때 올라갑니다. */
   docKey: number
@@ -37,8 +35,6 @@ interface Props {
   locked: boolean
   saving: boolean
   onStartManual: () => void
-  onRegenerate: () => void
-  regenerateLabel?: string
   /** 딜 카드가 바깥 면을 맡을 때 시트의 중복 테두리·sticky를 걷습니다. */
   embedded?: boolean
 }
@@ -48,7 +44,6 @@ export default function ReportSheet({
   titleId,
   title,
   onTitleChange,
-  when,
   body,
   docKey,
   onChange,
@@ -61,8 +56,6 @@ export default function ReportSheet({
   locked,
   saving,
   onStartManual,
-  onRegenerate,
-  regenerateLabel = 'AI 다시 생성',
   embedded = false,
 }: Props) {
   const generatedTitleId = useId()
@@ -119,7 +112,6 @@ export default function ReportSheet({
                   />
                 </>
               )}
-              <p className={styles.when}>{when}</p>
             </div>
 
             {phase === 'generating' ? (
@@ -137,19 +129,6 @@ export default function ReportSheet({
           </>
         )}
       </article>
-
-      {!empty && (
-        <div className={styles.actions}>
-          <Button
-            variant="outline"
-            type="button"
-            disabled={locked || saving || generationDisabled || phase === 'generating'}
-            onClick={onRegenerate}
-          >
-            {regenerateLabel}
-          </Button>
-        </div>
-      )}
     </div>
   )
 }

--- a/frontend/src/pages/Meetings/useMeetingDraft.ts
+++ b/frontend/src/pages/Meetings/useMeetingDraft.ts
@@ -345,7 +345,7 @@ export default function useMeetingDraft(
                   ? null
                   : reportError
                     ? reportGenerationMessage(reportError)
-                    : '보고서 생성에 실패했습니다. 기존 작성 내용은 유지됩니다.',
+                    : 'AI 보고서 작성을 완료하지 못했습니다. 다시 시도해 주세요.',
                 analysisPhase: generated.assessment
                   ? ('completed' as const)
                   : generated.analysisError
@@ -380,7 +380,10 @@ export default function useMeetingDraft(
         updateDeal(id, (draft) => ({
           ...draft,
           phase: isMeetingBodyBlank(draft.values) ? 'idle' : 'ready',
-          generationError: errorMessage(reason, '미팅 처리를 완료하지 못했습니다.'),
+          generationError: errorMessage(
+            reason,
+            'AI 보고서 작성을 완료하지 못했습니다. 다시 시도해 주세요.',
+          ),
           analysisPhase: draft.assessment ? 'completed' : 'failed',
           analysisError: draft.assessment ? null : '새 분석 결과를 받지 못했습니다.',
         }))

--- a/frontend/src/styles/_mixins.scss
+++ b/frontend/src/styles/_mixins.scss
@@ -40,6 +40,41 @@
   box-shadow: var(--sh-2);
 }
 
+// 화면 맨 위의 머리 띠. 놓인 판(card)과 달리 제 자리를 차지하는 한 장이라
+// 그림자를 한 겹만 두고, 오른쪽 끝에 옅은 물결을 깔아 조작부의 자리를 만듭니다.
+// 물결은 글자가 닿지 않는 오른쪽 절반에만 깔립니다.
+@mixin page-banner {
+  position: relative;
+  overflow: hidden;
+  padding: var(--s5) var(--s6);
+  border: 1px solid var(--line);
+  border-radius: var(--r-lg);
+  background: var(--surface);
+  box-shadow: var(--sh-1);
+
+  // 내용은 언제나 물결 위입니다. 쓰는 쪽이 z-index 를 다시 적지 않게 여기서 맡습니다.
+  > * {
+    position: relative;
+    z-index: 1;
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    z-index: 0;
+    inset: 0 0 0 auto;
+    width: 46%;
+    pointer-events: none;
+    background:
+      radial-gradient(120% 150% at 86% -40%, var(--blue-tint) 0%, transparent 62%),
+      radial-gradient(90% 130% at 112% 130%, var(--blue-tint) 0%, transparent 58%);
+  }
+
+  @include md {
+    padding: var(--s4);
+  }
+}
+
 // demo/layout_v3.html §12 의 .tag-pill
 @mixin tag-pill {
   display: inline-flex;
@@ -288,4 +323,26 @@
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+/* 되돌아가는 길. 테두리 없이 파란 글자 한 줄로만 섭니다. */
+@mixin back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: var(--r-xs);
+  color: var(--blue);
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+
+  &:focus-visible {
+    outline: 3px solid var(--blue-ring);
+    outline-offset: 3px;
+  }
 }

--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -123,6 +123,8 @@
 html {
   color-scheme: light;
   height: 100%;
+  // 내용이 짧은 화면에서 스크롤바가 사라지면 가운데 정렬된 본문 폭이 흔들립니다.
+  scrollbar-gutter: stable;
 }
 
 body {

--- a/frontend/tests/reportPresentation.test.mjs
+++ b/frontend/tests/reportPresentation.test.mjs
@@ -331,7 +331,10 @@ test('기간 메모는 guidance 2,000자 경계를 사용하고 최종 제출에
     reportInputError(periodGenerationRequestOf({ ...base, transcript: `${memo}😀` }, 'too-long')),
     'guidance_too_large',
   )
-  assert.equal(periodFinalizeRequestOf({ ...base, transcript: memo }, 'memo-finalize').transcript, memo)
+  assert.equal(
+    periodFinalizeRequestOf({ ...base, transcript: memo }, 'memo-finalize').transcript,
+    memo,
+  )
 })
 
 test('딜 드로어를 열고 닫아도 현재 목록 페이지를 초기화하지 않는다', async () => {
@@ -466,10 +469,9 @@ test('완료 미팅과 기간 보고서는 원본 목록을 복구하고 빈 직
 })
 
 test('미팅 보고서 내부 오류 코드는 작성·상세 화면에서 사용자 문구로 바꾼다', async () => {
-  const message =
-    'AI가 보고서 초안을 정상적으로 구성하지 못했습니다. 입력한 내용은 유지됩니다. 다시 시도해 주세요.'
+  const message = 'AI가 보고서 초안을 정상적으로 구성하지 못했습니다. 다시 시도해 주세요.'
   assert.equal(reportGenerationMessage('report_agent_output_invalid'), message)
-  assert.doesNotMatch(reportGenerationMessage('future_internal_error_code'), /future_internal/)
+  assert.match(reportGenerationMessage('future_internal_error_code'), /future_internal_error_code/)
   assert.match(messageForCode('report_attachment_ocr_too_large', '실패'), /페이지나 이미지/)
 
   const raw = response()
@@ -1420,8 +1422,9 @@ test('공통·미지정 기록은 읽기 전용 제목과 편집용 연결 label
     unassigned_report: { body: '미지정 내용 본문', evidence_ids: [] },
   }
   const view = renderToStaticMarkup(createElement(MeetingSharedPanel, { shared }))
-  assert.match(view, /<h3[^>]*>공통 내용<\/h3>/)
-  assert.match(view, /<h3[^>]*>딜 미지정 · 확인 필요<\/h3>/)
+  assert.match(view, /<h2[^>]*>미팅 공통 기록<\/h2>/)
+  assert.doesNotMatch(view, /<h3[^>]*>공통 내용<\/h3>/)
+  assert.match(view, /<h3[^>]*>딜 미지정 기록<\/h3>/)
   assert.doesNotMatch(view, /<label|<textarea/)
   assert.match(view, /공통 내용 본문/)
   assert.match(view, /미지정 내용 본문/)
@@ -1569,10 +1572,7 @@ test('다음 날 작성 완료·일정 이동 후 수정에도 기존 미팅일�
   )
   assert.match(compose, /date: meetingDate,\s+time: meetingTime/)
   assert.match(compose, /item=\{\{ \.\.\.item, date: meetingDate, time: meetingTime \}\}/)
-  assert.match(
-    compose,
-    /미팅일 \{fmtDot\(parseISO\(meetingDate\)\)\} · 작성 완료 후에도 이 날짜로 저장됩니다/,
-  )
+  assert.doesNotMatch(compose, /작성 완료 후에도 이 날짜로 저장됩니다/)
   const meetingDate = saved.date ?? item.date
   const draft = {
     reportId: saved.id,


### PR DESCRIPTION
## 변경 요약

- 미팅 보고서 작성·상세 화면의 정보 구조와 카드형 편집 경험을 재구성했습니다.
- 딜 카드 머리, 공통·미지정 기록, 좌측 정보 패널, 저장·PDF 동선을 정리했습니다.
- AI 보고서 생성 실패 원인을 더 구체적으로 안내하고, 새 화면에 맞춰 회귀 테스트를 갱신했습니다.

## 화면

![미팅 보고서 작성 화면](https://github.com/user-attachments/assets/10e3e1da-ba1d-499d-9e04-a3330536bc01)

![미팅 보고서 상세 화면](https://github.com/user-attachments/assets/b406ddcd-1457-485c-a4be-08dde269b127)

![미팅 보고서 카드 화면](https://github.com/user-attachments/assets/da0f2c0c-5bff-4353-9f08-bf21e0ee1cdb)

![미팅 보고서 추가 화면 1](https://github.com/user-attachments/assets/f8d5ae5d-c13d-464a-874f-91281ceee83e)

![미팅 보고서 추가 화면 2](https://github.com/user-attachments/assets/6f9ee503-6aad-4ee4-a51f-c15627b2a569)

## 검증

- `frontend`: `npm run lint`, `npm run format:check`, `npm test` (115 passed), `npm run build`

## 영향 및 주의 사항

- 이번 PR은 **미팅 보고서 디자인**만 다룹니다. 일일·주간·월간 보고서 화면 개선은 후속 작업으로 진행합니다.
- 현재 원격 `develop`에 이 브랜치 기준 이후 커밋이 있어, 병합 전 최신 기준의 충돌 여부를 확인해야 합니다.

## 관련 이슈

- #171
- @j3s30p 검토 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 미팅 보고서 작성 화면에 자동 임시 저장 상태와 복구·재생성 오류 안내를 추가했습니다.
  - 미팅 정보 영역과 자료 패널을 접고 펼칠 수 있습니다.
  - 딜 카드 헤더와 상태 배지 아이콘, 업무보고 목록 이동 경로를 개선했습니다.
  - 미팅 상세 화면에 반응형 배너와 자료 자세히 보기 기능을 추가했습니다.
  - 보고서 제목을 더 자연스럽게 편집하고, 저장·다운로드 작업을 쉽게 이용할 수 있습니다.

- **버그 수정**
  - AI 오류 유형별 안내 문구를 세분화했습니다.
  - 화면 전환 시 스크롤바로 인한 레이아웃 흔들림을 줄였습니다.
  - 선택된 딜과 링크·포커스 상태의 시각적 표시를 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->